### PR TITLE
diffs when running scalafmtAll

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/event/japi/EventBusJavaAPI.scala
+++ b/actor/src/main/scala/org/apache/pekko/event/japi/EventBusJavaAPI.scala
@@ -202,7 +202,7 @@ abstract class ScanningEventBus[E, S, C] extends EventBus[E, S, C] {
  */
 abstract class ManagedActorEventBus[E](system: ActorSystem) extends EventBus[E, ActorRef, ActorRef] {
   private val bus = new pekko.event.ActorEventBus with pekko.event.ManagedActorClassification
-  with pekko.event.ActorClassifier {
+    with pekko.event.ActorClassifier {
     type Event = E
 
     override val system = ManagedActorEventBus.this.system

--- a/docs/src/test/scala/docs/actor/SharedMutableStateDocSpec.scala
+++ b/docs/src/test/scala/docs/actor/SharedMutableStateDocSpec.scala
@@ -61,7 +61,7 @@ class SharedMutableStateDocSpec {
         // Very bad: shared mutable state will cause your
         // application to break in weird ways
         Future { state = "This will race" }
-        ((echoActor ? Message("With this other one")).mapTo[Message]).foreach { received =>
+        (echoActor ? Message("With this other one")).mapTo[Message].foreach { received =>
           state = received.msg
         }
 

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/RollingEventLogSimulationSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/RollingEventLogSimulationSpec.scala
@@ -110,7 +110,7 @@ class RollingEventLogSimulationSpec extends PekkoSpec {
 
     val instructions: Array[Instruction] =
       (Array(AdvanceHeader, TryMarkDirty) :+
-      WriteId) ++
+        WriteId) ++
       Array.fill(EntrySize - 2)(WriteByte) :+
       Commit
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphUnzipWithSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphUnzipWithSpec.scala
@@ -288,7 +288,7 @@ class GraphUnzipWithSpec extends StreamSpec("""
 
       RunnableGraph
         .fromGraph(GraphDSL.create() { implicit b =>
-          val split22 = (a: (List[Int])) =>
+          val split22 = (a: List[Int]) =>
             (
               a(0),
               a(0).toString,


### PR DESCRIPTION
I ran `sbt scalafmtAll javafmtAll scalafmtSbt` and got these diffs

Just thought it best to do a dedicated PR instead of having these appear in PR dedicated to fixing a particular issue (but that also needs scalafmt to be run - thus accidentally adding these unrelated diffs).