### PR TITLE
Remove sbtx usage

### DIFF
--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -36,16 +36,19 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
+      - name: Enable jvm-opts
+        run: cp .jvmopts-ci .jvmopts
+
       # compile code instead of doing mima check (until we re-enable mima check)
       - name: Compile code
-        run: sbtx -jvm-opts .jvmopts-ci "+~ ${{ matrix.scalaVersion }} Test/compile"
+        run: sbt "+~ ${{ matrix.scalaVersion }} Test/compile"
 
       # disable mima check until first pekko release is done
       #- name: Report MiMa Binary Issues
-      #  run: sbtx -jvm-opts .jvmopts-ci "+~ ${{ matrix.scalaVersion }} mimaReportBinaryIssues"
+      #  run: sbt "+~ ${{ matrix.scalaVersion }} mimaReportBinaryIssues"
 
       #- name: Check correct MiMa filter directories
-      #  run: sbtx -jvm-opts .jvmopts-ci checkMimaFilterDirectories
+      #  run: sbt checkMimaFilterDirectories
 
       # comment out email actions until we have an email address to use (and we need to get INFRA to whitelist dawidd6/action-send-mail)
       #- name: Email on failure

--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -27,9 +27,12 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
+      - name: Enable jvm-opts
+        run: cp .jvmopts-ci .jvmopts
+
       - name: Check headers
         run: |-
-          sbtx -jvm-opts .jvmopts-ci \
+          sbt \
           -Dsbt.override.build.repos=false \
           -Dsbt.log.noformat=false \
           headerCheckAll
@@ -52,9 +55,12 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
+      - name: Enable jvm-opts
+        run: cp .jvmopts-ci .jvmopts
+
       - name: sbt validatePullRequest
         run: |-
-          sbtx -jvm-opts .jvmopts-ci \
+          sbt \
           -Dpekko.mima.enabled=false \
           -Dpekko.test.multi-in-test=false \
           -Dpekko.test.timefactor=2 \

--- a/.github/workflows/multi-node.yml
+++ b/.github/workflows/multi-node.yml
@@ -48,10 +48,13 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
+      - name: Enable jvm-opts
+        run: cp .jvmopts-ci .jvmopts
+
       - name: Multi node test
         run: |
           cat multi-node-test.hosts
-          sbtx -jvm-opts .jvmopts-ci \
+          sbt \
             -Dpekko.test.timefactor=2 \
             -Dpekko.actor.testkit.typed.timefactor=2 \
             -Dpekko.test.tags.exclude=gh-exclude,timing \
@@ -132,10 +135,13 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
+      - name: Enable jvm-opts
+        run: cp .jvmopts-ci .jvmopts
+
       - name: Multi node test with Artery Aeron UDP
         run: |
           cat multi-node-test.hosts
-          sbtx -jvm-opts .jvmopts-ci \
+          sbt \
             -Dpekko.test.timefactor=2 \
             -Dpekko.actor.testkit.typed.timefactor=2 \
             -Dpekko.cluster.assert=on \

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -26,9 +26,12 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
+      - name: Enable jvm-opts
+        run: cp .jvmopts-ci .jvmopts
+
       - name: sbt akka-cluster-metrics/test
         run: |-
-          sbtx -jvm-opts .jvmopts-ci \
+          sbt \
             -Djava.security.egd=file:/dev/./urandom \
             -Dpekko.test.sigar=true \
             -Dpekko.cluster.assert=on \
@@ -95,10 +98,13 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
+      - name: Enable jvm-opts
+        run: cp .jvmopts-ci .jvmopts
+
       - name: sbt ${{ matrix.command }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
-          sbtx -jvm-opts .jvmopts-ci \
+          sbt \
           -Djava.security.egd=file:/dev/./urandom \
           -Dpekko.remote.artery.enabled=off \
           -Dpekko.test.timefactor=2 \
@@ -157,10 +163,13 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
+      - name: Enable jvm-opts
+        run: cp .jvmopts-ci .jvmopts
+
       - name: Compile and Test
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
-          sbtx -jvm-opts .jvmopts-ci \
+          sbt \
             -Dpekko.cluster.assert=on \
             -Dpekko.log.timestamps=true \
             -Dpekko.test.timefactor=2 \
@@ -194,7 +203,7 @@ jobs:
         if: ${{ startsWith(matrix.jdkVersion, 'adopt@1.11') }}
         run: |-
           sudo apt-get install graphviz
-          sbtx -jvm-opts .jvmopts-ci \
+          sbt \
             -Dpekko.genjavadoc.enabled=true \
             "+~ ${{ matrix.scalaVersion }} doc"
 
@@ -203,7 +212,7 @@ jobs:
         if: ${{ startsWith(matrix.jdkVersion, 'adopt@1.11') }}
         run: |-
           sudo apt-get install graphviz
-          sbtx -jvm-opts .jvmopts-ci \
+          sbt \
             -Dpekko.build.scalaVersion=${{ matrix.scalaVersion }} \
             "+~ ${{ matrix.scalaVersion }} publishLocal publishM2"
 
@@ -248,10 +257,13 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
+      - name: Enable jvm-opts
+        run: cp .jvmopts-ci .jvmopts
+
       - name: sbt ${{ matrix.command }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
-          sbtx -jvm-opts .jvmopts-ci \
+          sbt \
           -Djava.security.egd=file:/dev/./urandom \
           -Dpekko.remote.artery.transport=aeron-udp \
           -Dpekko.test.timefactor=2 \

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -45,10 +45,13 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
+      - name: Enable jvm-opts
+        run: cp .jvmopts-ci .jvmopts
+
       - name: Compile and run tests on Scala 3
         # note that this is not running any multi-jvm tests (yet) because multi-in-test=false
         run: |
-          sbtx -jvm-opts .jvmopts-ci \
+          sbt \
           -Dpekko.log.timestamps=true \
           -Dpekko.test.timefactor=2 \
           -Dpekko.actor.testkit.typed.timefactor=2 \

--- a/.github/workflows/scala3-compile.yml
+++ b/.github/workflows/scala3-compile.yml
@@ -42,7 +42,10 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
+      - name: Enable jvm-opts
+        run: cp .jvmopts-ci .jvmopts
+
       - name: Compile on Scala 3
         run: |
-          sbtx -jvm-opts .jvmopts-ci \
+          sbt \
           "+~ 3 ${{ matrix.command }}"

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -26,9 +26,12 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
+      - name: Enable jvm-opts
+        run: cp .jvmopts-ci .jvmopts
+
       - name: sbt test
         run: |-
-          sbtx -jvm-opts .jvmopts-ci \
+          sbt \
             -Djava.security.egd=file:/dev/./urandom \
             -Dpekko.cluster.assert=on \
             -Dpekko.test.timefactor=2 \


### PR DESCRIPTION
Fix for #59 

Replace by prior copy of `.jvmopts-ci` into `.jvmopts` which is the file sbt natively supports

Naive approach, just trying to help, not sure if that's what you expected? 😄  It seems sbt doesn't support a custom filename for jvm opts 