### PR TITLE
Remove readiness levels

### DIFF
--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -32,13 +32,6 @@ project-info {
   actor: ${project-info.shared-info} {
     title: "Pekko Actors (classic)"
     jpms-name: "pekko.actor"
-    levels: [
-      {
-        readiness: Supported
-        since: "2012-03-06"
-        since-version: "2.0"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"actor/index.html"
@@ -53,18 +46,6 @@ project-info {
   actor-testkit-typed: ${project-info.shared-info} {
     title: "Pekko Actor Testkit (typed)"
     jpms-name: "pekko.actor.testkit.typed"
-    levels: [
-      {
-        readiness: Supported
-        since: "2019-11-06"
-        since-version: "2.6.0"
-      }
-      {
-        readiness: Incubating
-        since: "2017-05-24"
-        since-version: "2.5.2"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"actor/testkit/typed/index.html"
@@ -79,18 +60,6 @@ project-info {
   actor-typed: ${project-info.shared-info} {
     title: "Pekko Actors (typed)"
     jpms-name: "pekko.actor.typed"
-    levels: [
-      {
-        readiness: Supported
-        since: "2019-11-06"
-        since-version: "2.6.0"
-      }
-      {
-        readiness: Incubating
-        since: "2017-05-24"
-        since-version: "2.5.2"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"actor/typed/index.html"
@@ -105,13 +74,6 @@ project-info {
   cluster: ${project-info.shared-info} {
     title: "Pekko Cluster (classic)"
     jpms-name: "pekko.cluster"
-    levels: [
-      {
-        readiness: Supported
-        since: "2013-07-09"
-        since-version: "2.2.0"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"cluster/index.html"
@@ -126,13 +88,6 @@ project-info {
   cluster-metrics: ${project-info.shared-info} {
     title: "Pekko Cluster Metrics (classic)"
     jpms-name: "pekko.cluster.metrics"
-    levels: [
-      {
-        readiness: Supported
-        since: "2014-03-05"
-        since-version: "2.3.0"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"cluster/metrics/index.html"
@@ -147,13 +102,6 @@ project-info {
   cluster-sharding: ${project-info.shared-info} {
     title: "Pekko Cluster Sharding (classic)"
     jpms-name: "pekko.cluster.sharding"
-    levels: [
-      {
-        readiness: Supported
-        since: "2014-03-05"
-        since-version: "2.3.0"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"cluster/sharding/index.html"
@@ -168,18 +116,6 @@ project-info {
   cluster-sharding-typed: ${project-info.shared-info} {
     title: "Pekko Cluster Sharding (typed)"
     jpms-name: "pekko.cluster.sharding.typed"
-    levels: [
-      {
-        readiness: Supported
-        since: "2019-11-06"
-        since-version: "2.6.0"
-      }
-      {
-        readiness: Incubating
-        since: "2017-05-24"
-        since-version: "2.5.2"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"cluster/sharding/typed/index.html"
@@ -194,13 +130,6 @@ project-info {
   cluster-tools: ${project-info.shared-info} {
     title: "Pekko Cluster Tools (classic)"
     jpms-name: "pekko.cluster.tools"
-    levels: [
-      {
-        readiness: Supported
-        since: "2014-03-05"
-        since-version: "2.3.0"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"cluster/tools/index.html"
@@ -215,18 +144,6 @@ project-info {
   cluster-typed: ${project-info.shared-info} {
     title: "Pekko Cluster (typed)"
     jpms-name: "pekko.cluster.typed"
-    levels: [
-      {
-        readiness: Supported
-        since: "2019-11-06"
-        since-version: "2.6.0"
-      }
-      {
-        readiness: Incubating
-        since: "2017-05-24"
-        since-version: "2.5.2"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"cluster/typed/index.html"
@@ -241,13 +158,6 @@ project-info {
   coordination: ${project-info.shared-info} {
     title: "Pekko Coordination"
     jpms-name: "pekko.coordination"
-    levels: [
-      {
-        readiness: Supported
-        since: "2019-04-03"
-        since-version: "2.5.22"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"coordination/index.html"
@@ -262,13 +172,6 @@ project-info {
   discovery: ${project-info.shared-info} {
     title: "Pekko Discovery"
     jpms-name: "pekko.discovery"
-    levels: [
-      {
-        readiness: Supported
-        since: "2018-12-07"
-        since-version: "2.5.19"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"discovery/index.html"
@@ -283,13 +186,6 @@ project-info {
   distributed-data: ${project-info.shared-info} {
     title: "Pekko Distributed Data (classic)"
     jpms-name: "pekko.cluster.ddata"
-    levels: [
-      {
-        readiness: Supported
-        since: "2018-12-07"
-        since-version: "2.5.19"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"discovery/index.html"
@@ -304,13 +200,6 @@ project-info {
   multi-node-testkit: ${project-info.shared-info} {
     title: "Pekko Multi-node Testkit"
     jpms-name: "pekko.remote.testkit"
-    levels: [
-      {
-        readiness: Supported
-        since: "2017-04-13"
-        since-version: "before 2.5.0"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"remote/testkit/index.html"
@@ -325,13 +214,6 @@ project-info {
   osgi: ${project-info.shared-info} {
     title: "Pekko OSGi"
     jpms-name: "pekko.osgi"
-    levels: [
-      {
-        readiness: CommunityDriven
-        since: "2017-04-13"
-        since-version: "before 2.5.0"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"osgi/index.html"
@@ -346,13 +228,6 @@ project-info {
   persistence: ${project-info.shared-info} {
     title: "Pekko Persistence (classic)"
     jpms-name: "pekko.persistence"
-    levels: [
-      {
-        readiness: Supported
-        since: "2014-03-05"
-        since-version: "2.3.0"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"persistence/index.html"
@@ -367,13 +242,6 @@ project-info {
   persistence-query: ${project-info.shared-info} {
     title: "Pekko Persistence Query"
     jpms-name: "pekko.persistence.query"
-    levels: [
-      {
-        readiness: Supported
-        since: "2017-04-13"
-        since-version: "before 2.5.0"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"persistence/query/index.html"
@@ -388,18 +256,6 @@ project-info {
   persistence-typed: ${project-info.shared-info} {
     title: "Pekko Event Sourcing (typed)"
     jpms-name: "pekko.persistence.typed"
-    levels: [
-      {
-        readiness: Supported
-        since: "2019-11-06"
-        since-version: "2.6.0"
-      }
-      {
-        readiness: Incubating
-        since: "2017-05-24"
-        since-version: "2.5.2"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"persistence/typed/index.html"
@@ -414,13 +270,6 @@ project-info {
   persistence-testkit: ${project-info.shared-info} {
     title: "Pekko Persistence Testkit"
     jpms-name: "pekko.persistence.testkit"
-    levels: [
-      {
-        readiness: Incubating
-        since: "2020-04-30"
-        since-version: "2.6.5"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"persistence/testkit/scaladsl/index.html"
@@ -435,19 +284,6 @@ project-info {
   remote: ${project-info.shared-info} {
     title: "Pekko Remoting"
     jpms-name: "pekko.remote"
-    levels: [
-      {
-        readiness: Supported
-        since: "2019-11-06"
-        since-version: "2.6.0"
-        note: "Classic remoting is deprecated and will be removed in Akka 2.7.0."
-      }
-      {
-        readiness: Supported
-        since: "2013-07-09"
-        since-version: "2.2.0"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"remote/index.html"
@@ -462,13 +298,6 @@ project-info {
   slf4j: ${project-info.shared-info} {
     title: "Pekko Logging (classic)"
     jpms-name: "pekko.slf4j"
-    levels: [
-      {
-        readiness: Supported
-        since: "2015-09-30"
-        since-version: "2.4.0"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"event/slf4j/index.html"
@@ -483,13 +312,6 @@ project-info {
   stream: ${project-info.shared-info} {
     title: "Pekko Streams"
     jpms-name: "pekko.stream"
-    levels: [
-      {
-        readiness: Supported
-        since: "2017-04-13"
-        since-version: "2.5.0"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"stream/index.html"
@@ -504,13 +326,6 @@ project-info {
   stream-testkit: ${project-info.shared-info} {
     title: "Pekko Stream Testkit"
     jpms-name: "pekko.stream.testkit"
-    levels: [
-      {
-        readiness: Supported
-        since: "2017-04-13"
-        since-version: "2.5.0"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"stream/testkit/index.html"
@@ -525,18 +340,6 @@ project-info {
   stream-typed: ${project-info.shared-info} {
     title: "Pekko Stream (typed)"
     jpms-name: "pekko.stream"
-    levels: [
-      {
-        readiness: Supported
-        since: "2019-11-06"
-        since-version: "2.6.0"
-      }
-      {
-        readiness: Incubating
-        since: "2017-05-24"
-        since-version: "2.5.2"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"stream/index.html"
@@ -551,13 +354,6 @@ project-info {
   testkit: ${project-info.shared-info} {
     title: "Pekko Actor Testkit (classic)"
     jpms-name: "pekko.actor.testkit"
-    levels: [
-      {
-        readiness: Supported
-        since: "2012-03-06"
-        since-version: "2.0"
-      }
-    ]
     api-docs: [
       {
         url: ${project-info.scaladoc}"testkit/index.html"


### PR DESCRIPTION
In trying to replace the akka paradox theme with just the basic paradox theme, one issue I found is that akka/lightbend projects use the concept of readiness levels which comes from sbt-paradox-project-info https://github.com/lightbend/sbt-paradox-project-info#readiness-levels.

While it is possible to provide our own readiness-levels, this doesn't make too much sense for Apache projects. Also in doing so we would have to create our own sbt-paradox-pekko-project-info (akin to https://github.com/lightbend/sbt-paradox-lightbend-project-info) which is too much overhead for now.

If we do end up deciding on readiness levels this should be done via an Apache process and we can always add it in later.

References: https://github.com/apache/incubator-pekko/issues/32