### PR TITLE
Properly set sonatype repo settings for publishTo

### DIFF
--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -16,18 +16,20 @@ package org.apache.pekko
 import sbt._
 import sbt.Keys._
 import com.lightbend.sbt.publishrsync.PublishRsyncPlugin.autoImport.publishRsyncHost
-import xerial.sbt.Sonatype.autoImport.sonatypeProfileName
+import xerial.sbt.Sonatype.autoImport._
 
 object Publish extends AutoPlugin {
 
   override def trigger = allRequirements
 
+  private val apacheBaseRepo = "repository.apache.org"
+
   override lazy val projectSettings = Seq(
-    publishTo := Some(pekkoPublishTo.value),
     publishRsyncHost := "akkarepo@gustav.akka.io",
     credentials ++= apacheNexusCredentials,
     organizationName := "Apache Software Foundation",
     organizationHomepage := Some(url("https://www.apache.org")),
+    sonatypeCredentialHost := apacheBaseRepo,
     sonatypeProfileName := "org.apache.pekko",
     startYear := Some(2022),
     developers := List(
@@ -39,17 +41,10 @@ object Publish extends AutoPlugin {
     publishMavenStyle := true,
     pomIncludeRepository := (_ => false))
 
-  private def pekkoPublishTo = Def.setting {
-    if (isSnapshot.value)
-      "apache-snapshots".at("https://repository.apache.org/content/repositories/snapshots")
-    else
-      Opts.resolver.sonatypeStaging
-  }
-
   private def apacheNexusCredentials: Seq[Credentials] =
     (sys.env.get("NEXUS_USER"), sys.env.get("NEXUS_PW")) match {
       case (Some(user), Some(password)) =>
-        Seq(Credentials("Apache Nexus Repository Manager", "repository.apache.org", user, password))
+        Seq(Credentials("Apache Nexus Repository Manager", apacheBaseRepo, user, password))
       case _ =>
         Seq.empty
     }


### PR DESCRIPTION
So I figured out the what was causing the publishing issues, it turns out that since sbt-ci-release was added into pekko, it overrode the settings defined in https://github.com/apache/incubator-pekko/blob/main/project/Publish.scala#L25-L56.

This is because sbt-ci-release depends on sbt-sonatype, which by default points to the OS sonatype public repo. This PR tries to set various sbt-sonatype settings so that sbt-ci-release ends up publishing to Apache's Nexus repo instead of sonatype, since they both use Nexus it should theoretically work however if it doesn't we may end up having to remove sbt-ci-release (because its hardcoded to use sbt-sonatype).

At least locally when I run `sbt show publishTo` it does appear the settings are now correctly working

```
pekko > show publishTo
[info] pki / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] actor-testkit-typed / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] coordination / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] cluster-sharding-typed / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] actor-typed / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] docs / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] actor-typed-tests / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] testkit / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] stream / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] multi-node-testkit / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] persistence-query / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] osgi / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] persistence-typed-tests / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] persistence-testkit / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] persistence / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] cluster-tools / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] remote-tests / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] protobuf-v3 / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] stream-tests-tck / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] protobuf / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] actor / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] discovery / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] bench-jmh / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] cluster-metrics / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] bill-of-materials / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] stream-tests / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] stream-testkit / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] remote / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] distributed-data / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] cluster / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] actor-tests / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] slf4j / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] cluster-typed / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] serialization-jackson / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] persistence-tck / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] stream-typed / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] persistence-shared / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] persistence-typed / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] cluster-sharding / publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
[info] publishTo
[info] 	Some(sonatype-snapshots: https://repository.apache.org/content/repositories/snapshots)
```