### PR TITLE
!str Eagerly fails flow if the future is already failed.

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowFromFutureSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowFromFutureSpec.scala
@@ -20,6 +20,7 @@ import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
 import org.apache.pekko.stream.testkit._
+import org.apache.pekko.stream.testkit.scaladsl.TestSink
 
 @nowarn("msg=deprecated") // testing deprecated API
 class FlowFromFutureSpec extends StreamSpec {
@@ -40,6 +41,13 @@ class FlowFromFutureSpec extends StreamSpec {
       val c = TestSubscriber.manualProbe[Int]()
       Source.fromFuture(Future.failed[Int](ex)).runWith(Sink.asPublisher(false)).subscribe(c)
       c.expectSubscriptionAndError(ex)
+    }
+
+    "fails flow from already failed Future even no demands" in {
+      val ex = new RuntimeException("test") with NoStackTrace
+      val sub = Source.fromFuture(Future.failed[Int](ex))
+        .runWith(TestSink.probe)
+      sub.expectSubscriptionAndError(ex)
     }
 
     "produce one element when Future is completed" in {

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/GraphStages.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/GraphStages.scala
@@ -390,26 +390,24 @@ import pekko.stream.stage._
     override def initialAttributes: Attributes = DefaultAttributes.futureSource
     override def createLogic(attr: Attributes) =
       new GraphStageLogic(shape) with OutHandler {
-        def onPull(): Unit = {
+        override def preStart(): Unit = {
           future.value match {
             case Some(completed) =>
               // optimization if the future is already completed
-              onFutureCompleted(completed)
+              handle(completed)
             case None =>
-              val cb = getAsyncCallback[Try[T]](onFutureCompleted).invoke _
+              val cb = getAsyncCallback[Try[T]](handle).invoke _
               future.onComplete(cb)(ExecutionContexts.parasitic)
           }
-
-          def onFutureCompleted(result: Try[T]): Unit = {
-            result match {
-              case scala.util.Success(null) => completeStage()
-              case scala.util.Success(v)    => emit(out, v, () => completeStage())
-              case scala.util.Failure(t)    => failStage(t)
-            }
-          }
-
-          setHandler(out, eagerTerminateOutput) // After first pull we won't produce anything more
         }
+
+        private def handle(result: Try[T]): Unit = result match {
+          case scala.util.Success(null) => completeStage()
+          case scala.util.Success(v)    => emit(out, v, () => completeStage())
+          case scala.util.Failure(t)    => failStage(t)
+        }
+
+        def onPull(): Unit = ()
 
         setHandler(out, this)
       }


### PR DESCRIPTION
If the future is already failed, it will fail the flow even if there is no downstream demands now.
refs: https://github.com/akka/akka/pull/31728
Which was reported first in akka/akka gitter

This is a behavior change, eagarly failing align with the FailedSource.

```
  /**
   * Emits a single value when the given `Future` is successfully completed and then completes the stream.
   * The stream fails if the `Future` is completed with a failure.
   */
```