### PR TITLE
Adds whitelist for custom serializer of classes in pekko package

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/serialization/SerializeSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/serialization/SerializeSpec.scala
@@ -55,7 +55,10 @@ object SerializationTests {
           "org.apache.pekko.serialization.SerializationTests$$D" = test
           "org.apache.pekko.serialization.SerializationTests$$Marker2" = test2
           "org.apache.pekko.serialization.SerializationTests$$AbstractOther" = other
+          "org.apache.pekko.serialization.SerializationTests$$AllowedOther" = other
         }
+
+        warn-non-pekko-serializer-allow-list += "org.apache.pekko.serialization.SerializationTests$$AllowedOther"
       }
     }
   """
@@ -98,6 +101,9 @@ object SerializationTests {
 
   final class Other extends AbstractOther {
     override def toString: String = "Other"
+  }
+  final class AllowedOther {
+    override def toString: String = "AllowedOther"
   }
 
   val verifySerializabilityConf = """
@@ -275,7 +281,7 @@ class SerializeSpec extends PekkoSpec(SerializationTests.serializeConf) {
         s"${classOf[ByteArraySerializer].getName} only serializes byte arrays, not [java.lang.String]")
     }
 
-    "log warning if non-Pekko serializer is configured for Pekko message" in {
+    "log warning if non-Pekko serializer is configured for Pekko message but not in allow list" in {
       EventFilter.warning(pattern = ".*not implemented by Apache Pekko.*", occurrences = 1).intercept {
         ser.serialize(new Other).get
       }

--- a/actor-tests/src/test/scala/org/apache/pekko/serialization/SerializeSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/serialization/SerializeSpec.scala
@@ -148,6 +148,7 @@ object SerializationTests {
       """)
       .withFallback(ConfigFactory.parseString(serializeConf))
       .withFallback(PekkoSpec.testConf.withFallback(referenceConf))
+      .resolve()
     ActorSystem("SerializationSystem", conf)
   }
 

--- a/actor/src/main/resources/reference.conf
+++ b/actor/src/main/resources/reference.conf
@@ -742,7 +742,7 @@ pekko {
     warn-on-no-serialization-verification = on
 
     # list of fqcn of classes that may use non-pekko serializer within pekko package without warn log
-    warn-non-pekko-serializer-whitelist = ${?akka.actor.warn-non-pekko-serializer-whitelist} []
+    warn-non-pekko-serializer-allow-list = ${?pekko.actor.warn-non-pekko-serializer-allow-list} []
 
     # Entries for pluggable serializers and their bindings.
     serializers {

--- a/actor/src/main/resources/reference.conf
+++ b/actor/src/main/resources/reference.conf
@@ -741,6 +741,9 @@ pekko {
     # to reduce noise.
     warn-on-no-serialization-verification = on
 
+    # list of fqcn of classes that may use non-pekko serializer within pekko package without warn log
+    warn-non-pekko-serializer-whitelist = ${?akka.actor.warn-non-pekko-serializer-whitelist} []
+
     # Entries for pluggable serializers and their bindings.
     serializers {
       java = "org.apache.pekko.serialization.JavaSerializer"

--- a/actor/src/main/resources/reference.conf
+++ b/actor/src/main/resources/reference.conf
@@ -741,7 +741,7 @@ pekko {
     # to reduce noise.
     warn-on-no-serialization-verification = on
 
-    # list of fqcn of classes that may use non-pekko serializer within pekko package without warn log
+    # list of fqcn of classes that may use non-pekko serializer within pekko package without warn log (added in Pekko 1.1.0)
     warn-non-pekko-serializer-allow-list = ${?pekko.actor.warn-non-pekko-serializer-allow-list} []
 
     # Entries for pluggable serializers and their bindings.

--- a/actor/src/main/scala/org/apache/pekko/serialization/Serialization.scala
+++ b/actor/src/main/scala/org/apache/pekko/serialization/Serialization.scala
@@ -464,7 +464,7 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
 
   @nowarn("msg=deprecated")
   private def warnUnexpectedNonPekkoSerializer(clazz: Class[_], ser: Serializer): Boolean = {
-    import scala.collection.JavaConverters._ // switch to scala.jdk.CollectionConverters once Scala 2.12 support is dropped
+    import pekko.util.ccompat.JavaConverters._
     if (clazz.getName.startsWith("org.apache.pekko.") && !ser.getClass.getName.startsWith("org.apache.pekko.") &&
       !system.settings.config.getStringList("pekko.actor.warn-non-pekko-serializer-allow-list").asScala.toSet.contains(
         clazz.getName)) {

--- a/actor/src/main/scala/org/apache/pekko/serialization/Serialization.scala
+++ b/actor/src/main/scala/org/apache/pekko/serialization/Serialization.scala
@@ -18,20 +18,17 @@ import java.nio.ByteBuffer
 import java.util.NoSuchElementException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
-
-import scala.annotation.tailrec
+import scala.annotation.{nowarn, tailrec}
 import scala.collection.immutable
 import scala.collection.mutable.ArrayBuffer
-import scala.util.{ DynamicVariable, Failure, Try }
+import scala.util.{DynamicVariable, Failure, Try}
 import scala.util.Success
 import scala.util.control.NonFatal
-
 import com.typesafe.config.Config
-
 import org.apache.pekko
 import pekko.actor._
 import pekko.annotation.InternalApi
-import pekko.event.{ LogMarker, Logging, LoggingAdapter }
+import pekko.event.{LogMarker, Logging, LoggingAdapter}
 import pekko.util.ccompat._
 
 @ccompatUsedUntil213
@@ -466,8 +463,12 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
     }
   }
 
+  @nowarn("msg=deprecated")
   private def warnUnexpectedNonPekkoSerializer(clazz: Class[_], ser: Serializer): Boolean = {
-    if (clazz.getName.startsWith("org.apache.pekko.") && !ser.getClass.getName.startsWith("org.apache.pekko.")) {
+    import scala.collection.JavaConverters._ // switch to scala.jdk.CollectionConverters once Scala 2.12 support is dropped
+    if (clazz.getName.startsWith("org.apache.pekko.") && !ser.getClass.getName.startsWith("org.apache.pekko.") &&
+      !system.settings.config.getStringList("pekko.actor.warn-non-pekko-serializer-whitelist").asScala.toSet.contains(
+        clazz.getName)) {
       log.warning(
         "Using serializer [{}] for message [{}]. Note that this serializer " +
         "is not implemented by Apache Pekko. It's not recommended to replace serializers for messages " +

--- a/actor/src/main/scala/org/apache/pekko/serialization/Serialization.scala
+++ b/actor/src/main/scala/org/apache/pekko/serialization/Serialization.scala
@@ -15,20 +15,19 @@ package org.apache.pekko.serialization
 
 import java.io.NotSerializableException
 import java.nio.ByteBuffer
-import java.util.NoSuchElementException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
-import scala.annotation.{nowarn, tailrec}
+import scala.annotation.{ nowarn, tailrec }
 import scala.collection.immutable
 import scala.collection.mutable.ArrayBuffer
-import scala.util.{DynamicVariable, Failure, Try}
+import scala.util.{ DynamicVariable, Failure, Try }
 import scala.util.Success
 import scala.util.control.NonFatal
 import com.typesafe.config.Config
 import org.apache.pekko
 import pekko.actor._
 import pekko.annotation.InternalApi
-import pekko.event.{LogMarker, Logging, LoggingAdapter}
+import pekko.event.{ LogMarker, Logging, LoggingAdapter }
 import pekko.util.ccompat._
 
 @ccompatUsedUntil213
@@ -467,7 +466,7 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
   private def warnUnexpectedNonPekkoSerializer(clazz: Class[_], ser: Serializer): Boolean = {
     import scala.collection.JavaConverters._ // switch to scala.jdk.CollectionConverters once Scala 2.12 support is dropped
     if (clazz.getName.startsWith("org.apache.pekko.") && !ser.getClass.getName.startsWith("org.apache.pekko.") &&
-      !system.settings.config.getStringList("pekko.actor.warn-non-pekko-serializer-whitelist").asScala.toSet.contains(
+      !system.settings.config.getStringList("pekko.actor.warn-non-pekko-serializer-allow-list").asScala.toSet.contains(
         clazz.getName)) {
       log.warning(
         "Using serializer [{}] for message [{}]. Note that this serializer " +


### PR DESCRIPTION
We implemented this in our internal Akka fork until we can migrate to Pekko.
The query view implementation need access to certain Actor internals and therefore has to reside within the akka/pekko package. As we want to use our persistence serializer for snapshots, this normally generates a warning which we want to ignore.