### PR TITLE
Update latest sbt version

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.8.2


### PR DESCRIPTION
Updates to the latest SBT version, this is important because its solves an SBT issue with the new Mac ARM machines (see https://github.com/sbt/sbt/releases/tag/v1.8.2).