### PR TITLE
System.getProperty("file.separator") replaced by "/" to avoid build p…

### DIFF
--- a/project/ValidatePullRequest.scala
+++ b/project/ValidatePullRequest.scala
@@ -46,7 +46,7 @@ object PekkoValidatePullRequest extends AutoPlugin {
 
       loadedBuild.value.allProjectRefs.collect {
         case (_, project) if !ignoredProjects.contains(project.id) =>
-          val directory = project.base.getPath.split(System.getProperty("file.separator")).last
+          val directory = project.base.getPath.split("/").last
           PathGlobFilter(s"$directory/**")
       }.fold(new FileFilter { // TODO: Replace with FileFilter.nothing when https://github.com/sbt/io/pull/340 gets released
         override def accept(pathname: File): Boolean = false


### PR DESCRIPTION
Fixes the build problems on Windows cause by a backslash file separator