### PR TITLE
=str Fix calling `onComplete` twice when downstream cancel.

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
@@ -2250,33 +2250,35 @@ private[pekko] final class StatefulMap[S, In, Out](create: () => S, f: (S, In) =
       override def onUpstreamFailure(ex: Throwable): Unit = closeStateAndFail(ex)
 
       override def onDownstreamFinish(cause: Throwable): Unit = {
-        onComplete(state)
         needInvokeOnCompleteCallback = false
+        onComplete(state)
         super.onDownstreamFinish(cause)
       }
 
       private def resetStateAndPull(): Unit = {
         needInvokeOnCompleteCallback = false
-        onComplete(state)
+        onComplete(state) match {
+          case Some(elem) => push(out, elem)
+          case None       => pull(in)
+        }
         state = create()
         needInvokeOnCompleteCallback = true;
-        pull(in)
       }
 
       private def closeStateAndComplete(): Unit = {
+        needInvokeOnCompleteCallback = false
         onComplete(state) match {
           case Some(elem) => emit(out, elem, () => completeStage())
           case None       => completeStage()
         }
-        needInvokeOnCompleteCallback = false
       }
 
       private def closeStateAndFail(ex: Throwable): Unit = {
+        needInvokeOnCompleteCallback = false
         onComplete(state) match {
           case Some(elem) => emit(out, elem, () => failStage(ex))
           case None       => failStage(ex)
         }
-        needInvokeOnCompleteCallback = false
       }
 
       override def onPull(): Unit = pull(in)


### PR DESCRIPTION
Try a another way for https://github.com/akka/akka/pull/31630
1. Keep the `onComplete` act as a finalizer
2. Do not call `onComplete` twice when restart
3. pump the option value downstream when restart

In fs2, resource/can be `null`.
```scala
package fs2

import cats.effect.{IO, Resource}

object Test extends App {
  val res1: Resource[IO, String] = Resource.make {
    println("make")
    IO.pure(null)
  } { r =>
    println("release:" + r)
    IO.unit
  }
  val str: Stream[IO, String] = Stream.resource(res1) ++ Stream.emit("done")
  str.compile.toList.unsafeRunAsync{
    case Left(value) => println(value)
    case Right(value) => println(value)
  }(cats.effect.unsafe.implicits.global)
  Thread.sleep(3000)
}
```
prints:
```
make
release:null
List(null, done)
```

I don't have a poweradapter now, so maybe can't update until tomorrow.

