### PR TITLE
Fix paradox project info artifact names

### DIFF
--- a/docs/src/main/paradox/additional/osgi.md
+++ b/docs/src/main/paradox/additional/osgi.md
@@ -9,7 +9,7 @@ To use Akka in OSGi, you must add the following dependency in your project:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-osgi_$scala.binary.version$
+  artifact=pekko-osgi_$scala.binary.version$
   version=PekkoVersion
 }
 

--- a/docs/src/main/paradox/durable-state/persistence-query.md
+++ b/docs/src/main/paradox/durable-state/persistence-query.md
@@ -12,7 +12,7 @@ To use Persistence Query, you must add the following dependency in your project:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-persistence-query_$scala.binary.version$
+  artifact=pekko-persistence-query_$scala.binary.version$
   version=PekkoVersion
 }
 

--- a/docs/src/main/paradox/persistence-query-leveldb.md
+++ b/docs/src/main/paradox/persistence-query-leveldb.md
@@ -12,7 +12,7 @@ To use Persistence Query, you must add the following dependency in your project:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-persistence-query_$scala.binary.version$
+  artifact=pekko-persistence-query_$scala.binary.version$
   version=PekkoVersion
 }
 

--- a/docs/src/main/paradox/persistence-query.md
+++ b/docs/src/main/paradox/persistence-query.md
@@ -12,7 +12,7 @@ To use Persistence Query, you must add the following dependency in your project:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-persistence-query_$scala.binary.version$
+  artifact=pekko-persistence-query_$scala.binary.version$
   version=PekkoVersion
 }
 

--- a/docs/src/main/paradox/remoting-artery.md
+++ b/docs/src/main/paradox/remoting-artery.md
@@ -27,7 +27,7 @@ To use Artery Remoting, you must add the following dependency in your project:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-remote_$scala.binary.version$
+  artifact=pekko-remote_$scala.binary.version$
   version=PekkoVersion
 }
 

--- a/docs/src/main/paradox/typed/actor-discovery.md
+++ b/docs/src/main/paradox/typed/actor-discovery.md
@@ -11,7 +11,7 @@ To use Akka Actor Typed, you must add the following dependency in your project:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-actor-typed_$scala.binary.version$
+  artifact=pekko-actor-typed_$scala.binary.version$
   version=PekkoVersion
 }
 

--- a/docs/src/main/paradox/typed/actor-lifecycle.md
+++ b/docs/src/main/paradox/typed/actor-lifecycle.md
@@ -14,7 +14,7 @@ To use Akka Actor Typed, you must add the following dependency in your project:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-actor-typed_$scala.binary.version$
+  artifact=pekko-actor-typed_$scala.binary.version$
   version=PekkoVersion
 }
 

--- a/docs/src/main/paradox/typed/cluster-dc.md
+++ b/docs/src/main/paradox/typed/cluster-dc.md
@@ -23,7 +23,7 @@ To use Akka Cluster add the following dependency in your project:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-cluster-typed_$scala.binary.version$
+  artifact=pekko-cluster-typed_$scala.binary.version$
   version=PekkoVersion
 }
 

--- a/docs/src/main/paradox/typed/coexisting.md
+++ b/docs/src/main/paradox/typed/coexisting.md
@@ -9,7 +9,7 @@ To use Akka Actor Typed, you must add the following dependency in your project:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-actor-typed_$scala.binary.version$
+  artifact=pekko-actor-typed_$scala.binary.version$
   version=PekkoVersion
 }
 

--- a/docs/src/main/paradox/typed/from-classic.md
+++ b/docs/src/main/paradox/typed/from-classic.md
@@ -30,7 +30,7 @@ For example `akka-cluster-typed`:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-cluster-typed_$scala.binary.version$
+  artifact=pekko-cluster-typed_$scala.binary.version$
   version=PekkoVersion
 }
 

--- a/docs/src/main/paradox/typed/guide/modules.md
+++ b/docs/src/main/paradox/typed/guide/modules.md
@@ -40,7 +40,7 @@ This page does not list all available modules, but overviews the main functional
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-actor-typed_$scala.binary.version$
+  artifact=pekko-actor-typed_$scala.binary.version$
   version=PekkoVersion
 }
 
@@ -68,7 +68,7 @@ Challenges that actors solve include the following:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-remote_$scala.binary.version$
+  artifact=pekko-remote_$scala.binary.version$
   version=PekkoVersion
 }
 
@@ -94,7 +94,7 @@ Challenges Remoting solves include the following:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-cluster-typed_$scala.binary.version$
+  artifact=pekko-cluster-typed_$scala.binary.version$
   version=PekkoVersion
 }
 
@@ -120,7 +120,7 @@ Challenges the Cluster module solves include the following:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-cluster-sharding-typed_$scala.binary.version$
+  artifact=pekko-cluster-sharding-typed_$scala.binary.version$
   version=PekkoVersion
 }
 
@@ -142,7 +142,7 @@ Challenges that Sharding solves include the following:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-cluster-singleton_$scala.binary.version$
+  artifact=pekko-cluster-singleton_$scala.binary.version$
   version=PekkoVersion
 }
 
@@ -166,7 +166,7 @@ The Singleton module can be used to solve these challenges:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-persistence-typed_$scala.binary.version$
+  artifact=pekko-persistence-typed_$scala.binary.version$
   version=PekkoVersion
 }
 
@@ -191,7 +191,7 @@ Persistence tackles the following challenges:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-projection-core_$scala.binary.version$
+  artifact=pekko-projection-core_$scala.binary.version$
   version=PekkoVersion
 }
 
@@ -211,7 +211,7 @@ Challenges Projections solve include the following:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-cluster-typed_$scala.binary.version$
+  artifact=pekko-cluster-typed_$scala.binary.version$
   version=PekkoVersion
 }
 
@@ -233,7 +233,7 @@ Distributed Data is intended to solve the following challenges:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-stream-typed_$scala.binary.version$
+  artifact=pekko-stream_$scala.binary.version$
   version=PekkoVersion
 }
 

--- a/docs/src/main/paradox/typed/interaction-patterns.md
+++ b/docs/src/main/paradox/typed/interaction-patterns.md
@@ -11,7 +11,7 @@ To use Akka Actor Typed, you must add the following dependency in your project:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-actor-typed_$scala.binary.version$
+  artifact=pekko-actor-typed_$scala.binary.version$
   version=PekkoVersion
 }
 

--- a/docs/src/main/paradox/typed/reliable-delivery.md
+++ b/docs/src/main/paradox/typed/reliable-delivery.md
@@ -22,7 +22,7 @@ To use reliable delivery, add the module to your project:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-actor-typed_$scala.binary.version$
+  artifact=pekko-actor-typed_$scala.binary.version$
   version=PekkoVersion
 }
 
@@ -259,7 +259,7 @@ To use reliable delivery with Cluster Sharding, add the following module to your
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-cluster-sharding-typed_$scala.binary.version$
+  artifact=pekko-cluster-sharding-typed_$scala.binary.version$
   version=PekkoVersion
 }
 
@@ -368,7 +368,7 @@ When using the `EventSourcedProducerQueue` the following dependency is needed:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-persistence-typed_$scala.binary.version$
+  artifact=pekko-persistence-typed_$scala.binary.version$
   version=PekkoVersion
 } 
 

--- a/docs/src/main/paradox/typed/routers.md
+++ b/docs/src/main/paradox/typed/routers.md
@@ -11,7 +11,7 @@ To use Akka Actor Typed, you must add the following dependency in your project:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-actor-typed_$scala.binary.version$
+  artifact=pekko-actor-typed_$scala.binary.version$
   version=PekkoVersion
 }
 

--- a/docs/src/main/paradox/typed/stash.md
+++ b/docs/src/main/paradox/typed/stash.md
@@ -11,7 +11,7 @@ To use Akka Actor Typed, you must add the following dependency in your project:
   symbol1=PekkoVersion
   value1="$pekko.version$"
   group=org.apache.pekko
-  artifact=akka-actor-typed_$scala.binary.version$
+  artifact=pekko-actor-typed_$scala.binary.version$
   version=PekkoVersion
 }
 


### PR DESCRIPTION
When looking at the docs I noticed that the `artifact` fields in `project-info` still had the `akka-` prefix.