### PR TITLE
Add github workflow to check scala code is formatted

### DIFF
--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -9,8 +9,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-code-style:
-    name: Check / Code Style
+  check-headers:
+    name: Check / Headers
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
@@ -27,12 +27,12 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.2
 
-      - name: Code style check
+      - name: Check headers
         run: |-
           sbt -jvm-opts .jvmopts-ci \
           -Dsbt.override.build.repos=false \
           -Dsbt.log.noformat=false \
-          verifyCodeStyle
+          headerCheckAll
 
   pull-request-validation:
     name: Check / Tests

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,24 @@
+name: Scalafmt
+
+permissions: read-all
+
+on:
+  pull_request:
+    branches: ['**']
+
+jobs:
+  build:
+    name: Code is formatted
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check project is formatted
+        uses: jrouly/scalafmt-native-action@v2
+        with:
+          version: '3.6.1'
+          arguments: '--list --mode diff-ref=origin/main'


### PR DESCRIPTION
This PR is a follow up from https://github.com/apache/incubator-pekko/pull/2 but only contains the replacement of sbt check with github actions. It also implements the git ratcheting system so that it only performs a diff against files that have actually been changed against `origin/main` meaning the format step should take ~10-20 seconds on average since it doesn't format the whole codebase as well as being initiated immediately rather than having to wait for the main test PR validation step to happen. Note that currently when one formats the code via `sbt-scalafmt` it takes roughly 1 minute.

Here is an example of a test run that I made deliberately to fail (i.e. I committed a single file that wasn't formatted). It took 4 seconds (ignoring the git branch checkout), 20 seconds full. https://github.com/apache/incubator-pekko/actions/runs/3400549218/jobs/5655050347.

Here is an example of a test run against no files that need to be formatted (i.e. not editing sources), it took <1 seconds (ignoring the git branch checkout), 16 seconds full. https://github.com/apache/incubator-pekko/actions/runs/3400546569/jobs/5655045456.