### PR TITLE
=sbt Make use of `File.separatorChar` to avoid exception.

### DIFF
--- a/project/ValidatePullRequest.scala
+++ b/project/ValidatePullRequest.scala
@@ -46,7 +46,7 @@ object PekkoValidatePullRequest extends AutoPlugin {
 
       loadedBuild.value.allProjectRefs.collect {
         case (_, project) if !ignoredProjects.contains(project.id) =>
-          val directory = project.base.getPath.split("/").last
+          val directory = project.base.getPath.split(java.io.File.separatorChar).last
           PathGlobFilter(s"$directory/**")
       }.fold(new FileFilter { // TODO: Replace with FileFilter.nothing when https://github.com/sbt/io/pull/340 gets released
         override def accept(pathname: File): Boolean = false


### PR DESCRIPTION
Make use of `java.io.File.separatorChar` to work properly on Windows
A follow up of https://github.com/apache/incubator-pekko/pull/75