### PR TITLE
temporarily remove email action from github builds

### DIFF
--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -42,17 +42,18 @@ jobs:
       - name: Check correct MiMa filter directories
         run: sbt -jvm-opts .jvmopts-ci checkMimaFilterDirectories
 
-      - name: Email on failure
-        if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-          to: akka.official@gmail.com
-          from: Akka CI (GHActions)
-          body: |
-            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      # comment out email actions until we have an email address to use (and we need to get INFRA to whitelist dawidd6/action-send-mail)
+      #- name: Email on failure
+      #  if: ${{ failure() }}
+      #  uses: dawidd6/action-send-mail@v3
+      #  with:
+      #    server_address: smtp.gmail.com
+      #    server_port: 465
+      #    username: ${{secrets.MAIL_USERNAME}}
+      #    password: ${{secrets.MAIL_PASSWORD}}
+      #    subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
+      #    to: akka.official@gmail.com
+      #    from: Akka CI (GHActions)
+      #    body: |
+      #      Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
+      #      https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/.github/workflows/multi-node.yml
+++ b/.github/workflows/multi-node.yml
@@ -71,22 +71,23 @@ jobs:
             -Dmultinode.Daeron.term.buffer.length=33554432 \
             multiNodeTest
 
-      - name: Email on failure
-        if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
+      # comment out email actions until we have an email address to use (and we need to get INFRA to whitelist dawidd6/action-send-mail)
+      #- name: Email on failure
+      #  if: ${{ failure() }}
+      #  uses: dawidd6/action-send-mail@v3
+      #  with:
+      #    server_address: smtp.gmail.com
+      #    server_port: 465
           # Using port 465 already sets `secure: true`
-          secure: true
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: Multi node test (Akka)
-          to: akka.official@gmail.com
-          from: Akka CI (GHActions)
-          body: |
-            Multi node test of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      #    secure: true
+      #    username: ${{secrets.MAIL_USERNAME}}
+      #    password: ${{secrets.MAIL_PASSWORD}}
+      #    subject: Multi node test (Akka)
+      #    to: akka.official@gmail.com
+      #    from: Akka CI (GHActions)
+      #    body: |
+      #      Multi node test of ${{github.repository}} failed!
+      #      https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
       
       - name: Cleanup the environment
         if: ${{ always() }}
@@ -155,22 +156,22 @@ jobs:
             -Dmultinode.Daeron.term.buffer.length=33554432 \
             multiNodeTest
 
-      - name: Email on failure
-        if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
+      #- name: Email on failure
+      #  if: ${{ failure() }}
+      #  uses: dawidd6/action-send-mail@v3
+      #  with:
+      #    server_address: smtp.gmail.com
+      #    server_port: 465
           # Using port 465 already sets `secure: true`
-          secure: true
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: Multi node test with Aeron (Akka)
-          to: akka.official@gmail.com
-          from: Akka CI (GHActions)
-          body: |
-            Multi node test of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      #    secure: true
+      #    username: ${{secrets.MAIL_USERNAME}}
+      #    password: ${{secrets.MAIL_PASSWORD}}
+      #    subject: Multi node test with Aeron (Akka)
+      #    to: akka.official@gmail.com
+      #    from: Akka CI (GHActions)
+      #    body: |
+      #      Multi node test of ${{github.repository}} failed!
+      #      https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
       
       - name: Cleanup the environment
         if: ${{ always() }}

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -52,20 +52,21 @@ jobs:
           fail_if_no_tests: false
           skip_publishing: true
 
-      - name: Email on failure
-        if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-          to: akka.official@gmail.com
-          from: Akka CI (GHActions)
-          body: |
-            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      # comment out email actions until we have an email address to use (and we need to get INFRA to whitelist dawidd6/action-send-mail)
+      #- name: Email on failure
+      #  if: ${{ failure() }}
+      #  uses: dawidd6/action-send-mail@v3
+      #  with:
+      #    server_address: smtp.gmail.com
+      #    server_port: 465
+      #    username: ${{secrets.MAIL_USERNAME}}
+      #    password: ${{secrets.MAIL_PASSWORD}}
+      #    subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
+      #    to: akka.official@gmail.com
+      #    from: Akka CI (GHActions)
+      #    body: |
+      #      Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
+      #      https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
 
   akka-classic-remoting-tests:
     name: Akka Classic Remoting Tests
@@ -106,20 +107,21 @@ jobs:
           -Dakka.cluster.assert=on \
           clean ${{ matrix.command }}
 
-      - name: Email on failure
-        if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-          to: akka.official@gmail.com
-          from: Akka CI (GHActions)
-          body: |
-            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      # comment out email actions until we have an email address to use (and we need to get INFRA to whitelist dawidd6/action-send-mail)
+      #- name: Email on failure
+      #  if: ${{ failure() }}
+      #  uses: dawidd6/action-send-mail@v3
+      #  with:
+      #    server_address: smtp.gmail.com
+      #    server_port: 465
+      #    username: ${{secrets.MAIL_USERNAME}}
+      #    password: ${{secrets.MAIL_PASSWORD}}
+      #    subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
+      #    to: akka.official@gmail.com
+      #    from: Akka CI (GHActions)
+      #    body: |
+      #      Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
+      #      https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
 
   jdk-nightly-build:
     name: JDK ${{ matrix.jdkVersion }} / Scala ${{ matrix.scalaVersion }}
@@ -203,20 +205,21 @@ jobs:
             -Dakka.build.scalaVersion=${{ matrix.scalaVersion }} \
             "+~ ${{ matrix.scalaVersion }} publishLocal publishM2"
 
-      - name: Email on failure
-        if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-          to: akka.official@gmail.com
-          from: Akka CI (GHActions)
-          body: |
-            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      # comment out email actions until we have an email address to use (and we need to get INFRA to whitelist dawidd6/action-send-mail)
+      #- name: Email on failure
+      #  if: ${{ failure() }}
+      #  uses: dawidd6/action-send-mail@v3
+      #  with:
+      #    server_address: smtp.gmail.com
+      #    server_port: 465
+      #    username: ${{secrets.MAIL_USERNAME}}
+      #    password: ${{secrets.MAIL_PASSWORD}}
+      #    subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
+      #    to: akka.official@gmail.com
+      #    from: Akka CI (GHActions)
+      #    body: |
+      #      Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
+      #      https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
 
   akka-artery-aeron-tests:
     name: Akka Artery Aeron Tests
@@ -258,17 +261,18 @@ jobs:
           -Daeron.term.buffer.length=33554432 \
           clean ${{ matrix.command }}
 
-      - name: Email on failure
-        if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-          to: akka.official@gmail.com
-          from: Akka CI (GHActions)
-          body: |
-            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      # comment out email actions until we have an email address to use (and we need to get INFRA to whitelist dawidd6/action-send-mail)
+      #- name: Email on failure
+      #  if: ${{ failure() }}
+      #  uses: dawidd6/action-send-mail@v3
+      #  with:
+      #    server_address: smtp.gmail.com
+      #    server_port: 465
+      #    username: ${{secrets.MAIL_USERNAME}}
+      #    password: ${{secrets.MAIL_PASSWORD}}
+      #    subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
+      #    to: akka.official@gmail.com
+      #    from: Akka CI (GHActions)
+      #    body: |
+      #      Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
+      #      https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -37,17 +37,18 @@ jobs:
         env:
           SCP_SECRET: ${{ secrets.SCP_SECRET }}
 
-      - name: Email on failure
-        if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-          to: akka.official@gmail.com
-          from: Akka CI (GHActions)
-          body: |
-            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      # comment out email actions until we have an email address to use (and we need to get INFRA to whitelist dawidd6/action-send-mail)
+      #- name: Email on failure
+      #  if: ${{ failure() }}
+      #  uses: dawidd6/action-send-mail@v3
+      #  with:
+      #    server_address: smtp.gmail.com
+      #    server_port: 465
+      #    username: ${{secrets.MAIL_USERNAME}}
+      #    password: ${{secrets.MAIL_PASSWORD}}
+      #    subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
+      #    to: akka.official@gmail.com
+      #    from: Akka CI (GHActions)
+      #    body: |
+      #     Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
+      #      https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,17 +36,18 @@ jobs:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
 
-      - name: Email on failure
-        if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-          to: akka.official@gmail.com
-          from: Akka CI (GHActions)
-          body: |
-            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      # comment out email actions until we have an email address to use (and we need to get INFRA to whitelist dawidd6/action-send-mail)
+      #- name: Email on failure
+      #  if: ${{ failure() }}
+      #  uses: dawidd6/action-send-mail@v3
+      #  with:
+      #    server_address: smtp.gmail.com
+      #    server_port: 465
+      #    username: ${{secrets.MAIL_USERNAME}}
+      #    password: ${{secrets.MAIL_PASSWORD}}
+      #    subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
+      #    to: akka.official@gmail.com
+      #    from: Akka CI (GHActions)
+      #    body: |
+      #      Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
+      #      https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -60,17 +60,18 @@ jobs:
           -Dmultinode.XX:+AlwaysActAsServerClassMachine \
           "+~ 3 ${{ matrix.command }}"
 
-      - name: Email on failure
-        if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-          to: akka.official@gmail.com
-          from: Akka CI (GHActions)
-          body: |
-            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      # comment out email actions until we have an email address to use (and we need to get INFRA to whitelist dawidd6/action-send-mail)
+      #- name: Email on failure
+      #  if: ${{ failure() }}
+      #  uses: dawidd6/action-send-mail@v3
+      #  with:
+      #    server_address: smtp.gmail.com
+      #    server_port: 465
+      #    username: ${{secrets.MAIL_USERNAME}}
+      #    password: ${{secrets.MAIL_PASSWORD}}
+      #    subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
+      #    to: akka.official@gmail.com
+      #    from: Akka CI (GHActions)
+      #    body: |
+      #      Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
+      #      https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -51,17 +51,18 @@ jobs:
           fail_if_no_tests: false
           skip_publishing: true
 
-      - name: Email on failure
-        if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-          to: akka.official@gmail.com
-          from: Akka CI (GHActions)
-          body: |
-            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      # comment out email actions until we have an email address to use (and we need to get INFRA to whitelist dawidd6/action-send-mail)
+      #- name: Email on failure
+      #  if: ${{ failure() }}
+      #  uses: dawidd6/action-send-mail@v3
+      #  with:
+      #    server_address: smtp.gmail.com
+      #    server_port: 465
+      #    username: ${{secrets.MAIL_USERNAME}}
+      #    password: ${{secrets.MAIL_PASSWORD}}
+      #    subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
+      #    to: akka.official@gmail.com
+      #    from: Akka CI (GHActions)
+      #    body: |
+      #      Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
+      #      https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}


### PR DESCRIPTION
* we need plenty of work to get Github workflows working
* we don't yet have an email address to send our failures to
* current code has an Akka team email address and I don't want to spam them with Pekko build issues