### PR TITLE
Publish nightly once a day

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -28,9 +28,6 @@ on:
         default: 30
   schedule:
     - cron: "0 0 * * *"
-  push:
-    branches:
-      - 'main'
 
 permissions:
   contents: read


### PR DESCRIPTION
I think this makes more sense otherwise snapshots will quickly become truncated or if we changed the eviction strategy to actually be time based we will end up with a lot of artifacts on nightly.