### PR TITLE
Make main branch protected

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -27,9 +27,11 @@ github:
     merge:   false
     rebase:  true
 
+  protected_branches:
+    main: { }
+
 notifications:
   commits:              commits@pekko.apache.org
   issues:               notifications@pekko.apache.org
   pullrequests:         notifications@pekko.apache.org
   discussions:          notifications@pekko.apache.org
-


### PR DESCRIPTION
This is to prevent accidental force pushes onto main (see https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-Branchprotection).