### PR TITLE
=sbt Make use of `File.separatorChar` to avoid exception.

### DIFF
--- a/project/ValidatePullRequest.scala
+++ b/project/ValidatePullRequest.scala
@@ -46,7 +46,7 @@ object PekkoValidatePullRequest extends AutoPlugin {
 
       loadedBuild.value.allProjectRefs.collect {
         case (_, project) if !ignoredProjects.contains(project.id) =>
-          val directory = project.base.getPath.split(System.getProperty("file.separator")).last
+          val directory = project.base.getPath.split(java.io.File.separatorChar).last
           PathGlobFilter(s"$directory/**")
       }.fold(new FileFilter { // TODO: Replace with FileFilter.nothing when https://github.com/sbt/io/pull/340 gets released
         override def accept(pathname: File): Boolean = false


### PR DESCRIPTION
Otherewise I got the errors below:
```scala
java.util.regex.PatternSyntaxException: Unexpected internal error near index 1
\
        at java.util.regex.Pattern.error(Pattern.java:1969)
        at java.util.regex.Pattern.compile(Pattern.java:1708)
        at java.util.regex.Pattern.<init>(Pattern.java:1352)
        at java.util.regex.Pattern.compile(Pattern.java:1028)
        at java.lang.String.split(String.java:2380)
        at java.lang.String.split(String.java:2422)
        at org.apache.pekko.PekkoValidatePullRequest$$anonfun$$nestedInanonfun$buildSettings$1$1.applyOrElse(ValidatePullRequest.scala:49)
        at org.apache.pekko.PekkoValidatePullRequest$$anonfun$$nestedInanonfun$buildSettings$1$1.applyOrElse(ValidatePullRequest.scala:47)
        at scala.PartialFunction.$anonfun$runWith$1$adapted(PartialFunction.scala:145)
        at scala.collection.Iterator.foreach(Iterator.scala:943)
        at scala.collection.Iterator.foreach$(Iterator.scala:943)
        at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
        at scala.collection.IterableLike.foreach(IterableLike.scala:74)
        at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
        at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
        at scala.collection.TraversableLike.collect(TraversableLike.scala:407)
        at scala.collection.TraversableLike.collect$(TraversableLike.scala:405)
        at scala.collection.AbstractTraversable.collect(Traversable.scala:108)
        at org.apache.pekko.PekkoValidatePullRequest$.$anonfun$buildSettings$1(ValidatePullRequest.scala:47)
        at scala.Function1.$anonfun$compose$1(Function1.scala:49)
        at sbt.internal.util.EvaluateSettings$MixedNode.evaluate0(INode.scala:228)
        at sbt.internal.util.EvaluateSettings$INode.evaluate(INode.scala:170)
        at sbt.internal.util.EvaluateSettings.$anonfun$submitEvaluate$1(INode.scala:87)
        at sbt.internal.util.EvaluateSettings.sbt$internal$util$EvaluateSettings$$run0(INode.scala:99)
        at sbt.internal.util.EvaluateSettings$$anon$3.run(INode.scala:94)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
[error] java.util.regex.PatternSyntaxException: Unexpected internal error near index 1
[error] \
[error] Use 'last' for the full log.
[warn] Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? (default: r)
```