### PR TITLE
upgrade cache-action due to build warnings

### DIFF
--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -34,7 +34,7 @@ jobs:
           java-version: adopt@1.8.0
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       # compile code instead of doing mima check (until we re-enable mima check)
       - name: Compile code

--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: adopt@1.8.0
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: Check headers
         run: |-
@@ -50,7 +50,7 @@ jobs:
           java-version: adopt@1.8.0
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: sbt validatePullRequest
         run: |-

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: adopt@1.11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: create the Akka site
         run: sbt -Dakka.genjavadoc.enabled=true "Javaunidoc/doc; Compile/unidoc; akka-docs/paradox"

--- a/.github/workflows/multi-node.yml
+++ b/.github/workflows/multi-node.yml
@@ -46,7 +46,7 @@ jobs:
           java-version: adopt@1.11.0-9
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: Multi node test
         run: |
@@ -130,7 +130,7 @@ jobs:
           java-version: adopt@1.11.0-9
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: Multi node test with Artery Aeron UDP
         run: |

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -24,7 +24,7 @@ jobs:
           java-version: adopt@1.11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: sbt akka-cluster-metrics/test
         run: |-
@@ -93,7 +93,7 @@ jobs:
           java-version: adopt@1.11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: sbt ${{ matrix.command }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
@@ -155,7 +155,7 @@ jobs:
           java-version: ${{ matrix.jdkVersion }}
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: Compile and Test
         # note that this is not running any multi-jvm tests because multi-in-test=false
@@ -246,7 +246,7 @@ jobs:
           java-version: adopt@1.11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: sbt ${{ matrix.command }}
         # note that this is not running any multi-jvm tests because multi-in-test=false

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -43,7 +43,7 @@ jobs:
           java-version: adopt@1.11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: Compile and run tests on Scala 3
         # note that this is not running any multi-jvm tests (yet) because multi-in-test=false

--- a/.github/workflows/scala3-compile.yml
+++ b/.github/workflows/scala3-compile.yml
@@ -40,7 +40,7 @@ jobs:
           java-version: adopt@1.11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: Compile on Scala 3
         run: |

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -24,7 +24,7 @@ jobs:
           java-version: adopt@1.11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: sbt test
         run: |-


### PR DESCRIPTION
Getting warnings like this:

```
Warning: The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
Warning: The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

This upgrade may not help that but it's usually good to keep up to date with versions.