### PR TITLE
Fix 2.12 copyright headers and enable headerCheckAll for all Scala versions

### DIFF
--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -35,7 +35,7 @@ jobs:
           sbt \
           -Dsbt.override.build.repos=false \
           -Dsbt.log.noformat=false \
-          headerCheckAll
+          +headerCheckAll
 
   pull-request-validation:
     name: Check / Tests

--- a/actor-tests/src/test/scala-2.12/org/apache/pekko/util/LineNumberSpec.scala
+++ b/actor-tests/src/test/scala-2.12/org/apache/pekko/util/LineNumberSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2014-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/actor-tests/src/test/scala-2.12/org/apache/pekko/util/TypedMultiMapSpec.scala
+++ b/actor-tests/src/test/scala-2.12/org/apache/pekko/util/TypedMultiMapSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2015-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/actor-tests/src/test/scala-3/org/apache/pekko/util/LineNumberSpec.scala
+++ b/actor-tests/src/test/scala-3/org/apache/pekko/util/LineNumberSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2014-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/actor-typed/src/main/scala-2.12/org/apache/pekko/actor/typed/internal/receptionist/Platform.scala
+++ b/actor-typed/src/main/scala-2.12/org/apache/pekko/actor/typed/internal/receptionist/Platform.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/actor-typed/src/main/scala-3/org/apache/pekko/actor/typed/internal/receptionist/Platform.scala
+++ b/actor-typed/src/main/scala-3/org/apache/pekko/actor/typed/internal/receptionist/Platform.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/actor/src/main/scala-2.12/org/apache/pekko/compat/Future.scala
+++ b/actor/src/main/scala-2.12/org/apache/pekko/compat/Future.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/actor/src/main/scala-2.12/org/apache/pekko/compat/PartialFunction.scala
+++ b/actor/src/main/scala-2.12/org/apache/pekko/compat/PartialFunction.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/actor/src/main/scala-2.12/org/apache/pekko/dispatch/internal/SameThreadExecutionContext.scala
+++ b/actor/src/main/scala-2.12/org/apache/pekko/dispatch/internal/SameThreadExecutionContext.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/actor/src/main/scala-2.12/org/apache/pekko/dispatch/internal/ScalaBatchable.scala
+++ b/actor/src/main/scala-2.12/org/apache/pekko/dispatch/internal/ScalaBatchable.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/actor/src/main/scala-2.12/org/apache/pekko/util/ByteIterator.scala
+++ b/actor/src/main/scala-2.12/org/apache/pekko/util/ByteIterator.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/actor/src/main/scala-2.12/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala-2.12/org/apache/pekko/util/ByteString.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/actor/src/main/scala-2.12/org/apache/pekko/util/ccompat/CompatImpl.scala
+++ b/actor/src/main/scala-2.12/org/apache/pekko/util/ccompat/CompatImpl.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/actor/src/main/scala-2.12/org/apache/pekko/util/ccompat/ccompatUsedUntil213.scala
+++ b/actor/src/main/scala-2.12/org/apache/pekko/util/ccompat/ccompatUsedUntil213.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2019-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/actor/src/main/scala-2.12/org/apache/pekko/util/ccompat/package.scala
+++ b/actor/src/main/scala-2.12/org/apache/pekko/util/ccompat/package.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/actor/src/main/scala-3/org/apache/pekko/dispatch/internal/ScalaBatchable.scala
+++ b/actor/src/main/scala-3/org/apache/pekko/dispatch/internal/ScalaBatchable.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/actor/src/main/scala-3/org/apache/pekko/util/ByteIterator.scala
+++ b/actor/src/main/scala-3/org/apache/pekko/util/ByteIterator.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/actor/src/main/scala-3/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala-3/org/apache/pekko/util/ByteString.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/cluster-typed/src/main/scala-2.12/org/apache/pekko/cluster/typed/internal/receptionist/ClusterReceptionistProtocol.scala
+++ b/cluster-typed/src/main/scala-2.12/org/apache/pekko/cluster/typed/internal/receptionist/ClusterReceptionistProtocol.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2021-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/cluster-typed/src/main/scala-3/org/apache/pekko/cluster/typed/internal/receptionist/ClusterReceptionistProtocol.scala
+++ b/cluster-typed/src/main/scala-3/org/apache/pekko/cluster/typed/internal/receptionist/ClusterReceptionistProtocol.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2021-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/distributed-data/src/main/scala-3/org/apache/pekko/cluster/ddata/GSet.scala
+++ b/distributed-data/src/main/scala-3/org/apache/pekko/cluster/ddata/GSet.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/persistence/src/main/scala-3/org/apache/pekko/persistence/TraitOrder.scala
+++ b/persistence/src/main/scala-3/org/apache/pekko/persistence/TraitOrder.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2021-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 


### PR DESCRIPTION
As noticed in https://github.com/apache/incubator-pekko/issues/107#issuecomment-1400285147 `headerCreate` runs during `ci-release` and will change the workspace so that it is not clean. Consequently, the nightly build will create snapshots with timestamps (and might just fail for actual releases).