### PR TITLE
Rename github action names to Pekko

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
-      - name: create the Akka site
+      - name: create the Pekko site
         run: sbt -Dpekko.genjavadoc.enabled=true "Javaunidoc/doc; Compile/unidoc; docs/paradox"
 
       - name: Install Coursier command line tool

--- a/.github/workflows/multi-node.yml
+++ b/.github/workflows/multi-node.yml
@@ -36,11 +36,11 @@ jobs:
         run: |-
           gcloud config set compute/region us-central1
           gcloud config set compute/zone us-central1-c
-          ./kubernetes/create-cluster-gke.sh "akka-multi-node-${GITHUB_RUN_ID}"
+          ./kubernetes/create-cluster-gke.sh "pekko-multi-node-${GITHUB_RUN_ID}"
 
       - name: Setup Pods
         run: |
-          # Start 10 pods. At most 10 MultiJvmNode (akka.cluster.StressSpec is currently disabled).
+          # Start 10 pods. At most 10 MultiJvmNode (org.apache.pekko.cluster.StressSpec is currently disabled).
           ./kubernetes/setup.sh 10 multi-node-test.hosts tcp
 
       - name: Setup Java 11
@@ -100,7 +100,7 @@ jobs:
         if: ${{ always() }}
         shell: bash {0}
         run: |
-          gcloud container clusters delete "akka-multi-node-${GITHUB_RUN_ID}" --quiet
+          gcloud container clusters delete "pekko-multi-node-${GITHUB_RUN_ID}" --quiet
 
   run-multi-node-aeron-tests:
     name: Multi Node Test with Artery Aeron UDP transport
@@ -124,11 +124,11 @@ jobs:
         run: |-
           gcloud config set compute/region us-central1
           gcloud config set compute/zone us-central1-c
-          ./kubernetes/create-cluster-gke.sh "akka-artery-aeron-cluster-${GITHUB_RUN_ID}"
+          ./kubernetes/create-cluster-gke.sh "pekko-artery-aeron-cluster-${GITHUB_RUN_ID}"
 
       - name: Setup Pods
         run: |
-          # Start 10 pods. At most 10 MultiJvmNode (akka.cluster.StressSpec is currently disabled).
+          # Start 10 pods. At most 10 MultiJvmNode (org.apache.pekko.cluster.StressSpec is currently disabled).
           ./kubernetes/setup.sh 10 multi-node-test.hosts udp
 
       - name: Setup Java 11
@@ -188,4 +188,4 @@ jobs:
         if: ${{ always() }}
         shell: bash {0}
         run: |
-          gcloud container clusters delete "akka-artery-aeron-cluster-${GITHUB_RUN_ID}" --quiet
+          gcloud container clusters delete "pekko-artery-aeron-cluster-${GITHUB_RUN_ID}" --quiet

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -1,4 +1,4 @@
-name: Build and test Akka with Scala 3
+name: Build and test Pekko with Scala 3
 
 on:
   schedule:

--- a/.github/workflows/scala3-compile.yml
+++ b/.github/workflows/scala3-compile.yml
@@ -1,4 +1,4 @@
-name: Compile Akka with Scala 3
+name: Compile Pekko with Scala 3
 
 on:
   pull_request:

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -9,8 +9,8 @@ permissions: {}
 
 jobs:
 
-  akka-timing-sensitive-tests:
-    name: Akka Tests taggedAs TimingTest
+  pekko-timing-sensitive-tests:
+    name: Pekko Tests taggedAs TimingTest
     runs-on: ubuntu-20.04
     if: github.repository == 'apache/incubator-pekko'
     steps:


### PR DESCRIPTION
This is a precursor to get https://github.com/apache/incubator-pekko/issues/23 working because the status checks are reliant on the name of the check hence why this PR is renaming check names that contain Akka to Pekko so that we don't have to update it again in the future.