### PR TITLE
Update description of project

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,7 +1,7 @@
 # https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories
 
 github:
-  description: "Build highly concurrent, distributed, and resilient message-driven applications on the JVM"
+  description: "Build highly concurrent, distributed, and resilient message-driven applications using Java/Scala"
   homepage: https://pekko.apache.org/
   labels:
     - pekko


### PR DESCRIPTION
While not so relevant now, the historical direction of a lot of Scala based projects (which Pekko is one, the Java API is technically a separate layer, i.e. none of the core is implemented in Java) is that at some point they end up adding support for runtimes aside of JVM, i.e. graalvm/scala-native, even Scala.js (or anything else that props up).

At some point Pekko might explore such things, in which case running on the JVM isn't the most accurate description.