### PR TITLE
Rename akka to pekko in CliOption and fix mima

### DIFF
--- a/project/AddLogTimestamps.scala
+++ b/project/AddLogTimestamps.scala
@@ -14,7 +14,7 @@ import sbt.internal.{ AppenderSupplier, LogManager }
 import sbt.internal.util.ConsoleOut
 
 object AddLogTimestamps extends AutoPlugin {
-  val enableTimestamps: Boolean = CliOption("akka.log.timestamps", false).get
+  val enableTimestamps: Boolean = CliOption("pekko.log.timestamps", false).get
 
   override def requires: Plugins = plugins.JvmPlugin
   override def trigger: PluginTrigger = allRequirements

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -19,8 +19,8 @@ import sbt.ScopeFilter.ProjectFilter
 object Scaladoc extends AutoPlugin {
 
   object CliOptions {
-    val scaladocDiagramsEnabled = CliOption("akka.scaladoc.diagrams", true)
-    val scaladocAutoAPI = CliOption("akka.scaladoc.autoapi", true)
+    val scaladocDiagramsEnabled = CliOption("pekko.scaladoc.diagrams", true)
+    val scaladocAutoAPI = CliOption("pekko.scaladoc.autoapi", true)
   }
 
   override def trigger = allRequirements
@@ -125,7 +125,7 @@ object ScaladocNoVerificationOfDiagrams extends AutoPlugin {
 object UnidocRoot extends AutoPlugin {
 
   object CliOptions {
-    val genjavadocEnabled = CliOption("akka.genjavadoc.enabled", false)
+    val genjavadocEnabled = CliOption("pekko.genjavadoc.enabled", false)
   }
 
   object autoImport {

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -23,7 +23,7 @@ object MiMa extends AutoPlugin {
 
   override val projectSettings = Seq(
     mimaReportSignatureProblems := true,
-    mimaPreviousArtifacts := Set.empty, // akkaPreviousArtifacts(name.value, organization.value, scalaBinaryVersion.value),
+    mimaPreviousArtifacts := akkaPreviousArtifacts(name.value, organization.value, scalaBinaryVersion.value),
     checkMimaFilterDirectories := checkFilterDirectories(baseDirectory.value))
 
   def checkFilterDirectories(moduleRoot: File): Unit = {

--- a/project/MultiNode.scala
+++ b/project/MultiNode.scala
@@ -27,7 +27,7 @@ object MultiNode extends AutoPlugin {
   val multiNodeTestInTest: Boolean = sys.props.getOrElse("pekko.test.multi-in-test", "true").toBoolean
 
   object CliOptions {
-    val multiNode = CliOption("akka.test.multi-node", false)
+    val multiNode = CliOption("pekko.test.multi-node", false)
     val sbtLogNoFormat = CliOption("sbt.log.noformat", false)
 
     val hostsFileName = sys.props.get("akka.test.multi-node.hostsFileName").toSeq

--- a/project/ValidatePullRequest.scala
+++ b/project/ValidatePullRequest.scala
@@ -17,7 +17,7 @@ import sbt._
 object PekkoValidatePullRequest extends AutoPlugin {
 
   object CliOptions {
-    val mimaEnabled = CliOption("akka.mima.enabled", true)
+    val mimaEnabled = CliOption("pekko.mima.enabled", true)
   }
 
   import ValidatePullRequest.autoImport._


### PR DESCRIPTION
Renames the `CliOption` that happens to have `akka` in the name. @pjfanning Note that this also reverts the change in https://github.com/apache/incubator-pekko/pull/65, the original cause for the CI suddenly checking for mima is that the https://github.com/apache/incubator-pekko/pull/58 PR changed the `-Dakka.mima.enabled=false` argument to `-Dpekko.mima.enabled=false` in the `build-test-prValidation.yml` workflow but not the `CliOption` which this PR is fixing.