### PR TITLE
Only allow Squash merges and update notification email addresses

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -25,7 +25,7 @@ github:
   enabled_merge_buttons:
     squash:  true
     merge:   false
-    rebase:  false
+    rebase:  true
 
 notifications:
   commits:              commits@pekko.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -21,3 +21,16 @@ github:
     issues: true
     # Enable projects for project management boards
     projects: false
+
+  enabled_merge_buttons:
+    squash:  true
+    merge:   false
+    rebase:  false
+
+notifications:
+  commits:              commits@pekko.apache.org
+  issues:               dev@pekko.apache.org
+  pullrequests_status:  dev@pekko.apache.org
+  pullrequests_comment: commits@pekko.apache.org
+  discussions:          dev@pekko.apache.org
+


### PR DESCRIPTION
* Squash merges keep the Git history clean
  * see https://medium.com/swlh/squash-and-rebase-git-basics-5cb1be1e0dac
* Add back notifications settings that were accidentally removed when I reset the last merge commit
  * aim is to not have emails go to dev mailing list every time someone comments on a PR  

Features are documented in https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features