### PR TITLE
Record fork base commit and version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Apache Pekko is an open-source framework for building applications that are conc
 Pekko uses the Actor Model to provide more intuitive high-level abstractions for concurrency.
 Using these abstractions, Pekko also provides libraries for persistence, streams, HTTP, and more.
 
-Pekko is a fork of [Akka](https://github.com/akka/akka) 2.6.x, prior to the Akka project's adoption of the Business Source License.
+Pekko is a fork of [Akka](https://github.com/akka/akka) taken at [the point](https://github.com/akka/akka/tree/6680c47dcc2305906a44d7794081682211d7ee0b) immediately after Akka's 2.6.20 release, just prior to the Akka project's adoption of the Business Source License.
 
 Reference Documentation
 -----------------------


### PR DESCRIPTION
It's useful for potential users of Pekko to know what version of Akka it corresponds to. This PR adds that info to the README. It also adds the precise commit of the fork, since that's likely to be of interest to us and to others in the future.

I'd like to propose tagging that commit as well, as akka-fork-base or similar - do you agree this would be a good idea?

See also https://github.com/apache/incubator-pekko-http/pull/20 which does the same for pekko-http.