### PR TITLE
Add documentation for git blame on ignoring formatting commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -417,6 +417,16 @@ Enable Travis CI #1
 * Details 3
 ```
 
+### Ignoring formatting commits in git blame
+
+Throughout the history of the codebase various formatting commits have been applied as the scalafmt style has evolved over time, if desired
+one can setup git blame to ignore these commits. The hashes for these specific are stored in [this file](.git-blame-ignore-revs) so to configure
+git blame to ignore these commits you can execute the following.
+
+```shell
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
 ### Pull request validation workflow details
 
 Akka uses GitHub Actions to validate pull requests, which involves checking code style, run tests, check binary compatibility, etc.


### PR DESCRIPTION
PR title is self explanatory, this is a follow on from https://github.com/apache/incubator-pekko/pull/17. Possible open question is whether this is put into the correct place in `CONTRIBUTING.md`.