### PR TITLE
Rename name for Apache nexus repo to work with Sonatype

### DIFF
--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -44,7 +44,7 @@ object Publish extends AutoPlugin {
   private def apacheNexusCredentials: Seq[Credentials] =
     (sys.env.get("NEXUS_USER"), sys.env.get("NEXUS_PW")) match {
       case (Some(user), Some(password)) =>
-        Seq(Credentials("Apache Nexus Repository Manager", apacheBaseRepo, user, password))
+        Seq(Credentials("Sonatype Nexus Repository Manager", apacheBaseRepo, user, password))
       case _ =>
         Seq.empty
     }


### PR DESCRIPTION
Since our sonatype is having a bit of an identity crisis having to look like an Apache's nexus repo, I need to change the name of the credential, see

```
[warn] versionScheme setting is empty; set `ThisBuild / versionScheme := Some("early-semver")`, `Some("semver-spec")` or `Some("pvp")`
[warn] so tooling can use it for eviction errors etc - https://www.scala-sbt.org/1.x/docs/Publishing.html
[error] Unable to find credentials for [Sonatype Nexus Repository Manager @ repository.apache.org].
[error]   Is one of these realms misspelled for host [repository.apache.org]:
[error]   * Apache Nexus Repository Manager
```

from the last run at https://github.com/apache/incubator-pekko/actions/runs/4015355806/jobs/6896983341

Related to https://github.com/apache/incubator-pekko/issues/103