### PR TITLE
Fix nightly build action

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -7,8 +7,8 @@ on:
 
 jobs:
 
-  akka-cluster-metrics-sigar:
-    name: Akka Cluster Metrics Test with Sigar
+  pekko-cluster-metrics-sigar:
+    name: Pekko Cluster Metrics Test with Sigar
     runs-on: ubuntu-20.04
     if: github.repository == 'apache/incubator-pekko'
     steps:
@@ -43,14 +43,15 @@ jobs:
             -Dmultinode.XX:+AlwaysActAsServerClassMachine \
             clean akka-cluster-metrics/test
 
-      - name: Test Reports
-        # Makes it easier to spot failures instead of looking at the logs.
-        if: ${{ failure() }}
-        uses: marcospereira/action-surefire-report@v1
-        with:
-          report_paths: '**/target/test-reports/TEST-*.xml'
-          fail_if_no_tests: false
-          skip_publishing: true
+# comment out test report until an apache or GitHub published action (action-surefire-report) can be found or added allowlist from INFRA
+#      - name: Test Reports
+#        # Makes it easier to spot failures instead of looking at the logs.
+#        if: ${{ failure() }}
+#        uses: marcospereira/action-surefire-report@v1
+#        with:
+#          report_paths: '**/target/test-reports/TEST-*.xml'
+#          fail_if_no_tests: false
+#          skip_publishing: true
 
       # comment out email actions until we have an email address to use (and we need to get INFRA to whitelist dawidd6/action-send-mail)
       #- name: Email on failure
@@ -68,8 +69,8 @@ jobs:
       #      Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
       #      https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
 
-  akka-classic-remoting-tests:
-    name: Akka Classic Remoting Tests
+  pekko-classic-remoting-tests:
+    name: Pekko Classic Remoting Tests
     runs-on: ubuntu-20.04
     if: github.repository == 'apache/incubator-pekko'
     strategy:
@@ -169,21 +170,22 @@ jobs:
             ${{ matrix.extraOpts }} \
             clean "+~ ${{ matrix.scalaVersion }} test" checkTestsHaveRun
 
-      - name: Test Reports
-        # Makes it easier to spot failures instead of looking at the logs.
-        if: ${{ failure() }}
-        uses: marcospereira/action-surefire-report@v1
-        with:
-          report_paths: '**/target/test-reports/TEST-*.xml'
-          fail_if_no_tests: false
+# comment out test report until an apache or GitHub published action (action-surefire-report) can be found or added allowlist from INFRA
+#      - name: Test Reports
+#        # Makes it easier to spot failures instead of looking at the logs.
+#        if: ${{ failure() }}
+#        uses: marcospereira/action-surefire-report@v1
+#        with:
+#          report_paths: '**/target/test-reports/TEST-*.xml'
+#          fail_if_no_tests: false
 
-      # Archive test results so we can do some diagnostics later
-      - name: Upload test results
-        uses: actions/upload-artifact@v2
-        if: success() || failure()        # run this step even if previous step failed
-        with:
-          name: test-results-${{ matrix.jdkVersion }}-${{ matrix.scalaVersion }}
-          path: '**/target/test-reports/TEST-*.xml'
+#      # Archive test results so we can do some diagnostics later
+#      - name: Upload test results
+#        uses: actions/upload-artifact@v2
+#        if: success() || failure()        # run this step even if previous step failed
+#        with:
+#          name: test-results-${{ matrix.jdkVersion }}-${{ matrix.scalaVersion }}
+#          path: '**/target/test-reports/TEST-*.xml'
 
       - name: Docs
         # Docs generation requires JDK 11. Checks with `startsWith` helps
@@ -221,8 +223,8 @@ jobs:
       #      Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
       #      https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
 
-  akka-artery-aeron-tests:
-    name: Akka Artery Aeron Tests
+  pekko-artery-aeron-tests:
+    name: Pekko Artery Aeron Tests
     runs-on: ubuntu-20.04
     if: github.repository == 'apache/incubator-pekko'
     strategy:

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -1,8 +1,10 @@
 name: Nightly Builds
 
 on:
-  schedule:
-    - cron: "0 0 * * *"
+# fixme revert
+#  schedule:
+#    - cron: "0 0 * * *"
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -1,10 +1,8 @@
 name: Nightly Builds
 
 on:
-# fixme revert
-#  schedule:
-#    - cron: "0 0 * * *"
-  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 jobs:
@@ -12,8 +10,7 @@ jobs:
   pekko-cluster-metrics-sigar:
     name: Pekko Cluster Metrics Test with Sigar
     runs-on: ubuntu-20.04
-    # fixme
-    #if: github.repository == 'apache/incubator-pekko'
+    if: github.repository == 'apache/incubator-pekko'
     steps:
 
       - name: Checkout
@@ -75,7 +72,7 @@ jobs:
   pekko-classic-remoting-tests:
     name: Pekko Classic Remoting Tests
     runs-on: ubuntu-20.04
-    # fixme
+    if: github.repository == 'apache/incubator-pekko'
     strategy:
       fail-fast: false
       matrix:
@@ -130,8 +127,7 @@ jobs:
   jdk-nightly-build:
     name: JDK ${{ matrix.jdkVersion }} / Scala ${{ matrix.scalaVersion }}
     runs-on: ubuntu-20.04
-    # fixme
-    #if: github.repository == 'apache/incubator-pekko'
+    if: github.repository == 'apache/incubator-pekko'
     strategy:
       fail-fast: false
       matrix:
@@ -230,8 +226,7 @@ jobs:
   pekko-artery-aeron-tests:
     name: Pekko Artery Aeron Tests
     runs-on: ubuntu-20.04
-    # fixme
-    #if: github.repository == 'apache/incubator-pekko'
+    if: github.repository == 'apache/incubator-pekko'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -10,7 +10,8 @@ jobs:
   pekko-cluster-metrics-sigar:
     name: Pekko Cluster Metrics Test with Sigar
     runs-on: ubuntu-20.04
-    if: github.repository == 'apache/incubator-pekko'
+    # fixme
+    #if: github.repository == 'apache/incubator-pekko'
     steps:
 
       - name: Checkout
@@ -72,7 +73,7 @@ jobs:
   pekko-classic-remoting-tests:
     name: Pekko Classic Remoting Tests
     runs-on: ubuntu-20.04
-    if: github.repository == 'apache/incubator-pekko'
+    # fixme
     strategy:
       fail-fast: false
       matrix:
@@ -127,7 +128,8 @@ jobs:
   jdk-nightly-build:
     name: JDK ${{ matrix.jdkVersion }} / Scala ${{ matrix.scalaVersion }}
     runs-on: ubuntu-20.04
-    if: github.repository == 'apache/incubator-pekko'
+    # fixme
+    #if: github.repository == 'apache/incubator-pekko'
     strategy:
       fail-fast: false
       matrix:
@@ -226,7 +228,8 @@ jobs:
   pekko-artery-aeron-tests:
     name: Pekko Artery Aeron Tests
     runs-on: ubuntu-20.04
-    if: github.repository == 'apache/incubator-pekko'
+    # fixme
+    #if: github.repository == 'apache/incubator-pekko'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Despite its name this build doesn't actually publish anything (except for test reports). It just runs some more verbose testing on different JDKs, cluster, artery, and some other things. We'll need to add the `marcospereira/action-surefire-report@v1` action to an allow list, or find an alternative, to get test report artifacts published.

Build on my fork: https://github.com/seglo/incubator-pekko/actions/runs/3400931121