### PR TITLE
docs: Apache Pekko naming

### DIFF
--- a/docs/src/main/paradox/additional/deploying.md
+++ b/docs/src/main/paradox/additional/deploying.md
@@ -1,5 +1,5 @@
 ---
-project.description: How to deploy Pekko Cluster to Kubernetes and Docker.
+project.description: How to deploy Apache Pekko Cluster to Kubernetes and Docker.
 ---
 # Deploying
 

--- a/docs/src/main/paradox/additional/faq.md
+++ b/docs/src/main/paradox/additional/faq.md
@@ -1,6 +1,6 @@
 # Frequently Asked Questions
 
-## Pekko Project
+## Apache Pekko Project
 
 ### Where does the name Pekko come from?
 

--- a/docs/src/main/paradox/additional/operations.md
+++ b/docs/src/main/paradox/additional/operations.md
@@ -1,5 +1,5 @@
 ---
-project.description: Operating, managing and monitoring Pekko and Pekko Cluster applications.
+project.description: Operating, managing and monitoring Apache Pekko and Apache Pekko Cluster applications.
 ---
 # Operating a Cluster
 

--- a/docs/src/main/paradox/additional/osgi.md
+++ b/docs/src/main/paradox/additional/osgi.md
@@ -1,8 +1,8 @@
-# Pekko in OSGi
+# Apache Pekko in OSGi
 
 ## Dependency
 
-To use Pekko in OSGi, you must add the following dependency in your project:
+To use Apache Pekko in OSGi, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   bomGroup=org.apache.pekko bomArtifact=pekko-bom_$scala.binary.version$ bomVersionSymbols=PekkoVersion

--- a/docs/src/main/paradox/additional/packaging.md
+++ b/docs/src/main/paradox/additional/packaging.md
@@ -1,9 +1,9 @@
 ---
-project.description: How to package a Pekko application for deployment.
+project.description: How to package a Apache Pekko application for deployment.
 ---
 # Packaging
 
-The simplest way to use Pekko is as a regular library, adding the Pekko jars you
+The simplest way to use Apache Pekko is as a regular library, adding the Pekko jars you
 need to your classpath (in case of a web app, in `WEB-INF/lib`).
 
 In many cases, such as deploying to an analytics cluster, building your application into a single 'fat jar' is needed.

--- a/docs/src/main/paradox/additional/rolling-updates.md
+++ b/docs/src/main/paradox/additional/rolling-updates.md
@@ -1,5 +1,5 @@
 ---
-project.description: How to do rolling updates and restarts with Pekko Cluster.
+project.description: How to do rolling updates and restarts with Apache Pekko Cluster.
 ---
 # Rolling Updates
 
@@ -13,7 +13,7 @@ versus being able to do a rolling update.
 A rolling update is the process of replacing one version of the system with another without downtime.
 The changes can be new code, changed dependencies such as new Pekko version, or modified configuration.
 
-In Pekko, rolling updates are typically used for a stateful Pekko Cluster where you can't run two separate clusters in
+In Apache Pekko, rolling updates are typically used for a stateful Pekko Cluster where you can't run two separate clusters in
 parallel during the update, for example in blue green deployments.
 
 For rolling updates related to Pekko dependency version upgrades and the migration guides, please see

--- a/docs/src/main/paradox/cluster-client.md
+++ b/docs/src/main/paradox/cluster-client.md
@@ -225,7 +225,7 @@ are entirely dynamic and the entire cluster might shut down or crash, be restart
 client will be stopped in that case a monitoring actor can watch it and upon `Terminate` a new set of initial
 contacts can be fetched and a new cluster client started.
 
-## Migration to Pekko gRPC
+## Migration to Apache Pekko gRPC
 
 Cluster Client is deprecated and it is not advised to build new applications with it.
 As a replacement, we recommend using [Pekko gRPC]($pekko.doc.dns$/docs/pekko-grpc/current/)

--- a/docs/src/main/paradox/common/binary-compatibility-rules.md
+++ b/docs/src/main/paradox/common/binary-compatibility-rules.md
@@ -1,9 +1,9 @@
 ---
-project.description: Binary compatibility across Pekko versions.
+project.description: Binary compatibility across Apache Pekko versions.
 ---
 # Binary Compatibility Rules
 
-Pekko maintains and verifies *backwards binary compatibility* across versions of modules.
+Apache Pekko maintains and verifies *backwards binary compatibility* across versions of modules.
 
 In the rest of this document whenever *binary compatibility* is mentioned "*backwards binary compatibility*" is meant
 (as opposed to forward compatibility).

--- a/docs/src/main/paradox/common/circuitbreaker.md
+++ b/docs/src/main/paradox/common/circuitbreaker.md
@@ -24,7 +24,7 @@ resource exhaustion.  Circuit breakers can also allow savvy developers to mark p
 the site that use the functionality unavailable, or perhaps show some cached content as 
 appropriate while the breaker is open.
 
-The Pekko library provides an implementation of a circuit breaker called 
+The Apache Pekko library provides an implementation of a circuit breaker called 
 @apidoc[CircuitBreaker] which has the behavior described below.
 
 ## What do they do?

--- a/docs/src/main/paradox/common/io-layer.md
+++ b/docs/src/main/paradox/common/io-layer.md
@@ -1,14 +1,14 @@
 # I/O Layer Design
 
-The `org.apache.pekko.io` package has been developed in collaboration between the Pekko
-and [spray.io](http://spray.io) teams. Its design incorporates the experiences with the
+The `org.apache.pekko.io` package design incorporates the experiences with the
 `spray-io` module along with improvements that were jointly developed for
-more general consumption as an actor-based service.
+more general consumption as an actor-based service. [Spray](http://spray.io/) has been
+deprecated in favour of Akka HTTP and Apache Pekko HTTP.
 
 ## Requirements
 
 In order to form a general and extensible IO layer basis for a wide range of
-applications, with Pekko remoting and spray HTTP being the initial ones, the
+applications, with Apache Pekko remoting and Spray HTTP being the initial ones, the
 following requirements were established as key drivers for the design:
 
  * scalability to millions of concurrent connections

--- a/docs/src/main/paradox/common/may-change.md
+++ b/docs/src/main/paradox/common/may-change.md
@@ -8,7 +8,7 @@ Concretely **may change** means that an API or module is in early access mode an
 
  * is not guaranteed to be binary compatible in minor releases
  * may have its API change in breaking ways in minor releases
- * may be entirely dropped from Pekko in a minor release
+ * may be entirely dropped from Apache Pekko in a minor release
 
 Complete modules can be marked as **may change**, which will be stated in the module's description and in the docs.
 

--- a/docs/src/main/paradox/common/other-modules.md
+++ b/docs/src/main/paradox/common/other-modules.md
@@ -1,4 +1,4 @@
-# Other Pekko modules
+# Other Apache Pekko modules
 
 This page describes modules that compliment libraries from the Pekko core.  See [this overview]($pekko.doc.dns$/docs/pekko/current/typed/guide/modules.html) instead for a guide on the core modules.
 
@@ -42,7 +42,7 @@ A Pekko Persistence journal and snapshot store for use with R2DBC-compatible dat
 Use [Google Cloud Spanner](https://cloud.google.com/spanner/) as Pekko Persistence journal and snapshot store. This integration relies on [Pekko gRPC]($pekko.doc.dns$/docs/pekko-grpc/current/).
 
 
-## Pekko Management
+## Apache Pekko Management
 
 * [Pekko Management]($pekko.doc.dns$/docs/pekko-management/current/) provides a central HTTP endpoint for Pekko management extensions.
 * [Pekko Cluster Bootstrap]($pekko.doc.dns$/docs/pekko-management/current/bootstrap/) helps bootstrapping a Pekko cluster using Pekko Discovery.

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -1,4 +1,4 @@
-# Pekko Documentation
+# Apache Pekko Documentation
 
 @@toc { depth=2 }
 

--- a/docs/src/main/paradox/typed/extending.md
+++ b/docs/src/main/paradox/typed/extending.md
@@ -1,6 +1,6 @@
-# Extending Pekko
+# Extending Apache Pekko
 
-Pekko extensions can be used for almost anything, they provide a way to create
+Apache Pekko extensions can be used for almost anything, they provide a way to create
 an instance of a class only once for the whole ActorSystem and be able to access
 it from anywhere. Pekko features such as Cluster, Serialization and Sharding are all
 Pekko extensions. Below is the use-case of managing an expensive database connection 

--- a/docs/src/main/paradox/typed/guide/introduction.md
+++ b/docs/src/main/paradox/typed/guide/introduction.md
@@ -1,6 +1,6 @@
-# Introduction to Pekko
+# Introduction to Apache Pekko
 
-Welcome to Pekko, a set of open-source libraries for designing scalable, resilient systems that span processor cores and networks. Pekko allows you to focus on meeting business needs instead of writing low-level code to provide reliable behavior, fault tolerance, and high performance.
+Welcome to Apache Pekko, a set of open-source libraries for designing scalable, resilient systems that span processor cores and networks. Pekko allows you to focus on meeting business needs instead of writing low-level code to provide reliable behavior, fault tolerance, and high performance.
 
 Many common practices and accepted programming models do not address important challenges
 inherent in designing systems for modern computer architectures. To be

--- a/docs/src/main/paradox/typed/guide/modules.md
+++ b/docs/src/main/paradox/typed/guide/modules.md
@@ -1,4 +1,4 @@
-# Overview of Pekko libraries and modules
+# Overview of Apache Pekko libraries and modules
 
 Before delving into some best practices for writing actors, it will be helpful to preview the most commonly used Pekko libraries. This will help you start thinking about the functionality you want to use in your system. All core Pekko functionality is available as Open Source Software (OSS).
 
@@ -13,10 +13,10 @@ The following capabilities are included with Pekko OSS and are introduced later 
 * @ref:[Projections](#projections)
 * @ref:[Distributed Data](#distributed-data)
 * @ref:[Streams](#streams)
-* @ref:[Pekko Connectors](#pekko-connectors)
+* @ref:[Apache Pekko Connectors](#pekko-connectors)
 * @ref:[HTTP](#http)
 * @ref:[gRPC](#grpc)
-* [Other Pekko modules]($pekko.doc.dns$/docs/pekko/current/common/other-modules.html)
+* [Other Apache Pekko modules]($pekko.doc.dns$/docs/pekko/current/common/other-modules.html)
 
 This page does not list all available modules, but overviews the main functionality and gives you an idea of the level of sophistication you can reach when you start building systems on top of Pekko.
 


### PR DESCRIPTION
We're going to have to go through docs page by page to decide when it's necessary to use 'Apache Pekko' as opposed to `Pekko`.

We should probably always start a page by referring to 'Apache Pekko' but later in the page, we might start shortening it to Pekko.

Current docs on https://pekko.apache.org highlight that we don't use 'Apache Pekko' enough.

This PR focuses on a few very visible instances that affect the table of contents.