### PR TITLE
Improve akka-actor-typed initialCommands

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -466,12 +466,17 @@ lazy val actorTyped = akkaModule("akka-actor-typed")
   .settings(OSGi.actorTyped)
   .settings(initialCommands :=
     """
-      import org.apache.pekko.actor.typed._
-      import org.apache.pekko.actor.typed.scaladsl.Behaviors
+      import org.apache.pekko
+
+      import pekko.actor.typed._
+      import pekko.actor.typed.scaladsl.Behaviors
+      import pekko.util.Timeout
+
       import scala.concurrent._
       import scala.concurrent.duration._
-      import org.apache.pekko.util.Timeout
-      implicit val timeout = Timeout(5.seconds)
+      import scala.language.postfixOps
+
+      implicit val timeout = Timeout(5 seconds)
     """)
   .enablePlugins(Jdk9)
 


### PR DESCRIPTION
This PR improves the `akka-actor-typed` `initialCommands` which are executed when you start the Scala REPL shell in the sbt console with `akka-actor-typed/console`. The two main improvements are

* We `import org.apache.pekko` which means that further pekko imports don't need the `org.apache` prefix
* Also `import scala.language.postfixOps` since especially in an Scala REPL session people often find it more convenient to write `5 seconds` instead of `5.seconds` or `seconds(5)`.

I can confirm that locally the REPL still works on my machine, i.e.
```
[info] Useful sbt tasks:
[info] >  compile - Compile the current project
[info] >  test - Run all the tests
[info] >  testOnly *.AnySpec - Only run a selected test
[info] >  verifyCodeStyle - Verify code style
[info] >  applyCodeStyle - Apply code style
[info] >  sortImports - Sort the imports
[info] >  mimaReportBinaryIssues  - Check binary issues
[info] >  validatePullRequest  - Validate pull request
[info] >  docs/paradox - Build documentation
[info] >  docs/paradoxBrowse - Browse the generated documentation
[info] >  tips: - prefix commands with `+` to run against cross Scala versions.
[info] >  Contributing guide: - https://github.com/apache/incubator-pekko/blob/main/CONTRIBUTING.md
[info] sbt server started at local:///Users/mdedetrich/.sbt/1.0/server/62a7cea246d563e33631/sock
[info] started sbt server
pekko > akka-actor-typed/console
[info] compiling 1 Scala source to /Users/mdedetrich/github/incubator-pekko/akka-actor/target/scala-2.13/classes ...
[info] Starting scala interpreter...
Welcome to Scala 2.13.8 (OpenJDK 64-Bit Server VM, Java 1.8.0_352).
Type in expressions for evaluation. Or try :help.
import org.apache.pekko
import pekko.actor.typed._
import pekko.actor.typed.scaladsl.Behaviors
import pekko.util.Timeout
import scala.concurrent._
import scala.concurrent.duration._
import scala.language.postfixOps
val timeout: org.apache.pekko.util.Timeout = Timeout(5 seconds)

scala>
```