### PR TITLE
fix binary protobuf descriptor data

### DIFF
--- a/cluster-sharding-typed/src/main/java/org/apache/pekko/cluster/sharding/typed/internal/protobuf/ShardingMessages.java
+++ b/cluster-sharding-typed/src/main/java/org/apache/pekko/cluster/sharding/typed/internal/protobuf/ShardingMessages.java
@@ -150,13 +150,13 @@ public final class ShardingMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_akka_cluster_sharding_typed_ShardingEnvelope_descriptor;
+      return org.apache.pekko.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_org_apache_pekko_cluster_sharding_typed_ShardingEnvelope_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_akka_cluster_sharding_typed_ShardingEnvelope_fieldAccessorTable
+      return org.apache.pekko.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_org_apache_pekko_cluster_sharding_typed_ShardingEnvelope_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.sharding.typed.internal.protobuf.ShardingMessages.ShardingEnvelope.class, org.apache.pekko.cluster.sharding.typed.internal.protobuf.ShardingMessages.ShardingEnvelope.Builder.class);
     }
@@ -426,13 +426,13 @@ public final class ShardingMessages {
         org.apache.pekko.cluster.sharding.typed.internal.protobuf.ShardingMessages.ShardingEnvelopeOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_akka_cluster_sharding_typed_ShardingEnvelope_descriptor;
+        return org.apache.pekko.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_org_apache_pekko_cluster_sharding_typed_ShardingEnvelope_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_akka_cluster_sharding_typed_ShardingEnvelope_fieldAccessorTable
+        return org.apache.pekko.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_org_apache_pekko_cluster_sharding_typed_ShardingEnvelope_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.sharding.typed.internal.protobuf.ShardingMessages.ShardingEnvelope.class, org.apache.pekko.cluster.sharding.typed.internal.protobuf.ShardingMessages.ShardingEnvelope.Builder.class);
       }
@@ -470,7 +470,7 @@ public final class ShardingMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_akka_cluster_sharding_typed_ShardingEnvelope_descriptor;
+        return org.apache.pekko.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_org_apache_pekko_cluster_sharding_typed_ShardingEnvelope_descriptor;
       }
 
       @java.lang.Override
@@ -857,10 +857,10 @@ public final class ShardingMessages {
   }
 
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_sharding_typed_ShardingEnvelope_descriptor;
+    internal_static_org_apache_pekko_cluster_sharding_typed_ShardingEnvelope_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_sharding_typed_ShardingEnvelope_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_sharding_typed_ShardingEnvelope_fieldAccessorTable;
 
   public static org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor
       getDescriptor() {
@@ -870,22 +870,23 @@ public final class ShardingMessages {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\026ShardingMessages.proto\022\033org.apache.pekko.cluster.s" +
-      "harding.typed\032\026ContainerFormats.proto\"?\n" +
-      "\020ShardingEnvelope\022\020\n\010entityId\030\001 \002(\t\022\031\n\007m" +
-      "essage\030\002 \002(\0132\010.PayloadB1\n-org.apache.pekko.cluster.s" +
-      "harding.typed.internal.protobufH\001"
+      "\n\026ShardingMessages.proto\022\'org.apache.pek" +
+      "ko.cluster.sharding.typed\032\026ContainerForm" +
+      "ats.proto\"?\n\020ShardingEnvelope\022\020\n\010entityI" +
+      "d\030\001 \002(\t\022\031\n\007message\030\002 \002(\0132\010.PayloadB=\n9or" +
+      "g.apache.pekko.cluster.sharding.typed.in" +
+      "ternal.protobufH\001"
     };
     descriptor = org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor[] {
           org.apache.pekko.remote.ContainerFormats.getDescriptor(),
         });
-    internal_static_akka_cluster_sharding_typed_ShardingEnvelope_descriptor =
+    internal_static_org_apache_pekko_cluster_sharding_typed_ShardingEnvelope_descriptor =
       getDescriptor().getMessageTypes().get(0);
-    internal_static_akka_cluster_sharding_typed_ShardingEnvelope_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_sharding_typed_ShardingEnvelope_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_sharding_typed_ShardingEnvelope_descriptor,
+        internal_static_org_apache_pekko_cluster_sharding_typed_ShardingEnvelope_descriptor,
         new java.lang.String[] { "EntityId", "Message", });
     org.apache.pekko.remote.ContainerFormats.getDescriptor();
   }

--- a/cluster-sharding/src/main/java/org/apache/pekko/cluster/sharding/protobuf/msg/ClusterShardingMessages.java
+++ b/cluster-sharding/src/main/java/org/apache/pekko/cluster/sharding/protobuf/msg/ClusterShardingMessages.java
@@ -21339,8 +21339,8 @@ public final class ClusterShardingMessages {
       "ntityIds\030\002 \003(\t\"F\n\027CurrentShardRegionStat" +
       "e\022\033\n\006shards\030\001 \003(\0132\013.ShardState\022\016\n\006failed" +
       "\030\002 \003(\t\"7\n\024RememberedShardState\022\017\n\007shardI" +
-      "d\030\001 \003(\t\022\016\n\006marker\030\002 \001(\010B&\n\"org.apache.pekko.cluster." +
-      "sharding.protobuf.msgH\001"
+      "d\030\001 \003(\t\022\016\n\006marker\030\002 \001(\010B2\n.org.apache.pe" +
+      "kko.cluster.sharding.protobuf.msgH\001"
     };
     descriptor = org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/cluster-typed/src/main/java/org/apache/pekko/cluster/typed/internal/protobuf/ClusterMessages.java
+++ b/cluster-typed/src/main/java/org/apache/pekko/cluster/typed/internal/protobuf/ClusterMessages.java
@@ -154,13 +154,13 @@ public final class ClusterMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.internal_static_akka_cluster_typed_ReceptionistEntry_descriptor;
+      return org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.internal_static_org_apache_pekko_cluster_typed_ReceptionistEntry_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.internal_static_akka_cluster_typed_ReceptionistEntry_fieldAccessorTable
+      return org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.internal_static_org_apache_pekko_cluster_typed_ReceptionistEntry_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.ReceptionistEntry.class, org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.ReceptionistEntry.Builder.class);
     }
@@ -455,13 +455,13 @@ public final class ClusterMessages {
         org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.ReceptionistEntryOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.internal_static_akka_cluster_typed_ReceptionistEntry_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.internal_static_org_apache_pekko_cluster_typed_ReceptionistEntry_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.internal_static_akka_cluster_typed_ReceptionistEntry_fieldAccessorTable
+        return org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.internal_static_org_apache_pekko_cluster_typed_ReceptionistEntry_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.ReceptionistEntry.class, org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.ReceptionistEntry.Builder.class);
       }
@@ -496,7 +496,7 @@ public final class ClusterMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.internal_static_akka_cluster_typed_ReceptionistEntry_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.internal_static_org_apache_pekko_cluster_typed_ReceptionistEntry_descriptor;
       }
 
       @java.lang.Override
@@ -935,13 +935,13 @@ public final class ClusterMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.internal_static_akka_cluster_typed_PubSubMessagePublished_descriptor;
+      return org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.internal_static_org_apache_pekko_cluster_typed_PubSubMessagePublished_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.internal_static_akka_cluster_typed_PubSubMessagePublished_fieldAccessorTable
+      return org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.internal_static_org_apache_pekko_cluster_typed_PubSubMessagePublished_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.PubSubMessagePublished.class, org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.PubSubMessagePublished.Builder.class);
     }
@@ -1147,13 +1147,13 @@ public final class ClusterMessages {
         org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.PubSubMessagePublishedOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.internal_static_akka_cluster_typed_PubSubMessagePublished_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.internal_static_org_apache_pekko_cluster_typed_PubSubMessagePublished_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.internal_static_akka_cluster_typed_PubSubMessagePublished_fieldAccessorTable
+        return org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.internal_static_org_apache_pekko_cluster_typed_PubSubMessagePublished_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.PubSubMessagePublished.class, org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.PubSubMessagePublished.Builder.class);
       }
@@ -1189,7 +1189,7 @@ public final class ClusterMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.internal_static_akka_cluster_typed_PubSubMessagePublished_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ClusterMessages.internal_static_org_apache_pekko_cluster_typed_PubSubMessagePublished_descriptor;
       }
 
       @java.lang.Override
@@ -1480,15 +1480,15 @@ public final class ClusterMessages {
   }
 
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_typed_ReceptionistEntry_descriptor;
+    internal_static_org_apache_pekko_cluster_typed_ReceptionistEntry_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_typed_ReceptionistEntry_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_typed_ReceptionistEntry_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_typed_PubSubMessagePublished_descriptor;
+    internal_static_org_apache_pekko_cluster_typed_PubSubMessagePublished_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_typed_PubSubMessagePublished_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_typed_PubSubMessagePublished_fieldAccessorTable;
 
   public static org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor
       getDescriptor() {
@@ -1498,30 +1498,30 @@ public final class ClusterMessages {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\025ClusterMessages.proto\022\022org.apache.pekko.cluster.ty" +
-      "ped\032\026ContainerFormats.proto\"R\n\021Reception" +
-      "istEntry\022\020\n\010actorRef\030\001 \002(\t\022\021\n\tsystemUid\030" +
-      "\002 \002(\004\022\030\n\020createdTimestamp\030\003 \001(\003\"3\n\026PubSu" +
-      "bMessagePublished\022\031\n\007message\030\001 \002(\0132\010.Pay" +
-      "loadB(\n$org.apache.pekko.cluster.typed.internal.prot" +
-      "obufH\001"
+      "\n\025ClusterMessages.proto\022\036org.apache.pekk" +
+      "o.cluster.typed\032\026ContainerFormats.proto\"" +
+      "R\n\021ReceptionistEntry\022\020\n\010actorRef\030\001 \002(\t\022\021" +
+      "\n\tsystemUid\030\002 \002(\004\022\030\n\020createdTimestamp\030\003 " +
+      "\001(\003\"3\n\026PubSubMessagePublished\022\031\n\007message" +
+      "\030\001 \002(\0132\010.PayloadB4\n0org.apache.pekko.clu" +
+      "ster.typed.internal.protobufH\001"
     };
     descriptor = org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor[] {
           org.apache.pekko.remote.ContainerFormats.getDescriptor(),
         });
-    internal_static_akka_cluster_typed_ReceptionistEntry_descriptor =
+    internal_static_org_apache_pekko_cluster_typed_ReceptionistEntry_descriptor =
       getDescriptor().getMessageTypes().get(0);
-    internal_static_akka_cluster_typed_ReceptionistEntry_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_typed_ReceptionistEntry_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_typed_ReceptionistEntry_descriptor,
+        internal_static_org_apache_pekko_cluster_typed_ReceptionistEntry_descriptor,
         new java.lang.String[] { "ActorRef", "SystemUid", "CreatedTimestamp", });
-    internal_static_akka_cluster_typed_PubSubMessagePublished_descriptor =
+    internal_static_org_apache_pekko_cluster_typed_PubSubMessagePublished_descriptor =
       getDescriptor().getMessageTypes().get(1);
-    internal_static_akka_cluster_typed_PubSubMessagePublished_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_typed_PubSubMessagePublished_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_typed_PubSubMessagePublished_descriptor,
+        internal_static_org_apache_pekko_cluster_typed_PubSubMessagePublished_descriptor,
         new java.lang.String[] { "Message", });
     org.apache.pekko.remote.ContainerFormats.getDescriptor();
   }

--- a/cluster-typed/src/main/java/org/apache/pekko/cluster/typed/internal/protobuf/ReliableDelivery.java
+++ b/cluster-typed/src/main/java/org/apache/pekko/cluster/typed/internal/protobuf/ReliableDelivery.java
@@ -258,13 +258,13 @@ public final class ReliableDelivery {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_SequencedMessage_descriptor;
+      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_SequencedMessage_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_SequencedMessage_fieldAccessorTable
+      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_SequencedMessage_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.SequencedMessage.class, org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.SequencedMessage.Builder.class);
     }
@@ -784,13 +784,13 @@ public final class ReliableDelivery {
         org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.SequencedMessageOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_SequencedMessage_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_SequencedMessage_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_SequencedMessage_fieldAccessorTable
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_SequencedMessage_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.SequencedMessage.class, org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.SequencedMessage.Builder.class);
       }
@@ -840,7 +840,7 @@ public final class ReliableDelivery {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_SequencedMessage_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_SequencedMessage_descriptor;
       }
 
       @java.lang.Override
@@ -1650,13 +1650,13 @@ public final class ReliableDelivery {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_RegisterConsumer_descriptor;
+      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_RegisterConsumer_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_RegisterConsumer_fieldAccessorTable
+      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_RegisterConsumer_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.RegisterConsumer.class, org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.RegisterConsumer.Builder.class);
     }
@@ -1883,13 +1883,13 @@ public final class ReliableDelivery {
         org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.RegisterConsumerOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_RegisterConsumer_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_RegisterConsumer_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_RegisterConsumer_fieldAccessorTable
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_RegisterConsumer_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.RegisterConsumer.class, org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.RegisterConsumer.Builder.class);
       }
@@ -1920,7 +1920,7 @@ public final class ReliableDelivery {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_RegisterConsumer_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_RegisterConsumer_descriptor;
       }
 
       @java.lang.Override
@@ -2308,13 +2308,13 @@ public final class ReliableDelivery {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Request_descriptor;
+      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Request_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Request_fieldAccessorTable
+      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Request_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.Request.class, org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.Request.Builder.class);
     }
@@ -2629,13 +2629,13 @@ public final class ReliableDelivery {
         org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.RequestOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Request_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Request_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Request_fieldAccessorTable
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Request_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.Request.class, org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.Request.Builder.class);
       }
@@ -2672,7 +2672,7 @@ public final class ReliableDelivery {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Request_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Request_descriptor;
       }
 
       @java.lang.Override
@@ -3104,13 +3104,13 @@ public final class ReliableDelivery {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Resend_descriptor;
+      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Resend_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Resend_fieldAccessorTable
+      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Resend_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.Resend.class, org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.Resend.Builder.class);
     }
@@ -3311,13 +3311,13 @@ public final class ReliableDelivery {
         org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.ResendOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Resend_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Resend_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Resend_fieldAccessorTable
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Resend_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.Resend.class, org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.Resend.Builder.class);
       }
@@ -3348,7 +3348,7 @@ public final class ReliableDelivery {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Resend_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Resend_descriptor;
       }
 
       @java.lang.Override
@@ -3639,13 +3639,13 @@ public final class ReliableDelivery {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Ack_descriptor;
+      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Ack_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Ack_fieldAccessorTable
+      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Ack_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.Ack.class, org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.Ack.Builder.class);
     }
@@ -3846,13 +3846,13 @@ public final class ReliableDelivery {
         org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.AckOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Ack_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Ack_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Ack_fieldAccessorTable
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Ack_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.Ack.class, org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.Ack.Builder.class);
       }
@@ -3883,7 +3883,7 @@ public final class ReliableDelivery {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Ack_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Ack_descriptor;
       }
 
       @java.lang.Override
@@ -4264,13 +4264,13 @@ public final class ReliableDelivery {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_State_descriptor;
+      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_State_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_State_fieldAccessorTable
+      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_State_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.State.class, org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.State.Builder.class);
     }
@@ -4617,13 +4617,13 @@ public final class ReliableDelivery {
         org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.StateOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_State_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_State_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_State_fieldAccessorTable
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_State_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.State.class, org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.State.Builder.class);
       }
@@ -4670,7 +4670,7 @@ public final class ReliableDelivery {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_State_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_State_descriptor;
       }
 
       @java.lang.Override
@@ -5608,13 +5608,13 @@ public final class ReliableDelivery {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Confirmed_descriptor;
+      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Confirmed_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Confirmed_fieldAccessorTable
+      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Confirmed_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.Confirmed.class, org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.Confirmed.Builder.class);
     }
@@ -5917,13 +5917,13 @@ public final class ReliableDelivery {
         org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.ConfirmedOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Confirmed_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Confirmed_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Confirmed_fieldAccessorTable
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Confirmed_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.Confirmed.class, org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.Confirmed.Builder.class);
       }
@@ -5958,7 +5958,7 @@ public final class ReliableDelivery {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Confirmed_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Confirmed_descriptor;
       }
 
       @java.lang.Override
@@ -6508,13 +6508,13 @@ public final class ReliableDelivery {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_MessageSent_descriptor;
+      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_MessageSent_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_MessageSent_fieldAccessorTable
+      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_MessageSent_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.MessageSent.class, org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.MessageSent.Builder.class);
     }
@@ -6970,13 +6970,13 @@ public final class ReliableDelivery {
         org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.MessageSentOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_MessageSent_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_MessageSent_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_MessageSent_fieldAccessorTable
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_MessageSent_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.MessageSent.class, org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.MessageSent.Builder.class);
       }
@@ -7024,7 +7024,7 @@ public final class ReliableDelivery {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_MessageSent_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_MessageSent_descriptor;
       }
 
       @java.lang.Override
@@ -7752,13 +7752,13 @@ public final class ReliableDelivery {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Cleanup_descriptor;
+      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Cleanup_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Cleanup_fieldAccessorTable
+      return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Cleanup_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.Cleanup.class, org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.Cleanup.Builder.class);
     }
@@ -7972,13 +7972,13 @@ public final class ReliableDelivery {
         org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.CleanupOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Cleanup_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Cleanup_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Cleanup_fieldAccessorTable
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Cleanup_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.Cleanup.class, org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.Cleanup.Builder.class);
       }
@@ -8009,7 +8009,7 @@ public final class ReliableDelivery {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Cleanup_descriptor;
+        return org.apache.pekko.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_org_apache_pekko_cluster_typed_delivery_Cleanup_descriptor;
       }
 
       @java.lang.Override
@@ -8285,50 +8285,50 @@ public final class ReliableDelivery {
   }
 
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_typed_delivery_SequencedMessage_descriptor;
+    internal_static_org_apache_pekko_cluster_typed_delivery_SequencedMessage_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_typed_delivery_SequencedMessage_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_typed_delivery_SequencedMessage_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_typed_delivery_RegisterConsumer_descriptor;
+    internal_static_org_apache_pekko_cluster_typed_delivery_RegisterConsumer_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_typed_delivery_RegisterConsumer_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_typed_delivery_RegisterConsumer_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_typed_delivery_Request_descriptor;
+    internal_static_org_apache_pekko_cluster_typed_delivery_Request_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_typed_delivery_Request_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_typed_delivery_Request_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_typed_delivery_Resend_descriptor;
+    internal_static_org_apache_pekko_cluster_typed_delivery_Resend_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_typed_delivery_Resend_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_typed_delivery_Resend_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_typed_delivery_Ack_descriptor;
+    internal_static_org_apache_pekko_cluster_typed_delivery_Ack_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_typed_delivery_Ack_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_typed_delivery_Ack_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_typed_delivery_State_descriptor;
+    internal_static_org_apache_pekko_cluster_typed_delivery_State_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_typed_delivery_State_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_typed_delivery_State_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_typed_delivery_Confirmed_descriptor;
+    internal_static_org_apache_pekko_cluster_typed_delivery_Confirmed_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_typed_delivery_Confirmed_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_typed_delivery_Confirmed_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_typed_delivery_MessageSent_descriptor;
+    internal_static_org_apache_pekko_cluster_typed_delivery_MessageSent_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_typed_delivery_MessageSent_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_typed_delivery_MessageSent_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_typed_delivery_Cleanup_descriptor;
+    internal_static_org_apache_pekko_cluster_typed_delivery_Cleanup_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_typed_delivery_Cleanup_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_typed_delivery_Cleanup_fieldAccessorTable;
 
   public static org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor
       getDescriptor() {
@@ -8338,89 +8338,90 @@ public final class ReliableDelivery {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\026ReliableDelivery.proto\022\033org.apache.pekko.cluster.t" +
-      "yped.delivery\032\026ContainerFormats.proto\"\262\001" +
-      "\n\020SequencedMessage\022\022\n\nproducerId\030\001 \002(\t\022\r" +
-      "\n\005seqNr\030\002 \002(\003\022\r\n\005first\030\003 \002(\010\022\013\n\003ack\030\004 \002(" +
-      "\010\022\035\n\025producerControllerRef\030\005 \002(\t\022\031\n\007mess" +
-      "age\030\006 \002(\0132\010.Payload\022\022\n\nfirstChunk\030\007 \001(\010\022" +
-      "\021\n\tlastChunk\030\010 \001(\010\"1\n\020RegisterConsumer\022\035" +
-      "\n\025consumerControllerRef\030\001 \002(\t\"f\n\007Request" +
-      "\022\026\n\016confirmedSeqNr\030\001 \002(\003\022\030\n\020requestUpToS" +
-      "eqNr\030\002 \002(\003\022\025\n\rsupportResend\030\003 \002(\010\022\022\n\nvia" +
-      "Timeout\030\004 \002(\010\"\033\n\006Resend\022\021\n\tfromSeqNr\030\001 \002" +
-      "(\003\"\035\n\003Ack\022\026\n\016confirmedSeqNr\030\001 \002(\003\"\266\001\n\005St" +
-      "ate\022\024\n\014currentSeqNr\030\001 \002(\003\022\035\n\025highestConf" +
-      "irmedSeqNr\030\002 \002(\003\0229\n\tconfirmed\030\003 \003(\0132&.ak" +
-      "ka.cluster.typed.delivery.Confirmed\022=\n\013u" +
-      "nconfirmed\030\004 \003(\0132(.org.apache.pekko.cluster.typed.de" +
-      "livery.MessageSent\"@\n\tConfirmed\022\r\n\005seqNr" +
-      "\030\001 \002(\003\022\021\n\tqualifier\030\002 \002(\t\022\021\n\ttimestamp\030\003" +
-      " \002(\003\"\221\001\n\013MessageSent\022\r\n\005seqNr\030\001 \002(\003\022\021\n\tq" +
-      "ualifier\030\002 \002(\t\022\013\n\003ack\030\003 \002(\010\022\021\n\ttimestamp" +
-      "\030\004 \002(\003\022\031\n\007message\030\005 \002(\0132\010.Payload\022\022\n\nfir" +
-      "stChunk\030\006 \001(\010\022\021\n\tlastChunk\030\007 \001(\010\"\035\n\007Clea" +
-      "nup\022\022\n\nqualifiers\030\001 \003(\tB(\n$org.apache.pekko.cluster." +
-      "typed.internal.protobufH\001"
+      "\n\026ReliableDelivery.proto\022\'org.apache.pek" +
+      "ko.cluster.typed.delivery\032\026ContainerForm" +
+      "ats.proto\"\262\001\n\020SequencedMessage\022\022\n\nproduc" +
+      "erId\030\001 \002(\t\022\r\n\005seqNr\030\002 \002(\003\022\r\n\005first\030\003 \002(\010" +
+      "\022\013\n\003ack\030\004 \002(\010\022\035\n\025producerControllerRef\030\005" +
+      " \002(\t\022\031\n\007message\030\006 \002(\0132\010.Payload\022\022\n\nfirst" +
+      "Chunk\030\007 \001(\010\022\021\n\tlastChunk\030\010 \001(\010\"1\n\020Regist" +
+      "erConsumer\022\035\n\025consumerControllerRef\030\001 \002(" +
+      "\t\"f\n\007Request\022\026\n\016confirmedSeqNr\030\001 \002(\003\022\030\n\020" +
+      "requestUpToSeqNr\030\002 \002(\003\022\025\n\rsupportResend\030" +
+      "\003 \002(\010\022\022\n\nviaTimeout\030\004 \002(\010\"\033\n\006Resend\022\021\n\tf" +
+      "romSeqNr\030\001 \002(\003\"\035\n\003Ack\022\026\n\016confirmedSeqNr\030" +
+      "\001 \002(\003\"\316\001\n\005State\022\024\n\014currentSeqNr\030\001 \002(\003\022\035\n" +
+      "\025highestConfirmedSeqNr\030\002 \002(\003\022E\n\tconfirme" +
+      "d\030\003 \003(\01322.org.apache.pekko.cluster.typed" +
+      ".delivery.Confirmed\022I\n\013unconfirmed\030\004 \003(\013" +
+      "24.org.apache.pekko.cluster.typed.delive" +
+      "ry.MessageSent\"@\n\tConfirmed\022\r\n\005seqNr\030\001 \002" +
+      "(\003\022\021\n\tqualifier\030\002 \002(\t\022\021\n\ttimestamp\030\003 \002(\003" +
+      "\"\221\001\n\013MessageSent\022\r\n\005seqNr\030\001 \002(\003\022\021\n\tquali" +
+      "fier\030\002 \002(\t\022\013\n\003ack\030\003 \002(\010\022\021\n\ttimestamp\030\004 \002" +
+      "(\003\022\031\n\007message\030\005 \002(\0132\010.Payload\022\022\n\nfirstCh" +
+      "unk\030\006 \001(\010\022\021\n\tlastChunk\030\007 \001(\010\"\035\n\007Cleanup\022" +
+      "\022\n\nqualifiers\030\001 \003(\tB4\n0org.apache.pekko." +
+      "cluster.typed.internal.protobufH\001"
     };
     descriptor = org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor[] {
           org.apache.pekko.remote.ContainerFormats.getDescriptor(),
         });
-    internal_static_akka_cluster_typed_delivery_SequencedMessage_descriptor =
+    internal_static_org_apache_pekko_cluster_typed_delivery_SequencedMessage_descriptor =
       getDescriptor().getMessageTypes().get(0);
-    internal_static_akka_cluster_typed_delivery_SequencedMessage_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_typed_delivery_SequencedMessage_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_typed_delivery_SequencedMessage_descriptor,
+        internal_static_org_apache_pekko_cluster_typed_delivery_SequencedMessage_descriptor,
         new java.lang.String[] { "ProducerId", "SeqNr", "First", "Ack", "ProducerControllerRef", "Message", "FirstChunk", "LastChunk", });
-    internal_static_akka_cluster_typed_delivery_RegisterConsumer_descriptor =
+    internal_static_org_apache_pekko_cluster_typed_delivery_RegisterConsumer_descriptor =
       getDescriptor().getMessageTypes().get(1);
-    internal_static_akka_cluster_typed_delivery_RegisterConsumer_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_typed_delivery_RegisterConsumer_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_typed_delivery_RegisterConsumer_descriptor,
+        internal_static_org_apache_pekko_cluster_typed_delivery_RegisterConsumer_descriptor,
         new java.lang.String[] { "ConsumerControllerRef", });
-    internal_static_akka_cluster_typed_delivery_Request_descriptor =
+    internal_static_org_apache_pekko_cluster_typed_delivery_Request_descriptor =
       getDescriptor().getMessageTypes().get(2);
-    internal_static_akka_cluster_typed_delivery_Request_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_typed_delivery_Request_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_typed_delivery_Request_descriptor,
+        internal_static_org_apache_pekko_cluster_typed_delivery_Request_descriptor,
         new java.lang.String[] { "ConfirmedSeqNr", "RequestUpToSeqNr", "SupportResend", "ViaTimeout", });
-    internal_static_akka_cluster_typed_delivery_Resend_descriptor =
+    internal_static_org_apache_pekko_cluster_typed_delivery_Resend_descriptor =
       getDescriptor().getMessageTypes().get(3);
-    internal_static_akka_cluster_typed_delivery_Resend_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_typed_delivery_Resend_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_typed_delivery_Resend_descriptor,
+        internal_static_org_apache_pekko_cluster_typed_delivery_Resend_descriptor,
         new java.lang.String[] { "FromSeqNr", });
-    internal_static_akka_cluster_typed_delivery_Ack_descriptor =
+    internal_static_org_apache_pekko_cluster_typed_delivery_Ack_descriptor =
       getDescriptor().getMessageTypes().get(4);
-    internal_static_akka_cluster_typed_delivery_Ack_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_typed_delivery_Ack_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_typed_delivery_Ack_descriptor,
+        internal_static_org_apache_pekko_cluster_typed_delivery_Ack_descriptor,
         new java.lang.String[] { "ConfirmedSeqNr", });
-    internal_static_akka_cluster_typed_delivery_State_descriptor =
+    internal_static_org_apache_pekko_cluster_typed_delivery_State_descriptor =
       getDescriptor().getMessageTypes().get(5);
-    internal_static_akka_cluster_typed_delivery_State_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_typed_delivery_State_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_typed_delivery_State_descriptor,
+        internal_static_org_apache_pekko_cluster_typed_delivery_State_descriptor,
         new java.lang.String[] { "CurrentSeqNr", "HighestConfirmedSeqNr", "Confirmed", "Unconfirmed", });
-    internal_static_akka_cluster_typed_delivery_Confirmed_descriptor =
+    internal_static_org_apache_pekko_cluster_typed_delivery_Confirmed_descriptor =
       getDescriptor().getMessageTypes().get(6);
-    internal_static_akka_cluster_typed_delivery_Confirmed_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_typed_delivery_Confirmed_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_typed_delivery_Confirmed_descriptor,
+        internal_static_org_apache_pekko_cluster_typed_delivery_Confirmed_descriptor,
         new java.lang.String[] { "SeqNr", "Qualifier", "Timestamp", });
-    internal_static_akka_cluster_typed_delivery_MessageSent_descriptor =
+    internal_static_org_apache_pekko_cluster_typed_delivery_MessageSent_descriptor =
       getDescriptor().getMessageTypes().get(7);
-    internal_static_akka_cluster_typed_delivery_MessageSent_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_typed_delivery_MessageSent_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_typed_delivery_MessageSent_descriptor,
+        internal_static_org_apache_pekko_cluster_typed_delivery_MessageSent_descriptor,
         new java.lang.String[] { "SeqNr", "Qualifier", "Ack", "Timestamp", "Message", "FirstChunk", "LastChunk", });
-    internal_static_akka_cluster_typed_delivery_Cleanup_descriptor =
+    internal_static_org_apache_pekko_cluster_typed_delivery_Cleanup_descriptor =
       getDescriptor().getMessageTypes().get(8);
-    internal_static_akka_cluster_typed_delivery_Cleanup_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_typed_delivery_Cleanup_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_typed_delivery_Cleanup_descriptor,
+        internal_static_org_apache_pekko_cluster_typed_delivery_Cleanup_descriptor,
         new java.lang.String[] { "Qualifiers", });
     org.apache.pekko.remote.ContainerFormats.getDescriptor();
   }

--- a/cluster/src/main/java/org/apache/pekko/cluster/protobuf/msg/ClusterMessages.java
+++ b/cluster/src/main/java/org/apache/pekko/cluster/protobuf/msg/ClusterMessages.java
@@ -15578,7 +15578,7 @@ public final class ClusterMessages {
    *
    * Protobuf type {@code VectorClock}
    */
-  public static final class VectorClock extends
+  public  static final class VectorClock extends
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:VectorClock)
       VectorClockOrBuilder {
@@ -15700,7 +15700,7 @@ public final class ClusterMessages {
     /**
      * Protobuf type {@code VectorClock.Version}
      */
-    public static final class Version extends
+    public  static final class Version extends
         org.apache.pekko.protobufv3.internal.GeneratedMessageV3 implements
         // @@protoc_insertion_point(message_implements:VectorClock.Version)
         VersionOrBuilder {
@@ -15986,23 +15986,23 @@ public final class ClusterMessages {
       }
 
       @java.lang.Override
-      public Version.Builder newBuilderForType() { return newBuilder(); }
-      public static Version.Builder newBuilder() {
+      public Builder newBuilderForType() { return newBuilder(); }
+      public static Builder newBuilder() {
         return DEFAULT_INSTANCE.toBuilder();
       }
       public static Builder newBuilder(org.apache.pekko.cluster.protobuf.msg.ClusterMessages.VectorClock.Version prototype) {
         return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
       }
       @java.lang.Override
-      public Version.Builder toBuilder() {
+      public Builder toBuilder() {
         return this == DEFAULT_INSTANCE
-            ? new Version.Builder() : new Version.Builder().mergeFrom(this);
+            ? new Builder() : new Builder().mergeFrom(this);
       }
 
       @java.lang.Override
-      protected Version.Builder newBuilderForType(
+      protected Builder newBuilderForType(
           org.apache.pekko.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
-        Version.Builder builder = new Version.Builder(parent);
+        Builder builder = new Builder(parent);
         return builder;
       }
       /**

--- a/distributed-data/src/main/java/org/apache/pekko/cluster/ddata/protobuf/msg/ReplicatedDataMessages.java
+++ b/distributed-data/src/main/java/org/apache/pekko/cluster/ddata/protobuf/msg/ReplicatedDataMessages.java
@@ -335,7 +335,7 @@ public final class ReplicatedDataMessages {
 
     /**
      * <pre>
-     * added in org.apache.pekko 2.5.14
+     * added in Akka 2.5.14
      * </pre>
      *
      * <code>repeated string actorRefElements = 5;</code>
@@ -345,7 +345,7 @@ public final class ReplicatedDataMessages {
         getActorRefElementsList();
     /**
      * <pre>
-     * added in org.apache.pekko 2.5.14
+     * added in Akka 2.5.14
      * </pre>
      *
      * <code>repeated string actorRefElements = 5;</code>
@@ -354,7 +354,7 @@ public final class ReplicatedDataMessages {
     int getActorRefElementsCount();
     /**
      * <pre>
-     * added in org.apache.pekko 2.5.14
+     * added in Akka 2.5.14
      * </pre>
      *
      * <code>repeated string actorRefElements = 5;</code>
@@ -364,7 +364,7 @@ public final class ReplicatedDataMessages {
     java.lang.String getActorRefElements(int index);
     /**
      * <pre>
-     * added in org.apache.pekko 2.5.14
+     * added in Akka 2.5.14
      * </pre>
      *
      * <code>repeated string actorRefElements = 5;</code>
@@ -530,13 +530,13 @@ public final class ReplicatedDataMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_GSet_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_GSet_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_GSet_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_GSet_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GSet.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GSet.Builder.class);
     }
@@ -669,7 +669,7 @@ public final class ReplicatedDataMessages {
     private org.apache.pekko.protobufv3.internal.LazyStringList actorRefElements_;
     /**
      * <pre>
-     * added in org.apache.pekko 2.5.14
+     * added in Akka 2.5.14
      * </pre>
      *
      * <code>repeated string actorRefElements = 5;</code>
@@ -681,7 +681,7 @@ public final class ReplicatedDataMessages {
     }
     /**
      * <pre>
-     * added in org.apache.pekko 2.5.14
+     * added in Akka 2.5.14
      * </pre>
      *
      * <code>repeated string actorRefElements = 5;</code>
@@ -692,7 +692,7 @@ public final class ReplicatedDataMessages {
     }
     /**
      * <pre>
-     * added in org.apache.pekko 2.5.14
+     * added in Akka 2.5.14
      * </pre>
      *
      * <code>repeated string actorRefElements = 5;</code>
@@ -704,7 +704,7 @@ public final class ReplicatedDataMessages {
     }
     /**
      * <pre>
-     * added in org.apache.pekko 2.5.14
+     * added in Akka 2.5.14
      * </pre>
      *
      * <code>repeated string actorRefElements = 5;</code>
@@ -977,13 +977,13 @@ public final class ReplicatedDataMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GSetOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_GSet_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_GSet_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_GSet_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_GSet_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GSet.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GSet.Builder.class);
       }
@@ -1027,7 +1027,7 @@ public final class ReplicatedDataMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_GSet_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_GSet_descriptor;
       }
 
       @java.lang.Override
@@ -1742,7 +1742,7 @@ public final class ReplicatedDataMessages {
       }
       /**
        * <pre>
-       * added in org.apache.pekko 2.5.14
+       * added in Akka 2.5.14
        * </pre>
        *
        * <code>repeated string actorRefElements = 5;</code>
@@ -1754,7 +1754,7 @@ public final class ReplicatedDataMessages {
       }
       /**
        * <pre>
-       * added in org.apache.pekko 2.5.14
+       * added in Akka 2.5.14
        * </pre>
        *
        * <code>repeated string actorRefElements = 5;</code>
@@ -1765,7 +1765,7 @@ public final class ReplicatedDataMessages {
       }
       /**
        * <pre>
-       * added in org.apache.pekko 2.5.14
+       * added in Akka 2.5.14
        * </pre>
        *
        * <code>repeated string actorRefElements = 5;</code>
@@ -1777,7 +1777,7 @@ public final class ReplicatedDataMessages {
       }
       /**
        * <pre>
-       * added in org.apache.pekko 2.5.14
+       * added in Akka 2.5.14
        * </pre>
        *
        * <code>repeated string actorRefElements = 5;</code>
@@ -1790,7 +1790,7 @@ public final class ReplicatedDataMessages {
       }
       /**
        * <pre>
-       * added in org.apache.pekko 2.5.14
+       * added in Akka 2.5.14
        * </pre>
        *
        * <code>repeated string actorRefElements = 5;</code>
@@ -1810,7 +1810,7 @@ public final class ReplicatedDataMessages {
       }
       /**
        * <pre>
-       * added in org.apache.pekko 2.5.14
+       * added in Akka 2.5.14
        * </pre>
        *
        * <code>repeated string actorRefElements = 5;</code>
@@ -1829,7 +1829,7 @@ public final class ReplicatedDataMessages {
       }
       /**
        * <pre>
-       * added in org.apache.pekko 2.5.14
+       * added in Akka 2.5.14
        * </pre>
        *
        * <code>repeated string actorRefElements = 5;</code>
@@ -1846,7 +1846,7 @@ public final class ReplicatedDataMessages {
       }
       /**
        * <pre>
-       * added in org.apache.pekko 2.5.14
+       * added in Akka 2.5.14
        * </pre>
        *
        * <code>repeated string actorRefElements = 5;</code>
@@ -1860,7 +1860,7 @@ public final class ReplicatedDataMessages {
       }
       /**
        * <pre>
-       * added in org.apache.pekko 2.5.14
+       * added in Akka 2.5.14
        * </pre>
        *
        * <code>repeated string actorRefElements = 5;</code>
@@ -2058,7 +2058,7 @@ public final class ReplicatedDataMessages {
 
     /**
      * <pre>
-     * added in org.apache.pekko 2.5.14
+     * added in Akka 2.5.14
      * </pre>
      *
      * <code>repeated string actorRefElements = 7;</code>
@@ -2068,7 +2068,7 @@ public final class ReplicatedDataMessages {
         getActorRefElementsList();
     /**
      * <pre>
-     * added in org.apache.pekko 2.5.14
+     * added in Akka 2.5.14
      * </pre>
      *
      * <code>repeated string actorRefElements = 7;</code>
@@ -2077,7 +2077,7 @@ public final class ReplicatedDataMessages {
     int getActorRefElementsCount();
     /**
      * <pre>
-     * added in org.apache.pekko 2.5.14
+     * added in Akka 2.5.14
      * </pre>
      *
      * <code>repeated string actorRefElements = 7;</code>
@@ -2087,7 +2087,7 @@ public final class ReplicatedDataMessages {
     java.lang.String getActorRefElements(int index);
     /**
      * <pre>
-     * added in org.apache.pekko 2.5.14
+     * added in Akka 2.5.14
      * </pre>
      *
      * <code>repeated string actorRefElements = 7;</code>
@@ -2279,13 +2279,13 @@ public final class ReplicatedDataMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSet_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORSet_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSet_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORSet_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet.Builder.class);
     }
@@ -2477,7 +2477,7 @@ public final class ReplicatedDataMessages {
     private org.apache.pekko.protobufv3.internal.LazyStringList actorRefElements_;
     /**
      * <pre>
-     * added in org.apache.pekko 2.5.14
+     * added in Akka 2.5.14
      * </pre>
      *
      * <code>repeated string actorRefElements = 7;</code>
@@ -2489,7 +2489,7 @@ public final class ReplicatedDataMessages {
     }
     /**
      * <pre>
-     * added in org.apache.pekko 2.5.14
+     * added in Akka 2.5.14
      * </pre>
      *
      * <code>repeated string actorRefElements = 7;</code>
@@ -2500,7 +2500,7 @@ public final class ReplicatedDataMessages {
     }
     /**
      * <pre>
-     * added in org.apache.pekko 2.5.14
+     * added in Akka 2.5.14
      * </pre>
      *
      * <code>repeated string actorRefElements = 7;</code>
@@ -2512,7 +2512,7 @@ public final class ReplicatedDataMessages {
     }
     /**
      * <pre>
-     * added in org.apache.pekko 2.5.14
+     * added in Akka 2.5.14
      * </pre>
      *
      * <code>repeated string actorRefElements = 7;</code>
@@ -2828,13 +2828,13 @@ public final class ReplicatedDataMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSet_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORSet_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSet_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORSet_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet.Builder.class);
       }
@@ -2892,7 +2892,7 @@ public final class ReplicatedDataMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSet_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORSet_descriptor;
       }
 
       @java.lang.Override
@@ -4026,7 +4026,7 @@ public final class ReplicatedDataMessages {
       }
       /**
        * <pre>
-       * added in org.apache.pekko 2.5.14
+       * added in Akka 2.5.14
        * </pre>
        *
        * <code>repeated string actorRefElements = 7;</code>
@@ -4038,7 +4038,7 @@ public final class ReplicatedDataMessages {
       }
       /**
        * <pre>
-       * added in org.apache.pekko 2.5.14
+       * added in Akka 2.5.14
        * </pre>
        *
        * <code>repeated string actorRefElements = 7;</code>
@@ -4049,7 +4049,7 @@ public final class ReplicatedDataMessages {
       }
       /**
        * <pre>
-       * added in org.apache.pekko 2.5.14
+       * added in Akka 2.5.14
        * </pre>
        *
        * <code>repeated string actorRefElements = 7;</code>
@@ -4061,7 +4061,7 @@ public final class ReplicatedDataMessages {
       }
       /**
        * <pre>
-       * added in org.apache.pekko 2.5.14
+       * added in Akka 2.5.14
        * </pre>
        *
        * <code>repeated string actorRefElements = 7;</code>
@@ -4074,7 +4074,7 @@ public final class ReplicatedDataMessages {
       }
       /**
        * <pre>
-       * added in org.apache.pekko 2.5.14
+       * added in Akka 2.5.14
        * </pre>
        *
        * <code>repeated string actorRefElements = 7;</code>
@@ -4094,7 +4094,7 @@ public final class ReplicatedDataMessages {
       }
       /**
        * <pre>
-       * added in org.apache.pekko 2.5.14
+       * added in Akka 2.5.14
        * </pre>
        *
        * <code>repeated string actorRefElements = 7;</code>
@@ -4113,7 +4113,7 @@ public final class ReplicatedDataMessages {
       }
       /**
        * <pre>
-       * added in org.apache.pekko 2.5.14
+       * added in Akka 2.5.14
        * </pre>
        *
        * <code>repeated string actorRefElements = 7;</code>
@@ -4130,7 +4130,7 @@ public final class ReplicatedDataMessages {
       }
       /**
        * <pre>
-       * added in org.apache.pekko 2.5.14
+       * added in Akka 2.5.14
        * </pre>
        *
        * <code>repeated string actorRefElements = 7;</code>
@@ -4144,7 +4144,7 @@ public final class ReplicatedDataMessages {
       }
       /**
        * <pre>
-       * added in org.apache.pekko 2.5.14
+       * added in Akka 2.5.14
        * </pre>
        *
        * <code>repeated string actorRefElements = 7;</code>
@@ -4322,13 +4322,13 @@ public final class ReplicatedDataMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORSetDeltaGroup_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORSetDeltaGroup_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Builder.class);
     }
@@ -4456,13 +4456,13 @@ public final class ReplicatedDataMessages {
       }
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_Entry_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORSetDeltaGroup_Entry_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_Entry_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORSetDeltaGroup_Entry_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.Builder.class);
       }
@@ -4706,13 +4706,13 @@ public final class ReplicatedDataMessages {
           org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.EntryOrBuilder {
         public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptor() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORSetDeltaGroup_Entry_descriptor;
         }
 
         @java.lang.Override
         protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_Entry_fieldAccessorTable
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORSetDeltaGroup_Entry_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
                   org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.Builder.class);
         }
@@ -4750,7 +4750,7 @@ public final class ReplicatedDataMessages {
         @java.lang.Override
         public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptorForType() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORSetDeltaGroup_Entry_descriptor;
         }
 
         @java.lang.Override
@@ -5299,13 +5299,13 @@ public final class ReplicatedDataMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroupOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORSetDeltaGroup_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORSetDeltaGroup_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Builder.class);
       }
@@ -5341,7 +5341,7 @@ public final class ReplicatedDataMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORSetDeltaGroup_descriptor;
       }
 
       @java.lang.Override
@@ -5859,13 +5859,13 @@ public final class ReplicatedDataMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_Flag_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_Flag_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_Flag_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_Flag_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.Flag.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.Flag.Builder.class);
     }
@@ -6062,13 +6062,13 @@ public final class ReplicatedDataMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.FlagOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_Flag_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_Flag_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_Flag_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_Flag_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.Flag.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.Flag.Builder.class);
       }
@@ -6099,7 +6099,7 @@ public final class ReplicatedDataMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_Flag_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_Flag_descriptor;
       }
 
       @java.lang.Override
@@ -6442,13 +6442,13 @@ public final class ReplicatedDataMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_LWWRegister_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_LWWRegister_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_LWWRegister_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_LWWRegister_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.LWWRegister.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.LWWRegister.Builder.class);
     }
@@ -6739,13 +6739,13 @@ public final class ReplicatedDataMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.LWWRegisterOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_LWWRegister_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_LWWRegister_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_LWWRegister_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_LWWRegister_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.LWWRegister.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.LWWRegister.Builder.class);
       }
@@ -6790,7 +6790,7 @@ public final class ReplicatedDataMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_LWWRegister_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_LWWRegister_descriptor;
       }
 
       @java.lang.Override
@@ -7372,13 +7372,13 @@ public final class ReplicatedDataMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_GCounter_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_GCounter_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_GCounter_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_GCounter_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GCounter.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GCounter.Builder.class);
     }
@@ -7499,13 +7499,13 @@ public final class ReplicatedDataMessages {
       }
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_GCounter_Entry_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_GCounter_Entry_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_GCounter_Entry_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_GCounter_Entry_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GCounter.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GCounter.Entry.Builder.class);
       }
@@ -7748,13 +7748,13 @@ public final class ReplicatedDataMessages {
           org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GCounter.EntryOrBuilder {
         public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptor() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_GCounter_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_GCounter_Entry_descriptor;
         }
 
         @java.lang.Override
         protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_GCounter_Entry_fieldAccessorTable
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_GCounter_Entry_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
                   org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GCounter.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GCounter.Entry.Builder.class);
         }
@@ -7792,7 +7792,7 @@ public final class ReplicatedDataMessages {
         @java.lang.Override
         public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptorForType() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_GCounter_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_GCounter_Entry_descriptor;
         }
 
         @java.lang.Override
@@ -8339,13 +8339,13 @@ public final class ReplicatedDataMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GCounterOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_GCounter_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_GCounter_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_GCounter_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_GCounter_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GCounter.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GCounter.Builder.class);
       }
@@ -8381,7 +8381,7 @@ public final class ReplicatedDataMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_GCounter_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_GCounter_descriptor;
       }
 
       @java.lang.Override
@@ -8939,13 +8939,13 @@ public final class ReplicatedDataMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_PNCounter_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_PNCounter_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_PNCounter_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_PNCounter_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.PNCounter.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.PNCounter.Builder.class);
     }
@@ -9198,13 +9198,13 @@ public final class ReplicatedDataMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.PNCounterOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_PNCounter_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_PNCounter_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_PNCounter_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_PNCounter_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.PNCounter.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.PNCounter.Builder.class);
       }
@@ -9247,7 +9247,7 @@ public final class ReplicatedDataMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_PNCounter_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_PNCounter_descriptor;
       }
 
       @java.lang.Override
@@ -9810,13 +9810,13 @@ public final class ReplicatedDataMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMap_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMap_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMap_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMap_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMap.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMap.Builder.class);
     }
@@ -10004,13 +10004,13 @@ public final class ReplicatedDataMessages {
       }
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMap_Entry_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMap_Entry_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMap_Entry_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMap_Entry_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMap.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMap.Entry.Builder.class);
       }
@@ -10388,13 +10388,13 @@ public final class ReplicatedDataMessages {
           org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMap.EntryOrBuilder {
         public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptor() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMap_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMap_Entry_descriptor;
         }
 
         @java.lang.Override
         protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMap_Entry_fieldAccessorTable
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMap_Entry_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
                   org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMap.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMap.Entry.Builder.class);
         }
@@ -10443,7 +10443,7 @@ public final class ReplicatedDataMessages {
         @java.lang.Override
         public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptorForType() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMap_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMap_Entry_descriptor;
         }
 
         @java.lang.Override
@@ -11305,13 +11305,13 @@ public final class ReplicatedDataMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMap_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMap_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMap_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMap_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMap.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMap.Builder.class);
       }
@@ -11354,7 +11354,7 @@ public final class ReplicatedDataMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMap_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMap_descriptor;
       }
 
       @java.lang.Override
@@ -12032,13 +12032,13 @@ public final class ReplicatedDataMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMapDeltaGroup_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMapDeltaGroup_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.Builder.class);
     }
@@ -12226,13 +12226,13 @@ public final class ReplicatedDataMessages {
       }
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMapDeltaGroup_MapEntry_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_MapEntry_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMapDeltaGroup_MapEntry_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_MapEntry_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.Builder.class);
       }
@@ -12608,13 +12608,13 @@ public final class ReplicatedDataMessages {
           org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntryOrBuilder {
         public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptor() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMapDeltaGroup_MapEntry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_MapEntry_descriptor;
         }
 
         @java.lang.Override
         protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMapDeltaGroup_MapEntry_fieldAccessorTable
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_MapEntry_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
                   org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.Builder.class);
         }
@@ -12663,7 +12663,7 @@ public final class ReplicatedDataMessages {
         @java.lang.Override
         public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptorForType() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMapDeltaGroup_MapEntry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_MapEntry_descriptor;
         }
 
         @java.lang.Override
@@ -13445,13 +13445,13 @@ public final class ReplicatedDataMessages {
       }
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMapDeltaGroup_Entry_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_Entry_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMapDeltaGroup_Entry_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_Entry_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.Entry.Builder.class);
       }
@@ -13786,13 +13786,13 @@ public final class ReplicatedDataMessages {
           org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.EntryOrBuilder {
         public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptor() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMapDeltaGroup_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_Entry_descriptor;
         }
 
         @java.lang.Override
         protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMapDeltaGroup_Entry_fieldAccessorTable
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_Entry_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
                   org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.Entry.Builder.class);
         }
@@ -13839,7 +13839,7 @@ public final class ReplicatedDataMessages {
         @java.lang.Override
         public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptorForType() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMapDeltaGroup_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_Entry_descriptor;
         }
 
         @java.lang.Override
@@ -14715,13 +14715,13 @@ public final class ReplicatedDataMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroupOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMapDeltaGroup_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMapDeltaGroup_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.Builder.class);
       }
@@ -14757,7 +14757,7 @@ public final class ReplicatedDataMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMapDeltaGroup_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_descriptor;
       }
 
       @java.lang.Override
@@ -15324,13 +15324,13 @@ public final class ReplicatedDataMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_LWWMap_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_LWWMap_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_LWWMap_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_LWWMap_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.LWWMap.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.LWWMap.Builder.class);
     }
@@ -15518,13 +15518,13 @@ public final class ReplicatedDataMessages {
       }
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_LWWMap_Entry_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_LWWMap_Entry_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_LWWMap_Entry_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_LWWMap_Entry_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.LWWMap.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.LWWMap.Entry.Builder.class);
       }
@@ -15902,13 +15902,13 @@ public final class ReplicatedDataMessages {
           org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.LWWMap.EntryOrBuilder {
         public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptor() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_LWWMap_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_LWWMap_Entry_descriptor;
         }
 
         @java.lang.Override
         protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_LWWMap_Entry_fieldAccessorTable
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_LWWMap_Entry_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
                   org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.LWWMap.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.LWWMap.Entry.Builder.class);
         }
@@ -15957,7 +15957,7 @@ public final class ReplicatedDataMessages {
         @java.lang.Override
         public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptorForType() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_LWWMap_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_LWWMap_Entry_descriptor;
         }
 
         @java.lang.Override
@@ -16819,13 +16819,13 @@ public final class ReplicatedDataMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.LWWMapOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_LWWMap_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_LWWMap_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_LWWMap_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_LWWMap_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.LWWMap.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.LWWMap.Builder.class);
       }
@@ -16868,7 +16868,7 @@ public final class ReplicatedDataMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_LWWMap_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_LWWMap_descriptor;
       }
 
       @java.lang.Override
@@ -17574,13 +17574,13 @@ public final class ReplicatedDataMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_PNCounterMap_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_PNCounterMap_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_PNCounterMap_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_PNCounterMap_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.PNCounterMap.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.PNCounterMap.Builder.class);
     }
@@ -17768,13 +17768,13 @@ public final class ReplicatedDataMessages {
       }
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_PNCounterMap_Entry_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_PNCounterMap_Entry_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_PNCounterMap_Entry_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_PNCounterMap_Entry_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.PNCounterMap.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.PNCounterMap.Entry.Builder.class);
       }
@@ -18152,13 +18152,13 @@ public final class ReplicatedDataMessages {
           org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.PNCounterMap.EntryOrBuilder {
         public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptor() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_PNCounterMap_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_PNCounterMap_Entry_descriptor;
         }
 
         @java.lang.Override
         protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_PNCounterMap_Entry_fieldAccessorTable
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_PNCounterMap_Entry_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
                   org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.PNCounterMap.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.PNCounterMap.Entry.Builder.class);
         }
@@ -18207,7 +18207,7 @@ public final class ReplicatedDataMessages {
         @java.lang.Override
         public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptorForType() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_PNCounterMap_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_PNCounterMap_Entry_descriptor;
         }
 
         @java.lang.Override
@@ -19069,13 +19069,13 @@ public final class ReplicatedDataMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.PNCounterMapOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_PNCounterMap_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_PNCounterMap_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_PNCounterMap_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_PNCounterMap_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.PNCounterMap.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.PNCounterMap.Builder.class);
       }
@@ -19118,7 +19118,7 @@ public final class ReplicatedDataMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_PNCounterMap_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_PNCounterMap_descriptor;
       }
 
       @java.lang.Override
@@ -19840,13 +19840,13 @@ public final class ReplicatedDataMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMultiMap_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMultiMap_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMultiMap_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMultiMap_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMultiMap.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMultiMap.Builder.class);
     }
@@ -20034,13 +20034,13 @@ public final class ReplicatedDataMessages {
       }
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMultiMap_Entry_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMultiMap_Entry_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMultiMap_Entry_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMultiMap_Entry_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMultiMap.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMultiMap.Entry.Builder.class);
       }
@@ -20418,13 +20418,13 @@ public final class ReplicatedDataMessages {
           org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMultiMap.EntryOrBuilder {
         public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptor() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMultiMap_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMultiMap_Entry_descriptor;
         }
 
         @java.lang.Override
         protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMultiMap_Entry_fieldAccessorTable
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMultiMap_Entry_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
                   org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMultiMap.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMultiMap.Entry.Builder.class);
         }
@@ -20473,7 +20473,7 @@ public final class ReplicatedDataMessages {
         @java.lang.Override
         public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptorForType() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMultiMap_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMultiMap_Entry_descriptor;
         }
 
         @java.lang.Override
@@ -21369,13 +21369,13 @@ public final class ReplicatedDataMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMultiMapOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMultiMap_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMultiMap_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMultiMap_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMultiMap_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMultiMap.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMultiMap.Builder.class);
       }
@@ -21420,7 +21420,7 @@ public final class ReplicatedDataMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMultiMap_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_org_apache_pekko_cluster_ddata_ORMultiMap_descriptor;
       }
 
       @java.lang.Override
@@ -22034,106 +22034,106 @@ public final class ReplicatedDataMessages {
 
   }
 
-  private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor 
-    internal_static_akka_cluster_ddata_GSet_descriptor;
-  private static final 
-    org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_GSet_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_ORSet_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_GSet_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_ORSet_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_GSet_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_ORSetDeltaGroup_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_ORSet_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_ORSetDeltaGroup_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_ORSet_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_ORSetDeltaGroup_Entry_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_ORSetDeltaGroup_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_ORSetDeltaGroup_Entry_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_ORSetDeltaGroup_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_Flag_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_ORSetDeltaGroup_Entry_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_Flag_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_ORSetDeltaGroup_Entry_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_LWWRegister_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_Flag_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_LWWRegister_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_Flag_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_GCounter_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_LWWRegister_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_GCounter_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_LWWRegister_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_GCounter_Entry_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_GCounter_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_GCounter_Entry_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_GCounter_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_PNCounter_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_GCounter_Entry_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_PNCounter_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_GCounter_Entry_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_ORMap_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_PNCounter_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_ORMap_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_PNCounter_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_ORMap_Entry_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_ORMap_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_ORMap_Entry_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_ORMap_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_ORMapDeltaGroup_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_ORMap_Entry_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_ORMapDeltaGroup_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_ORMap_Entry_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_ORMapDeltaGroup_MapEntry_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_ORMapDeltaGroup_MapEntry_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_ORMapDeltaGroup_Entry_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_MapEntry_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_ORMapDeltaGroup_Entry_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_MapEntry_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_LWWMap_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_Entry_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_LWWMap_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_Entry_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_LWWMap_Entry_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_LWWMap_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_LWWMap_Entry_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_LWWMap_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_PNCounterMap_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_LWWMap_Entry_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_PNCounterMap_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_LWWMap_Entry_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_PNCounterMap_Entry_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_PNCounterMap_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_PNCounterMap_Entry_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_PNCounterMap_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_ORMultiMap_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_PNCounterMap_Entry_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_ORMultiMap_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_PNCounterMap_Entry_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_ORMultiMap_Entry_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_ORMultiMap_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_ORMultiMap_Entry_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_ORMultiMap_fieldAccessorTable;
+  private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
+    internal_static_org_apache_pekko_cluster_ddata_ORMultiMap_Entry_descriptor;
+  private static final 
+    org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+      internal_static_org_apache_pekko_cluster_ddata_ORMultiMap_Entry_fieldAccessorTable;
 
   public static org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor
       getDescriptor() {
@@ -22143,202 +22143,213 @@ public final class ReplicatedDataMessages {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\034ReplicatedDataMessages.proto\022\022org.apache.pekko.clu" +
-      "ster.ddata\032\030ReplicatorMessages.proto\"\244\001\n" +
-      "\004GSet\022\026\n\016stringElements\030\001 \003(\t\022\027\n\013intElem" +
-      "ents\030\002 \003(\021B\002\020\001\022\030\n\014longElements\030\003 \003(\022B\002\020\001" +
-      "\0227\n\rotherElements\030\004 \003(\0132 .org.apache.pekko.cluster.d" +
-      "data.OtherMessage\022\030\n\020actorRefElements\030\005 " +
-      "\003(\t\"\212\002\n\005ORSet\0222\n\007vvector\030\001 \002(\0132!.org.apache.pekko.cl" +
-      "uster.ddata.VersionVector\022/\n\004dots\030\002 \003(\0132" +
-      "!.org.apache.pekko.cluster.ddata.VersionVector\022\026\n\016st" +
-      "ringElements\030\003 \003(\t\022\027\n\013intElements\030\004 \003(\021B" +
-      "\002\020\001\022\030\n\014longElements\030\005 \003(\022B\002\020\001\0227\n\rotherEl" +
-      "ements\030\006 \003(\0132 .org.apache.pekko.cluster.ddata.OtherM" +
-      "essage\022\030\n\020actorRefElements\030\007 \003(\t\"\272\001\n\017ORS" +
-      "etDeltaGroup\022:\n\007entries\030\001 \003(\0132).org.apache.pekko.clu" +
-      "ster.ddata.ORSetDeltaGroup.Entry\032k\n\005Entr" +
-      "y\0223\n\toperation\030\001 \002(\0162 .org.apache.pekko.cluster.ddat" +
-      "a.ORSetDeltaOp\022-\n\nunderlying\030\002 \002(\0132\031.akk" +
-      "a.cluster.ddata.ORSet\"\027\n\004Flag\022\017\n\007enabled" +
-      "\030\001 \002(\010\"\202\001\n\013LWWRegister\022\021\n\ttimestamp\030\001 \002(" +
-      "\022\022/\n\004node\030\002 \002(\0132!.org.apache.pekko.cluster.ddata.Uni" +
-      "queAddress\022/\n\005state\030\003 \002(\0132 .org.apache.pekko.cluster" +
-      ".ddata.OtherMessage\"\210\001\n\010GCounter\0223\n\007entr" +
-      "ies\030\001 \003(\0132\".org.apache.pekko.cluster.ddata.GCounter." +
-      "Entry\032G\n\005Entry\022/\n\004node\030\001 \002(\0132!.org.apache.pekko.clus" +
-      "ter.ddata.UniqueAddress\022\r\n\005value\030\002 \002(\014\"o" +
-      "\n\tPNCounter\0220\n\nincrements\030\001 \002(\0132\034.org.apache.pekko.c" +
-      "luster.ddata.GCounter\0220\n\ndecrements\030\002 \002(" +
-      "\0132\034.org.apache.pekko.cluster.ddata.GCounter\"\205\002\n\005ORMa" +
-      "p\022\'\n\004keys\030\001 \002(\0132\031.org.apache.pekko.cluster.ddata.ORS" +
-      "et\0220\n\007entries\030\002 \003(\0132\037.org.apache.pekko.cluster.ddata" +
-      ".ORMap.Entry\032\240\001\n\005Entry\022\021\n\tstringKey\030\001 \001(" +
-      "\t\022/\n\005value\030\002 \002(\0132 .org.apache.pekko.cluster.ddata.Ot" +
-      "herMessage\022\016\n\006intKey\030\003 \001(\021\022\017\n\007longKey\030\004 " +
-      "\001(\022\0222\n\010otherKey\030\005 \001(\0132 .org.apache.pekko.cluster.dda" +
-      "ta.OtherMessage\"\263\003\n\017ORMapDeltaGroup\022:\n\007e" +
-      "ntries\030\001 \003(\0132).org.apache.pekko.cluster.ddata.ORMapD" +
-      "eltaGroup.Entry\032\243\001\n\010MapEntry\022\021\n\tstringKe" +
-      "y\030\001 \001(\t\022/\n\005value\030\002 \001(\0132 .org.apache.pekko.cluster.dd" +
+      "\n\034ReplicatedDataMessages.proto\022\036org.apac" +
+      "he.pekko.cluster.ddata\032\030ReplicatorMessag" +
+      "es.proto\"\260\001\n\004GSet\022\026\n\016stringElements\030\001 \003(" +
+      "\t\022\027\n\013intElements\030\002 \003(\021B\002\020\001\022\030\n\014longElemen" +
+      "ts\030\003 \003(\022B\002\020\001\022C\n\rotherElements\030\004 \003(\0132,.or" +
+      "g.apache.pekko.cluster.ddata.OtherMessag" +
+      "e\022\030\n\020actorRefElements\030\005 \003(\t\"\256\002\n\005ORSet\022>\n" +
+      "\007vvector\030\001 \002(\0132-.org.apache.pekko.cluste" +
+      "r.ddata.VersionVector\022;\n\004dots\030\002 \003(\0132-.or" +
+      "g.apache.pekko.cluster.ddata.VersionVect" +
+      "or\022\026\n\016stringElements\030\003 \003(\t\022\027\n\013intElement" +
+      "s\030\004 \003(\021B\002\020\001\022\030\n\014longElements\030\005 \003(\022B\002\020\001\022C\n" +
+      "\rotherElements\030\006 \003(\0132,.org.apache.pekko." +
+      "cluster.ddata.OtherMessage\022\030\n\020actorRefEl" +
+      "ements\030\007 \003(\t\"\337\001\n\017ORSetDeltaGroup\022F\n\007entr" +
+      "ies\030\001 \003(\01325.org.apache.pekko.cluster.dda" +
+      "ta.ORSetDeltaGroup.Entry\032\203\001\n\005Entry\022?\n\top" +
+      "eration\030\001 \002(\0162,.org.apache.pekko.cluster" +
+      ".ddata.ORSetDeltaOp\0229\n\nunderlying\030\002 \002(\0132" +
+      "%.org.apache.pekko.cluster.ddata.ORSet\"\027" +
+      "\n\004Flag\022\017\n\007enabled\030\001 \002(\010\"\232\001\n\013LWWRegister\022" +
+      "\021\n\ttimestamp\030\001 \002(\022\022;\n\004node\030\002 \002(\0132-.org.a" +
+      "pache.pekko.cluster.ddata.UniqueAddress\022" +
+      ";\n\005state\030\003 \002(\0132,.org.apache.pekko.cluste" +
+      "r.ddata.OtherMessage\"\240\001\n\010GCounter\022?\n\007ent" +
+      "ries\030\001 \003(\0132..org.apache.pekko.cluster.dd" +
+      "ata.GCounter.Entry\032S\n\005Entry\022;\n\004node\030\001 \002(" +
+      "\0132-.org.apache.pekko.cluster.ddata.Uniqu" +
+      "eAddress\022\r\n\005value\030\002 \002(\014\"\207\001\n\tPNCounter\022<\n" +
+      "\nincrements\030\001 \002(\0132(.org.apache.pekko.clu" +
+      "ster.ddata.GCounter\022<\n\ndecrements\030\002 \002(\0132" +
+      "(.org.apache.pekko.cluster.ddata.GCounte" +
+      "r\"\265\002\n\005ORMap\0223\n\004keys\030\001 \002(\0132%.org.apache.p" +
+      "ekko.cluster.ddata.ORSet\022<\n\007entries\030\002 \003(" +
+      "\0132+.org.apache.pekko.cluster.ddata.ORMap" +
+      ".Entry\032\270\001\n\005Entry\022\021\n\tstringKey\030\001 \001(\t\022;\n\005v" +
+      "alue\030\002 \002(\0132,.org.apache.pekko.cluster.dd" +
       "ata.OtherMessage\022\016\n\006intKey\030\003 \001(\021\022\017\n\007long" +
-      "Key\030\004 \001(\022\0222\n\010otherKey\030\005 \001(\0132 .org.apache.pekko.clust" +
-      "er.ddata.OtherMessage\032\275\001\n\005Entry\0223\n\topera" +
-      "tion\030\001 \002(\0162 .org.apache.pekko.cluster.ddata.ORMapDel" +
-      "taOp\022-\n\nunderlying\030\002 \002(\0132\031.org.apache.pekko.cluster." +
-      "ddata.ORSet\022\017\n\007zeroTag\030\003 \002(\021\022?\n\tentryDat" +
-      "a\030\004 \003(\0132,.org.apache.pekko.cluster.ddata.ORMapDeltaG" +
-      "roup.MapEntry\"\206\002\n\006LWWMap\022\'\n\004keys\030\001 \002(\0132\031" +
-      ".org.apache.pekko.cluster.ddata.ORSet\0221\n\007entries\030\002 \003" +
-      "(\0132 .org.apache.pekko.cluster.ddata.LWWMap.Entry\032\237\001\n" +
-      "\005Entry\022\021\n\tstringKey\030\001 \001(\t\022.\n\005value\030\002 \002(\013" +
-      "2\037.org.apache.pekko.cluster.ddata.LWWRegister\022\016\n\006int" +
-      "Key\030\003 \001(\021\022\017\n\007longKey\030\004 \001(\022\0222\n\010otherKey\030\005" +
-      " \001(\0132 .org.apache.pekko.cluster.ddata.OtherMessage\"\220" +
-      "\002\n\014PNCounterMap\022\'\n\004keys\030\001 \002(\0132\031.org.apache.pekko.clu" +
-      "ster.ddata.ORSet\0227\n\007entries\030\002 \003(\0132&.org.apache.pekko" +
-      ".cluster.ddata.PNCounterMap.Entry\032\235\001\n\005En" +
-      "try\022\021\n\tstringKey\030\001 \001(\t\022,\n\005value\030\002 \002(\0132\035." +
-      "org.apache.pekko.cluster.ddata.PNCounter\022\016\n\006intKey\030\003" +
-      " \001(\021\022\017\n\007longKey\030\004 \001(\022\0222\n\010otherKey\030\005 \001(\0132" +
-      " .org.apache.pekko.cluster.ddata.OtherMessage\"\241\002\n\nOR" +
-      "MultiMap\022\'\n\004keys\030\001 \002(\0132\031.org.apache.pekko.cluster.dd" +
-      "ata.ORSet\0225\n\007entries\030\002 \003(\0132$.org.apache.pekko.cluste" +
-      "r.ddata.ORMultiMap.Entry\022\027\n\017withValueDel" +
-      "tas\030\003 \001(\010\032\231\001\n\005Entry\022\021\n\tstringKey\030\001 \001(\t\022(" +
-      "\n\005value\030\002 \002(\0132\031.org.apache.pekko.cluster.ddata.ORSet" +
-      "\022\016\n\006intKey\030\003 \001(\021\022\017\n\007longKey\030\004 \001(\022\0222\n\010oth" +
-      "erKey\030\005 \001(\0132 .org.apache.pekko.cluster.ddata.OtherMe" +
-      "ssage*-\n\014ORSetDeltaOp\022\007\n\003Add\020\000\022\n\n\006Remove" +
-      "\020\001\022\010\n\004Full\020\002*R\n\014ORMapDeltaOp\022\014\n\010ORMapPut" +
-      "\020\000\022\017\n\013ORMapRemove\020\001\022\022\n\016ORMapRemoveKey\020\002\022" +
-      "\017\n\013ORMapUpdate\020\003B#\n\037org.apache.pekko.cluster.ddata.p" +
-      "rotobuf.msgH\001"
+      "Key\030\004 \001(\022\022>\n\010otherKey\030\005 \001(\0132,.org.apache" +
+      ".pekko.cluster.ddata.OtherMessage\"\373\003\n\017OR" +
+      "MapDeltaGroup\022F\n\007entries\030\001 \003(\01325.org.apa" +
+      "che.pekko.cluster.ddata.ORMapDeltaGroup." +
+      "Entry\032\273\001\n\010MapEntry\022\021\n\tstringKey\030\001 \001(\t\022;\n" +
+      "\005value\030\002 \001(\0132,.org.apache.pekko.cluster." +
+      "ddata.OtherMessage\022\016\n\006intKey\030\003 \001(\021\022\017\n\007lo" +
+      "ngKey\030\004 \001(\022\022>\n\010otherKey\030\005 \001(\0132,.org.apac" +
+      "he.pekko.cluster.ddata.OtherMessage\032\341\001\n\005" +
+      "Entry\022?\n\toperation\030\001 \002(\0162,.org.apache.pe" +
+      "kko.cluster.ddata.ORMapDeltaOp\0229\n\nunderl" +
+      "ying\030\002 \002(\0132%.org.apache.pekko.cluster.dd" +
+      "ata.ORSet\022\017\n\007zeroTag\030\003 \002(\021\022K\n\tentryData\030" +
+      "\004 \003(\01328.org.apache.pekko.cluster.ddata.O" +
+      "RMapDeltaGroup.MapEntry\"\266\002\n\006LWWMap\0223\n\004ke" +
+      "ys\030\001 \002(\0132%.org.apache.pekko.cluster.ddat" +
+      "a.ORSet\022=\n\007entries\030\002 \003(\0132,.org.apache.pe" +
+      "kko.cluster.ddata.LWWMap.Entry\032\267\001\n\005Entry" +
+      "\022\021\n\tstringKey\030\001 \001(\t\022:\n\005value\030\002 \002(\0132+.org" +
+      ".apache.pekko.cluster.ddata.LWWRegister\022" +
+      "\016\n\006intKey\030\003 \001(\021\022\017\n\007longKey\030\004 \001(\022\022>\n\010othe" +
+      "rKey\030\005 \001(\0132,.org.apache.pekko.cluster.dd" +
+      "ata.OtherMessage\"\300\002\n\014PNCounterMap\0223\n\004key" +
+      "s\030\001 \002(\0132%.org.apache.pekko.cluster.ddata" +
+      ".ORSet\022C\n\007entries\030\002 \003(\01322.org.apache.pek" +
+      "ko.cluster.ddata.PNCounterMap.Entry\032\265\001\n\005" +
+      "Entry\022\021\n\tstringKey\030\001 \001(\t\0228\n\005value\030\002 \002(\0132" +
+      ").org.apache.pekko.cluster.ddata.PNCount" +
+      "er\022\016\n\006intKey\030\003 \001(\021\022\017\n\007longKey\030\004 \001(\022\022>\n\010o" +
+      "therKey\030\005 \001(\0132,.org.apache.pekko.cluster" +
+      ".ddata.OtherMessage\"\321\002\n\nORMultiMap\0223\n\004ke" +
+      "ys\030\001 \002(\0132%.org.apache.pekko.cluster.ddat" +
+      "a.ORSet\022A\n\007entries\030\002 \003(\01320.org.apache.pe" +
+      "kko.cluster.ddata.ORMultiMap.Entry\022\027\n\017wi" +
+      "thValueDeltas\030\003 \001(\010\032\261\001\n\005Entry\022\021\n\tstringK" +
+      "ey\030\001 \001(\t\0224\n\005value\030\002 \002(\0132%.org.apache.pek" +
+      "ko.cluster.ddata.ORSet\022\016\n\006intKey\030\003 \001(\021\022\017" +
+      "\n\007longKey\030\004 \001(\022\022>\n\010otherKey\030\005 \001(\0132,.org." +
+      "apache.pekko.cluster.ddata.OtherMessage*" +
+      "-\n\014ORSetDeltaOp\022\007\n\003Add\020\000\022\n\n\006Remove\020\001\022\010\n\004" +
+      "Full\020\002*R\n\014ORMapDeltaOp\022\014\n\010ORMapPut\020\000\022\017\n\013" +
+      "ORMapRemove\020\001\022\022\n\016ORMapRemoveKey\020\002\022\017\n\013ORM" +
+      "apUpdate\020\003B/\n+org.apache.pekko.cluster.d" +
+      "data.protobuf.msgH\001"
     };
     descriptor = org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor[] {
           org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.getDescriptor(),
         });
-    internal_static_akka_cluster_ddata_GSet_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_GSet_descriptor =
       getDescriptor().getMessageTypes().get(0);
-    internal_static_akka_cluster_ddata_GSet_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_GSet_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-            internal_static_akka_cluster_ddata_GSet_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_GSet_descriptor,
         new java.lang.String[] { "StringElements", "IntElements", "LongElements", "OtherElements", "ActorRefElements", });
-    internal_static_akka_cluster_ddata_ORSet_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_ORSet_descriptor =
       getDescriptor().getMessageTypes().get(1);
-    internal_static_akka_cluster_ddata_ORSet_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_ORSet_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_ORSet_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_ORSet_descriptor,
         new java.lang.String[] { "Vvector", "Dots", "StringElements", "IntElements", "LongElements", "OtherElements", "ActorRefElements", });
-    internal_static_akka_cluster_ddata_ORSetDeltaGroup_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_ORSetDeltaGroup_descriptor =
       getDescriptor().getMessageTypes().get(2);
-    internal_static_akka_cluster_ddata_ORSetDeltaGroup_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_ORSetDeltaGroup_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_ORSetDeltaGroup_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_ORSetDeltaGroup_descriptor,
         new java.lang.String[] { "Entries", });
-    internal_static_akka_cluster_ddata_ORSetDeltaGroup_Entry_descriptor =
-      internal_static_akka_cluster_ddata_ORSetDeltaGroup_descriptor.getNestedTypes().get(0);
-    internal_static_akka_cluster_ddata_ORSetDeltaGroup_Entry_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_ORSetDeltaGroup_Entry_descriptor =
+      internal_static_org_apache_pekko_cluster_ddata_ORSetDeltaGroup_descriptor.getNestedTypes().get(0);
+    internal_static_org_apache_pekko_cluster_ddata_ORSetDeltaGroup_Entry_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_ORSetDeltaGroup_Entry_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_ORSetDeltaGroup_Entry_descriptor,
         new java.lang.String[] { "Operation", "Underlying", });
-    internal_static_akka_cluster_ddata_Flag_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_Flag_descriptor =
       getDescriptor().getMessageTypes().get(3);
-    internal_static_akka_cluster_ddata_Flag_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_Flag_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_Flag_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_Flag_descriptor,
         new java.lang.String[] { "Enabled", });
-    internal_static_akka_cluster_ddata_LWWRegister_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_LWWRegister_descriptor =
       getDescriptor().getMessageTypes().get(4);
-    internal_static_akka_cluster_ddata_LWWRegister_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_LWWRegister_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_LWWRegister_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_LWWRegister_descriptor,
         new java.lang.String[] { "Timestamp", "Node", "State", });
-    internal_static_akka_cluster_ddata_GCounter_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_GCounter_descriptor =
       getDescriptor().getMessageTypes().get(5);
-    internal_static_akka_cluster_ddata_GCounter_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_GCounter_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_GCounter_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_GCounter_descriptor,
         new java.lang.String[] { "Entries", });
-    internal_static_akka_cluster_ddata_GCounter_Entry_descriptor =
-      internal_static_akka_cluster_ddata_GCounter_descriptor.getNestedTypes().get(0);
-    internal_static_akka_cluster_ddata_GCounter_Entry_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_GCounter_Entry_descriptor =
+      internal_static_org_apache_pekko_cluster_ddata_GCounter_descriptor.getNestedTypes().get(0);
+    internal_static_org_apache_pekko_cluster_ddata_GCounter_Entry_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_GCounter_Entry_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_GCounter_Entry_descriptor,
         new java.lang.String[] { "Node", "Value", });
-    internal_static_akka_cluster_ddata_PNCounter_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_PNCounter_descriptor =
       getDescriptor().getMessageTypes().get(6);
-    internal_static_akka_cluster_ddata_PNCounter_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_PNCounter_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_PNCounter_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_PNCounter_descriptor,
         new java.lang.String[] { "Increments", "Decrements", });
-    internal_static_akka_cluster_ddata_ORMap_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_ORMap_descriptor =
       getDescriptor().getMessageTypes().get(7);
-    internal_static_akka_cluster_ddata_ORMap_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_ORMap_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_ORMap_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_ORMap_descriptor,
         new java.lang.String[] { "Keys", "Entries", });
-    internal_static_akka_cluster_ddata_ORMap_Entry_descriptor =
-      internal_static_akka_cluster_ddata_ORMap_descriptor.getNestedTypes().get(0);
-    internal_static_akka_cluster_ddata_ORMap_Entry_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_ORMap_Entry_descriptor =
+      internal_static_org_apache_pekko_cluster_ddata_ORMap_descriptor.getNestedTypes().get(0);
+    internal_static_org_apache_pekko_cluster_ddata_ORMap_Entry_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_ORMap_Entry_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_ORMap_Entry_descriptor,
         new java.lang.String[] { "StringKey", "Value", "IntKey", "LongKey", "OtherKey", });
-    internal_static_akka_cluster_ddata_ORMapDeltaGroup_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_descriptor =
       getDescriptor().getMessageTypes().get(8);
-    internal_static_akka_cluster_ddata_ORMapDeltaGroup_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_ORMapDeltaGroup_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_descriptor,
         new java.lang.String[] { "Entries", });
-    internal_static_akka_cluster_ddata_ORMapDeltaGroup_MapEntry_descriptor =
-      internal_static_akka_cluster_ddata_ORMapDeltaGroup_descriptor.getNestedTypes().get(0);
-    internal_static_akka_cluster_ddata_ORMapDeltaGroup_MapEntry_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_MapEntry_descriptor =
+      internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_descriptor.getNestedTypes().get(0);
+    internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_MapEntry_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_ORMapDeltaGroup_MapEntry_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_MapEntry_descriptor,
         new java.lang.String[] { "StringKey", "Value", "IntKey", "LongKey", "OtherKey", });
-    internal_static_akka_cluster_ddata_ORMapDeltaGroup_Entry_descriptor =
-      internal_static_akka_cluster_ddata_ORMapDeltaGroup_descriptor.getNestedTypes().get(1);
-    internal_static_akka_cluster_ddata_ORMapDeltaGroup_Entry_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_Entry_descriptor =
+      internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_descriptor.getNestedTypes().get(1);
+    internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_Entry_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_ORMapDeltaGroup_Entry_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_ORMapDeltaGroup_Entry_descriptor,
         new java.lang.String[] { "Operation", "Underlying", "ZeroTag", "EntryData", });
-    internal_static_akka_cluster_ddata_LWWMap_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_LWWMap_descriptor =
       getDescriptor().getMessageTypes().get(9);
-    internal_static_akka_cluster_ddata_LWWMap_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_LWWMap_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_LWWMap_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_LWWMap_descriptor,
         new java.lang.String[] { "Keys", "Entries", });
-    internal_static_akka_cluster_ddata_LWWMap_Entry_descriptor =
-      internal_static_akka_cluster_ddata_LWWMap_descriptor.getNestedTypes().get(0);
-    internal_static_akka_cluster_ddata_LWWMap_Entry_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_LWWMap_Entry_descriptor =
+      internal_static_org_apache_pekko_cluster_ddata_LWWMap_descriptor.getNestedTypes().get(0);
+    internal_static_org_apache_pekko_cluster_ddata_LWWMap_Entry_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_LWWMap_Entry_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_LWWMap_Entry_descriptor,
         new java.lang.String[] { "StringKey", "Value", "IntKey", "LongKey", "OtherKey", });
-    internal_static_akka_cluster_ddata_PNCounterMap_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_PNCounterMap_descriptor =
       getDescriptor().getMessageTypes().get(10);
-    internal_static_akka_cluster_ddata_PNCounterMap_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_PNCounterMap_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_PNCounterMap_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_PNCounterMap_descriptor,
         new java.lang.String[] { "Keys", "Entries", });
-    internal_static_akka_cluster_ddata_PNCounterMap_Entry_descriptor =
-      internal_static_akka_cluster_ddata_PNCounterMap_descriptor.getNestedTypes().get(0);
-    internal_static_akka_cluster_ddata_PNCounterMap_Entry_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_PNCounterMap_Entry_descriptor =
+      internal_static_org_apache_pekko_cluster_ddata_PNCounterMap_descriptor.getNestedTypes().get(0);
+    internal_static_org_apache_pekko_cluster_ddata_PNCounterMap_Entry_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_PNCounterMap_Entry_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_PNCounterMap_Entry_descriptor,
         new java.lang.String[] { "StringKey", "Value", "IntKey", "LongKey", "OtherKey", });
-    internal_static_akka_cluster_ddata_ORMultiMap_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_ORMultiMap_descriptor =
       getDescriptor().getMessageTypes().get(11);
-    internal_static_akka_cluster_ddata_ORMultiMap_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_ORMultiMap_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_ORMultiMap_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_ORMultiMap_descriptor,
         new java.lang.String[] { "Keys", "Entries", "WithValueDeltas", });
-    internal_static_akka_cluster_ddata_ORMultiMap_Entry_descriptor =
-      internal_static_akka_cluster_ddata_ORMultiMap_descriptor.getNestedTypes().get(0);
-    internal_static_akka_cluster_ddata_ORMultiMap_Entry_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_ORMultiMap_Entry_descriptor =
+      internal_static_org_apache_pekko_cluster_ddata_ORMultiMap_descriptor.getNestedTypes().get(0);
+    internal_static_org_apache_pekko_cluster_ddata_ORMultiMap_Entry_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_ORMultiMap_Entry_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_ORMultiMap_Entry_descriptor,
         new java.lang.String[] { "StringKey", "Value", "IntKey", "LongKey", "OtherKey", });
     org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.getDescriptor();
   }

--- a/distributed-data/src/main/java/org/apache/pekko/cluster/ddata/protobuf/msg/ReplicatorMessages.java
+++ b/distributed-data/src/main/java/org/apache/pekko/cluster/ddata/protobuf/msg/ReplicatorMessages.java
@@ -218,13 +218,13 @@ public final class ReplicatorMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Get_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Get_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Get_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Get_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Get.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Get.Builder.class);
     }
@@ -615,13 +615,13 @@ public final class ReplicatorMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.GetOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Get_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Get_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Get_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Get_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Get.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Get.Builder.class);
       }
@@ -672,7 +672,7 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Get_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Get_descriptor;
       }
 
       @java.lang.Override
@@ -1435,13 +1435,13 @@ public final class ReplicatorMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_GetSuccess_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_GetSuccess_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_GetSuccess_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_GetSuccess_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.GetSuccess.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.GetSuccess.Builder.class);
     }
@@ -1739,13 +1739,13 @@ public final class ReplicatorMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.GetSuccessOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_GetSuccess_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_GetSuccess_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_GetSuccess_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_GetSuccess_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.GetSuccess.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.GetSuccess.Builder.class);
       }
@@ -1795,7 +1795,7 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_GetSuccess_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_GetSuccess_descriptor;
       }
 
       @java.lang.Override
@@ -2485,13 +2485,13 @@ public final class ReplicatorMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_NotFound_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_NotFound_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_NotFound_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_NotFound_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.NotFound.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.NotFound.Builder.class);
     }
@@ -2742,13 +2742,13 @@ public final class ReplicatorMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.NotFoundOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_NotFound_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_NotFound_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_NotFound_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_NotFound_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.NotFound.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.NotFound.Builder.class);
       }
@@ -2791,7 +2791,7 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_NotFound_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_NotFound_descriptor;
       }
 
       @java.lang.Override
@@ -3344,13 +3344,13 @@ public final class ReplicatorMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_GetFailure_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_GetFailure_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_GetFailure_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_GetFailure_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.GetFailure.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.GetFailure.Builder.class);
     }
@@ -3601,13 +3601,13 @@ public final class ReplicatorMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.GetFailureOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_GetFailure_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_GetFailure_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_GetFailure_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_GetFailure_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.GetFailure.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.GetFailure.Builder.class);
       }
@@ -3650,7 +3650,7 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_GetFailure_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_GetFailure_descriptor;
       }
 
       @java.lang.Override
@@ -4199,13 +4199,13 @@ public final class ReplicatorMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Subscribe_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Subscribe_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Subscribe_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Subscribe_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Subscribe.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Subscribe.Builder.class);
     }
@@ -4475,13 +4475,13 @@ public final class ReplicatorMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.SubscribeOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Subscribe_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Subscribe_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Subscribe_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Subscribe_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Subscribe.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Subscribe.Builder.class);
       }
@@ -4519,7 +4519,7 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Subscribe_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Subscribe_descriptor;
       }
 
       @java.lang.Override
@@ -5028,13 +5028,13 @@ public final class ReplicatorMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Unsubscribe_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Unsubscribe_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Unsubscribe_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Unsubscribe_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Unsubscribe.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Unsubscribe.Builder.class);
     }
@@ -5304,13 +5304,13 @@ public final class ReplicatorMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.UnsubscribeOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Unsubscribe_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Unsubscribe_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Unsubscribe_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Unsubscribe_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Unsubscribe.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Unsubscribe.Builder.class);
       }
@@ -5348,7 +5348,7 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Unsubscribe_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Unsubscribe_descriptor;
       }
 
       @java.lang.Override
@@ -5861,13 +5861,13 @@ public final class ReplicatorMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Changed_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Changed_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Changed_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Changed_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Changed.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Changed.Builder.class);
     }
@@ -6120,13 +6120,13 @@ public final class ReplicatorMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.ChangedOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Changed_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Changed_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Changed_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Changed_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Changed.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Changed.Builder.class);
       }
@@ -6169,7 +6169,7 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Changed_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Changed_descriptor;
       }
 
       @java.lang.Override
@@ -6747,13 +6747,13 @@ public final class ReplicatorMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Write_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Write_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Write_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Write_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Write.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Write.Builder.class);
     }
@@ -7068,13 +7068,13 @@ public final class ReplicatorMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.WriteOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Write_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Write_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Write_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Write_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Write.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Write.Builder.class);
       }
@@ -7119,7 +7119,7 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Write_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Write_descriptor;
       }
 
       @java.lang.Override
@@ -7711,13 +7711,13 @@ public final class ReplicatorMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Empty_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Empty_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Empty_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Empty_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Empty.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Empty.Builder.class);
     }
@@ -7875,13 +7875,13 @@ public final class ReplicatorMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.EmptyOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Empty_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Empty_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Empty_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Empty_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Empty.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Empty.Builder.class);
       }
@@ -7910,7 +7910,7 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Empty_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Empty_descriptor;
       }
 
       @java.lang.Override
@@ -8182,13 +8182,13 @@ public final class ReplicatorMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Read_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Read_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Read_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Read_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Read.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Read.Builder.class);
     }
@@ -8456,13 +8456,13 @@ public final class ReplicatorMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.ReadOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Read_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Read_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Read_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Read_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Read.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Read.Builder.class);
       }
@@ -8500,7 +8500,7 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Read_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Read_descriptor;
       }
 
       @java.lang.Override
@@ -8984,13 +8984,13 @@ public final class ReplicatorMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_ReadResult_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_ReadResult_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_ReadResult_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_ReadResult_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.ReadResult.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.ReadResult.Builder.class);
     }
@@ -9194,13 +9194,13 @@ public final class ReplicatorMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.ReadResultOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_ReadResult_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_ReadResult_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_ReadResult_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_ReadResult_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.ReadResult.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.ReadResult.Builder.class);
       }
@@ -9236,7 +9236,7 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_ReadResult_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_ReadResult_descriptor;
       }
 
       @java.lang.Override
@@ -9689,13 +9689,13 @@ public final class ReplicatorMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DataEnvelope_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DataEnvelope_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DataEnvelope_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DataEnvelope_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.Builder.class);
     }
@@ -9896,13 +9896,13 @@ public final class ReplicatorMessages {
       }
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DataEnvelope_PruningEntry_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DataEnvelope_PruningEntry_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DataEnvelope_PruningEntry_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DataEnvelope_PruningEntry_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.PruningEntry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.PruningEntry.Builder.class);
       }
@@ -10281,13 +10281,13 @@ public final class ReplicatorMessages {
           org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.PruningEntryOrBuilder {
         public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptor() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DataEnvelope_PruningEntry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DataEnvelope_PruningEntry_descriptor;
         }
 
         @java.lang.Override
         protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DataEnvelope_PruningEntry_fieldAccessorTable
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DataEnvelope_PruningEntry_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
                   org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.PruningEntry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.PruningEntry.Builder.class);
         }
@@ -10341,7 +10341,7 @@ public final class ReplicatorMessages {
         @java.lang.Override
         public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptorForType() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DataEnvelope_PruningEntry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DataEnvelope_PruningEntry_descriptor;
         }
 
         @java.lang.Override
@@ -11439,13 +11439,13 @@ public final class ReplicatorMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelopeOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DataEnvelope_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DataEnvelope_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DataEnvelope_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DataEnvelope_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.Builder.class);
       }
@@ -11495,7 +11495,7 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DataEnvelope_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DataEnvelope_descriptor;
       }
 
       @java.lang.Override
@@ -12373,13 +12373,13 @@ public final class ReplicatorMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Status_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Status_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Status_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Status_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Status.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Status.Builder.class);
     }
@@ -12496,13 +12496,13 @@ public final class ReplicatorMessages {
       }
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Status_Entry_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Status_Entry_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Status_Entry_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Status_Entry_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Status.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Status.Entry.Builder.class);
       }
@@ -12762,13 +12762,13 @@ public final class ReplicatorMessages {
           org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Status.EntryOrBuilder {
         public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptor() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Status_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Status_Entry_descriptor;
         }
 
         @java.lang.Override
         protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Status_Entry_fieldAccessorTable
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Status_Entry_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
                   org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Status.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Status.Entry.Builder.class);
         }
@@ -12801,7 +12801,7 @@ public final class ReplicatorMessages {
         @java.lang.Override
         public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptorForType() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Status_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Status_Entry_descriptor;
         }
 
         @java.lang.Override
@@ -13450,13 +13450,13 @@ public final class ReplicatorMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.StatusOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Status_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Status_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Status_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Status_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Status.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Status.Builder.class);
       }
@@ -13500,7 +13500,7 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Status_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Status_descriptor;
       }
 
       @java.lang.Override
@@ -14271,13 +14271,13 @@ public final class ReplicatorMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Gossip_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Gossip_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Gossip_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Gossip_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Gossip.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Gossip.Builder.class);
     }
@@ -14405,13 +14405,13 @@ public final class ReplicatorMessages {
       }
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Gossip_Entry_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Gossip_Entry_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Gossip_Entry_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Gossip_Entry_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Gossip.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Gossip.Entry.Builder.class);
       }
@@ -14681,13 +14681,13 @@ public final class ReplicatorMessages {
           org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Gossip.EntryOrBuilder {
         public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptor() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Gossip_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Gossip_Entry_descriptor;
         }
 
         @java.lang.Override
         protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Gossip_Entry_fieldAccessorTable
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Gossip_Entry_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
                   org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Gossip.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Gossip.Entry.Builder.class);
         }
@@ -14725,7 +14725,7 @@ public final class ReplicatorMessages {
         @java.lang.Override
         public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptorForType() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Gossip_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Gossip_Entry_descriptor;
         }
 
         @java.lang.Override
@@ -15425,13 +15425,13 @@ public final class ReplicatorMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.GossipOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Gossip_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Gossip_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Gossip_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Gossip_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Gossip.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Gossip.Builder.class);
       }
@@ -15473,7 +15473,7 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Gossip_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Gossip_descriptor;
       }
 
       @java.lang.Override
@@ -16201,13 +16201,13 @@ public final class ReplicatorMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DeltaPropagation_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DeltaPropagation_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Builder.class);
     }
@@ -16375,13 +16375,13 @@ public final class ReplicatorMessages {
       }
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_Entry_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DeltaPropagation_Entry_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_Entry_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DeltaPropagation_Entry_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder.class);
       }
@@ -16731,13 +16731,13 @@ public final class ReplicatorMessages {
           org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.EntryOrBuilder {
         public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptor() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DeltaPropagation_Entry_descriptor;
         }
 
         @java.lang.Override
         protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_Entry_fieldAccessorTable
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DeltaPropagation_Entry_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
                   org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder.class);
         }
@@ -16779,7 +16779,7 @@ public final class ReplicatorMessages {
         @java.lang.Override
         public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptorForType() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DeltaPropagation_Entry_descriptor;
         }
 
         @java.lang.Override
@@ -17569,13 +17569,13 @@ public final class ReplicatorMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagationOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DeltaPropagation_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DeltaPropagation_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Builder.class);
       }
@@ -17620,7 +17620,7 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DeltaPropagation_descriptor;
       }
 
       @java.lang.Override
@@ -18389,13 +18389,13 @@ public final class ReplicatorMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_UniqueAddress_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_UniqueAddress_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_UniqueAddress_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_UniqueAddress_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.Builder.class);
     }
@@ -18679,13 +18679,13 @@ public final class ReplicatorMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddressOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_UniqueAddress_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_UniqueAddress_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_UniqueAddress_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_UniqueAddress_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.Builder.class);
       }
@@ -18725,7 +18725,7 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_UniqueAddress_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_UniqueAddress_descriptor;
       }
 
       @java.lang.Override
@@ -19233,13 +19233,13 @@ public final class ReplicatorMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Address_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Address_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Address_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Address_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Address.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Address.Builder.class);
     }
@@ -19499,13 +19499,13 @@ public final class ReplicatorMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.AddressOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Address_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Address_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Address_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Address_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Address.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.Address.Builder.class);
       }
@@ -19538,7 +19538,7 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Address_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_Address_descriptor;
       }
 
       @java.lang.Override
@@ -19942,13 +19942,13 @@ public final class ReplicatorMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_VersionVector_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_VersionVector_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder.class);
     }
@@ -20068,13 +20068,13 @@ public final class ReplicatorMessages {
       }
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_Entry_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_VersionVector_Entry_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_Entry_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_VersionVector_Entry_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.Builder.class);
       }
@@ -20318,13 +20318,13 @@ public final class ReplicatorMessages {
           org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.EntryOrBuilder {
         public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptor() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_VersionVector_Entry_descriptor;
         }
 
         @java.lang.Override
         protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_Entry_fieldAccessorTable
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_VersionVector_Entry_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
                   org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.Builder.class);
         }
@@ -20362,7 +20362,7 @@ public final class ReplicatorMessages {
         @java.lang.Override
         public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptorForType() {
-          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_Entry_descriptor;
+          return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_VersionVector_Entry_descriptor;
         }
 
         @java.lang.Override
@@ -20906,13 +20906,13 @@ public final class ReplicatorMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_VersionVector_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_VersionVector_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder.class);
       }
@@ -20948,7 +20948,7 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_VersionVector_descriptor;
       }
 
       @java.lang.Override
@@ -21500,13 +21500,13 @@ public final class ReplicatorMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_OtherMessage_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_OtherMessage_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_OtherMessage_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_OtherMessage_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.OtherMessage.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.OtherMessage.Builder.class);
     }
@@ -21772,13 +21772,13 @@ public final class ReplicatorMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.OtherMessageOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_OtherMessage_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_OtherMessage_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_OtherMessage_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_OtherMessage_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.OtherMessage.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.OtherMessage.Builder.class);
       }
@@ -21813,7 +21813,7 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_OtherMessage_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_OtherMessage_descriptor;
       }
 
       @java.lang.Override
@@ -22219,13 +22219,13 @@ public final class ReplicatorMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_StringGSet_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_StringGSet_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_StringGSet_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_StringGSet_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.StringGSet.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.StringGSet.Builder.class);
     }
@@ -22435,13 +22435,13 @@ public final class ReplicatorMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.StringGSetOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_StringGSet_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_StringGSet_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_StringGSet_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_StringGSet_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.StringGSet.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.StringGSet.Builder.class);
       }
@@ -22472,7 +22472,7 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_StringGSet_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_StringGSet_descriptor;
       }
 
       @java.lang.Override
@@ -22883,13 +22883,13 @@ public final class ReplicatorMessages {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DurableDataEnvelope_descriptor;
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DurableDataEnvelope_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DurableDataEnvelope_fieldAccessorTable
+      return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DurableDataEnvelope_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DurableDataEnvelope.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DurableDataEnvelope.Builder.class);
     }
@@ -23149,13 +23149,13 @@ public final class ReplicatorMessages {
         org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DurableDataEnvelopeOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DurableDataEnvelope_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DurableDataEnvelope_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DurableDataEnvelope_fieldAccessorTable
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DurableDataEnvelope_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DurableDataEnvelope.class, org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.DurableDataEnvelope.Builder.class);
       }
@@ -23198,7 +23198,7 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DurableDataEnvelope_descriptor;
+        return org.apache.pekko.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_org_apache_pekko_cluster_ddata_DurableDataEnvelope_descriptor;
       }
 
       @java.lang.Override
@@ -23769,135 +23769,135 @@ public final class ReplicatorMessages {
   }
 
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_Get_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_Get_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_Get_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_Get_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_GetSuccess_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_GetSuccess_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_GetSuccess_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_GetSuccess_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_NotFound_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_NotFound_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_NotFound_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_NotFound_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_GetFailure_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_GetFailure_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_GetFailure_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_GetFailure_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_Subscribe_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_Subscribe_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_Subscribe_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_Subscribe_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_Unsubscribe_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_Unsubscribe_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_Unsubscribe_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_Unsubscribe_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_Changed_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_Changed_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_Changed_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_Changed_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_Write_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_Write_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_Write_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_Write_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_Empty_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_Empty_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_Empty_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_Empty_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_Read_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_Read_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_Read_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_Read_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_ReadResult_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_ReadResult_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_ReadResult_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_ReadResult_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_DataEnvelope_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_DataEnvelope_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_DataEnvelope_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_DataEnvelope_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_DataEnvelope_PruningEntry_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_DataEnvelope_PruningEntry_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_DataEnvelope_PruningEntry_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_DataEnvelope_PruningEntry_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_Status_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_Status_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_Status_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_Status_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_Status_Entry_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_Status_Entry_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_Status_Entry_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_Status_Entry_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_Gossip_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_Gossip_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_Gossip_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_Gossip_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_Gossip_Entry_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_Gossip_Entry_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_Gossip_Entry_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_Gossip_Entry_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_DeltaPropagation_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_DeltaPropagation_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_DeltaPropagation_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_DeltaPropagation_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_DeltaPropagation_Entry_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_DeltaPropagation_Entry_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_DeltaPropagation_Entry_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_DeltaPropagation_Entry_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_UniqueAddress_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_UniqueAddress_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_UniqueAddress_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_UniqueAddress_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_Address_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_Address_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_Address_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_Address_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_VersionVector_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_VersionVector_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_VersionVector_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_VersionVector_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_VersionVector_Entry_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_VersionVector_Entry_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_VersionVector_Entry_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_VersionVector_Entry_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_OtherMessage_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_OtherMessage_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_OtherMessage_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_OtherMessage_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_StringGSet_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_StringGSet_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_StringGSet_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_StringGSet_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_DurableDataEnvelope_descriptor;
+    internal_static_org_apache_pekko_cluster_ddata_DurableDataEnvelope_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_cluster_ddata_DurableDataEnvelope_fieldAccessorTable;
+      internal_static_org_apache_pekko_cluster_ddata_DurableDataEnvelope_fieldAccessorTable;
 
   public static org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor
       getDescriptor() {
@@ -23907,236 +23907,247 @@ public final class ReplicatorMessages {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\030ReplicatorMessages.proto\022\022org.apache.pekko.cluster" +
-      ".ddata\"\307\001\n\003Get\022-\n\003key\030\001 \002(\0132 .pekko.clust" +
-      "er.ddata.OtherMessage\022\023\n\013consistency\030\002 \002" +
-      "(\021\022\017\n\007timeout\030\003 \002(\r\0221\n\007request\030\004 \001(\0132 .a" +
-      "kka.cluster.ddata.OtherMessage\022\031\n\021consis" +
-      "tencyMinCap\030\005 \001(\005\022\035\n\025consistencyAddition" +
-      "al\030\006 \001(\005\"\236\001\n\nGetSuccess\022-\n\003key\030\001 \002(\0132 .a" +
-      "kka.cluster.ddata.OtherMessage\022.\n\004data\030\002" +
-      " \002(\0132 .org.apache.pekko.cluster.ddata.OtherMessage\0221" +
-      "\n\007request\030\004 \001(\0132 .org.apache.pekko.cluster.ddata.Oth" +
-      "erMessage\"l\n\010NotFound\022-\n\003key\030\001 \002(\0132 .akk" +
-      "a.cluster.ddata.OtherMessage\0221\n\007request\030" +
-      "\002 \001(\0132 .org.apache.pekko.cluster.ddata.OtherMessage\"" +
-      "n\n\nGetFailure\022-\n\003key\030\001 \002(\0132 .pekko.cluste" +
-      "r.ddata.OtherMessage\0221\n\007request\030\002 \001(\0132 ." +
-      "org.apache.pekko.cluster.ddata.OtherMessage\"G\n\tSubsc" +
-      "ribe\022-\n\003key\030\001 \002(\0132 .org.apache.pekko.cluster.ddata.O" +
-      "therMessage\022\013\n\003ref\030\002 \002(\t\"I\n\013Unsubscribe\022" +
-      "-\n\003key\030\001 \002(\0132 .org.apache.pekko.cluster.ddata.OtherM" +
-      "essage\022\013\n\003ref\030\002 \002(\t\"h\n\007Changed\022-\n\003key\030\001 " +
-      "\002(\0132 .org.apache.pekko.cluster.ddata.OtherMessage\022.\n" +
-      "\004data\030\002 \002(\0132 .org.apache.pekko.cluster.ddata.OtherMe" +
-      "ssage\"}\n\005Write\022\013\n\003key\030\001 \002(\t\0222\n\010envelope\030" +
-      "\002 \002(\0132 .org.apache.pekko.cluster.ddata.DataEnvelope\022" +
-      "3\n\010fromNode\030\003 \001(\0132!.org.apache.pekko.cluster.ddata.U" +
-      "niqueAddress\"\007\n\005Empty\"H\n\004Read\022\013\n\003key\030\001 \002" +
-      "(\t\0223\n\010fromNode\030\002 \001(\0132!.org.apache.pekko.cluster.ddat" +
-      "a.UniqueAddress\"@\n\nReadResult\0222\n\010envelop" +
-      "e\030\001 \001(\0132 .org.apache.pekko.cluster.ddata.DataEnvelop" +
-      "e\"\221\003\n\014DataEnvelope\022.\n\004data\030\001 \002(\0132 .akka." +
-      "cluster.ddata.OtherMessage\022>\n\007pruning\030\002 " +
-      "\003(\0132-.org.apache.pekko.cluster.ddata.DataEnvelope.Pr" +
-      "uningEntry\0228\n\rdeltaVersions\030\003 \001(\0132!.akka" +
-      ".cluster.ddata.VersionVector\032\326\001\n\014Pruning" +
-      "Entry\0229\n\016removedAddress\030\001 \002(\0132!.pekko.clu" +
-      "ster.ddata.UniqueAddress\0227\n\014ownerAddress" +
-      "\030\002 \002(\0132!.org.apache.pekko.cluster.ddata.UniqueAddres" +
-      "s\022\021\n\tperformed\030\003 \002(\010\022)\n\004seen\030\004 \003(\0132\033.akk" +
-      "a.cluster.ddata.Address\022\024\n\014obsoleteTime\030" +
-      "\005 \001(\022\"\257\001\n\006Status\022\r\n\005chunk\030\001 \002(\r\022\021\n\ttotCh" +
-      "unks\030\002 \002(\r\0221\n\007entries\030\003 \003(\0132 .pekko.clust" +
-      "er.ddata.Status.Entry\022\023\n\013toSystemUid\030\004 \001" +
-      "(\020\022\025\n\rfromSystemUid\030\005 \001(\020\032$\n\005Entry\022\013\n\003ke" +
-      "y\030\001 \002(\t\022\016\n\006digest\030\002 \002(\014\"\303\001\n\006Gossip\022\020\n\010se" +
-      "ndBack\030\001 \002(\010\0221\n\007entries\030\002 \003(\0132 .pekko.clu" +
-      "ster.ddata.Gossip.Entry\022\023\n\013toSystemUid\030\003" +
-      " \001(\020\022\025\n\rfromSystemUid\030\004 \001(\020\032H\n\005Entry\022\013\n\003" +
-      "key\030\001 \002(\t\0222\n\010envelope\030\002 \002(\0132 .pekko.clust" +
-      "er.ddata.DataEnvelope\"\201\002\n\020DeltaPropagati" +
-      "on\0223\n\010fromNode\030\001 \002(\0132!.org.apache.pekko.cluster.ddat" +
-      "a.UniqueAddress\022;\n\007entries\030\002 \003(\0132*.akka." +
-      "cluster.ddata.DeltaPropagation.Entry\022\r\n\005" +
-      "reply\030\003 \001(\010\032l\n\005Entry\022\013\n\003key\030\001 \002(\t\0222\n\010env" +
-      "elope\030\002 \002(\0132 .org.apache.pekko.cluster.ddata.DataEnv" +
-      "elope\022\021\n\tfromSeqNr\030\003 \002(\003\022\017\n\007toSeqNr\030\004 \001(" +
-      "\003\"X\n\rUniqueAddress\022,\n\007address\030\001 \002(\0132\033.ak" +
-      "ka.cluster.ddata.Address\022\013\n\003uid\030\002 \002(\017\022\014\n" +
-      "\004uid2\030\003 \001(\017\")\n\007Address\022\020\n\010hostname\030\001 \002(\t" +
-      "\022\014\n\004port\030\002 \002(\r\"\224\001\n\rVersionVector\0228\n\007entr" +
-      "ies\030\001 \003(\0132\'.org.apache.pekko.cluster.ddata.VersionVe" +
-      "ctor.Entry\032I\n\005Entry\022/\n\004node\030\001 \002(\0132!.akka" +
+      "\n\030ReplicatorMessages.proto\022\036org.apache.p" +
+      "ekko.cluster.ddata\"\337\001\n\003Get\0229\n\003key\030\001 \002(\0132" +
+      ",.org.apache.pekko.cluster.ddata.OtherMe" +
+      "ssage\022\023\n\013consistency\030\002 \002(\021\022\017\n\007timeout\030\003 " +
+      "\002(\r\022=\n\007request\030\004 \001(\0132,.org.apache.pekko." +
+      "cluster.ddata.OtherMessage\022\031\n\021consistenc" +
+      "yMinCap\030\005 \001(\005\022\035\n\025consistencyAdditional\030\006" +
+      " \001(\005\"\302\001\n\nGetSuccess\0229\n\003key\030\001 \002(\0132,.org.a" +
+      "pache.pekko.cluster.ddata.OtherMessage\022:" +
+      "\n\004data\030\002 \002(\0132,.org.apache.pekko.cluster." +
+      "ddata.OtherMessage\022=\n\007request\030\004 \001(\0132,.or" +
+      "g.apache.pekko.cluster.ddata.OtherMessag" +
+      "e\"\204\001\n\010NotFound\0229\n\003key\030\001 \002(\0132,.org.apache" +
+      ".pekko.cluster.ddata.OtherMessage\022=\n\007req" +
+      "uest\030\002 \001(\0132,.org.apache.pekko.cluster.dd" +
+      "ata.OtherMessage\"\206\001\n\nGetFailure\0229\n\003key\030\001" +
+      " \002(\0132,.org.apache.pekko.cluster.ddata.Ot" +
+      "herMessage\022=\n\007request\030\002 \001(\0132,.org.apache" +
+      ".pekko.cluster.ddata.OtherMessage\"S\n\tSub" +
+      "scribe\0229\n\003key\030\001 \002(\0132,.org.apache.pekko.c" +
+      "luster.ddata.OtherMessage\022\013\n\003ref\030\002 \002(\t\"U" +
+      "\n\013Unsubscribe\0229\n\003key\030\001 \002(\0132,.org.apache." +
+      "pekko.cluster.ddata.OtherMessage\022\013\n\003ref\030" +
+      "\002 \002(\t\"\200\001\n\007Changed\0229\n\003key\030\001 \002(\0132,.org.apa" +
+      "che.pekko.cluster.ddata.OtherMessage\022:\n\004" +
+      "data\030\002 \002(\0132,.org.apache.pekko.cluster.dd" +
+      "ata.OtherMessage\"\225\001\n\005Write\022\013\n\003key\030\001 \002(\t\022" +
+      ">\n\010envelope\030\002 \002(\0132,.org.apache.pekko.clu" +
+      "ster.ddata.DataEnvelope\022?\n\010fromNode\030\003 \001(" +
+      "\0132-.org.apache.pekko.cluster.ddata.Uniqu" +
+      "eAddress\"\007\n\005Empty\"T\n\004Read\022\013\n\003key\030\001 \002(\t\022?" +
+      "\n\010fromNode\030\002 \001(\0132-.org.apache.pekko.clus" +
+      "ter.ddata.UniqueAddress\"L\n\nReadResult\022>\n" +
+      "\010envelope\030\001 \001(\0132,.org.apache.pekko.clust" +
+      "er.ddata.DataEnvelope\"\331\003\n\014DataEnvelope\022:" +
+      "\n\004data\030\001 \002(\0132,.org.apache.pekko.cluster." +
+      "ddata.OtherMessage\022J\n\007pruning\030\002 \003(\01329.or" +
+      "g.apache.pekko.cluster.ddata.DataEnvelop" +
+      "e.PruningEntry\022D\n\rdeltaVersions\030\003 \001(\0132-." +
+      "org.apache.pekko.cluster.ddata.VersionVe" +
+      "ctor\032\372\001\n\014PruningEntry\022E\n\016removedAddress\030" +
+      "\001 \002(\0132-.org.apache.pekko.cluster.ddata.U" +
+      "niqueAddress\022C\n\014ownerAddress\030\002 \002(\0132-.org" +
+      ".apache.pekko.cluster.ddata.UniqueAddres" +
+      "s\022\021\n\tperformed\030\003 \002(\010\0225\n\004seen\030\004 \003(\0132\'.org" +
+      ".apache.pekko.cluster.ddata.Address\022\024\n\014o" +
+      "bsoleteTime\030\005 \001(\022\"\273\001\n\006Status\022\r\n\005chunk\030\001 " +
+      "\002(\r\022\021\n\ttotChunks\030\002 \002(\r\022=\n\007entries\030\003 \003(\0132" +
+      ",.org.apache.pekko.cluster.ddata.Status." +
+      "Entry\022\023\n\013toSystemUid\030\004 \001(\020\022\025\n\rfromSystem" +
+      "Uid\030\005 \001(\020\032$\n\005Entry\022\013\n\003key\030\001 \002(\t\022\016\n\006diges" +
+      "t\030\002 \002(\014\"\333\001\n\006Gossip\022\020\n\010sendBack\030\001 \002(\010\022=\n\007" +
+      "entries\030\002 \003(\0132,.org.apache.pekko.cluster" +
+      ".ddata.Gossip.Entry\022\023\n\013toSystemUid\030\003 \001(\020" +
+      "\022\025\n\rfromSystemUid\030\004 \001(\020\032T\n\005Entry\022\013\n\003key\030" +
+      "\001 \002(\t\022>\n\010envelope\030\002 \002(\0132,.org.apache.pek" +
+      "ko.cluster.ddata.DataEnvelope\"\245\002\n\020DeltaP" +
+      "ropagation\022?\n\010fromNode\030\001 \002(\0132-.org.apach" +
+      "e.pekko.cluster.ddata.UniqueAddress\022G\n\007e" +
+      "ntries\030\002 \003(\01326.org.apache.pekko.cluster." +
+      "ddata.DeltaPropagation.Entry\022\r\n\005reply\030\003 " +
+      "\001(\010\032x\n\005Entry\022\013\n\003key\030\001 \002(\t\022>\n\010envelope\030\002 " +
+      "\002(\0132,.org.apache.pekko.cluster.ddata.Dat" +
+      "aEnvelope\022\021\n\tfromSeqNr\030\003 \002(\003\022\017\n\007toSeqNr\030" +
+      "\004 \001(\003\"d\n\rUniqueAddress\0228\n\007address\030\001 \002(\0132" +
+      "\'.org.apache.pekko.cluster.ddata.Address" +
+      "\022\013\n\003uid\030\002 \002(\017\022\014\n\004uid2\030\003 \001(\017\")\n\007Address\022\020" +
+      "\n\010hostname\030\001 \002(\t\022\014\n\004port\030\002 \002(\r\"\254\001\n\rVersi" +
+      "onVector\022D\n\007entries\030\001 \003(\01323.org.apache.p" +
+      "ekko.cluster.ddata.VersionVector.Entry\032U" +
+      "\n\005Entry\022;\n\004node\030\001 \002(\0132-.org.apache.pekko" +
       ".cluster.ddata.UniqueAddress\022\017\n\007version\030" +
       "\002 \002(\003\"V\n\014OtherMessage\022\027\n\017enclosedMessage" +
       "\030\001 \002(\014\022\024\n\014serializerId\030\002 \002(\005\022\027\n\017messageM" +
       "anifest\030\004 \001(\014\"\036\n\nStringGSet\022\020\n\010elements\030" +
-      "\001 \003(\t\"\205\001\n\023DurableDataEnvelope\022.\n\004data\030\001 " +
-      "\002(\0132 .org.apache.pekko.cluster.ddata.OtherMessage\022>\n" +
-      "\007pruning\030\002 \003(\0132-.org.apache.pekko.cluster.ddata.Data" +
-      "Envelope.PruningEntryB#\n\037org.apache.pekko.cluster.dd" +
-      "ata.protobuf.msgH\001"
+      "\001 \003(\t\"\235\001\n\023DurableDataEnvelope\022:\n\004data\030\001 " +
+      "\002(\0132,.org.apache.pekko.cluster.ddata.Oth" +
+      "erMessage\022J\n\007pruning\030\002 \003(\01329.org.apache." +
+      "pekko.cluster.ddata.DataEnvelope.Pruning" +
+      "EntryB/\n+org.apache.pekko.cluster.ddata." +
+      "protobuf.msgH\001"
     };
     descriptor = org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor[] {
         });
-    internal_static_akka_cluster_ddata_Get_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_Get_descriptor =
       getDescriptor().getMessageTypes().get(0);
-    internal_static_akka_cluster_ddata_Get_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_Get_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_Get_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_Get_descriptor,
         new java.lang.String[] { "Key", "Consistency", "Timeout", "Request", "ConsistencyMinCap", "ConsistencyAdditional", });
-    internal_static_akka_cluster_ddata_GetSuccess_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_GetSuccess_descriptor =
       getDescriptor().getMessageTypes().get(1);
-    internal_static_akka_cluster_ddata_GetSuccess_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_GetSuccess_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_GetSuccess_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_GetSuccess_descriptor,
         new java.lang.String[] { "Key", "Data", "Request", });
-    internal_static_akka_cluster_ddata_NotFound_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_NotFound_descriptor =
       getDescriptor().getMessageTypes().get(2);
-    internal_static_akka_cluster_ddata_NotFound_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_NotFound_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_NotFound_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_NotFound_descriptor,
         new java.lang.String[] { "Key", "Request", });
-    internal_static_akka_cluster_ddata_GetFailure_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_GetFailure_descriptor =
       getDescriptor().getMessageTypes().get(3);
-    internal_static_akka_cluster_ddata_GetFailure_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_GetFailure_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_GetFailure_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_GetFailure_descriptor,
         new java.lang.String[] { "Key", "Request", });
-    internal_static_akka_cluster_ddata_Subscribe_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_Subscribe_descriptor =
       getDescriptor().getMessageTypes().get(4);
-    internal_static_akka_cluster_ddata_Subscribe_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_Subscribe_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_Subscribe_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_Subscribe_descriptor,
         new java.lang.String[] { "Key", "Ref", });
-    internal_static_akka_cluster_ddata_Unsubscribe_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_Unsubscribe_descriptor =
       getDescriptor().getMessageTypes().get(5);
-    internal_static_akka_cluster_ddata_Unsubscribe_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_Unsubscribe_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_Unsubscribe_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_Unsubscribe_descriptor,
         new java.lang.String[] { "Key", "Ref", });
-    internal_static_akka_cluster_ddata_Changed_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_Changed_descriptor =
       getDescriptor().getMessageTypes().get(6);
-    internal_static_akka_cluster_ddata_Changed_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_Changed_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_Changed_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_Changed_descriptor,
         new java.lang.String[] { "Key", "Data", });
-    internal_static_akka_cluster_ddata_Write_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_Write_descriptor =
       getDescriptor().getMessageTypes().get(7);
-    internal_static_akka_cluster_ddata_Write_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_Write_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_Write_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_Write_descriptor,
         new java.lang.String[] { "Key", "Envelope", "FromNode", });
-    internal_static_akka_cluster_ddata_Empty_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_Empty_descriptor =
       getDescriptor().getMessageTypes().get(8);
-    internal_static_akka_cluster_ddata_Empty_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_Empty_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_Empty_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_Empty_descriptor,
         new java.lang.String[] { });
-    internal_static_akka_cluster_ddata_Read_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_Read_descriptor =
       getDescriptor().getMessageTypes().get(9);
-    internal_static_akka_cluster_ddata_Read_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_Read_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_Read_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_Read_descriptor,
         new java.lang.String[] { "Key", "FromNode", });
-    internal_static_akka_cluster_ddata_ReadResult_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_ReadResult_descriptor =
       getDescriptor().getMessageTypes().get(10);
-    internal_static_akka_cluster_ddata_ReadResult_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_ReadResult_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_ReadResult_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_ReadResult_descriptor,
         new java.lang.String[] { "Envelope", });
-    internal_static_akka_cluster_ddata_DataEnvelope_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_DataEnvelope_descriptor =
       getDescriptor().getMessageTypes().get(11);
-    internal_static_akka_cluster_ddata_DataEnvelope_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_DataEnvelope_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_DataEnvelope_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_DataEnvelope_descriptor,
         new java.lang.String[] { "Data", "Pruning", "DeltaVersions", });
-    internal_static_akka_cluster_ddata_DataEnvelope_PruningEntry_descriptor =
-      internal_static_akka_cluster_ddata_DataEnvelope_descriptor.getNestedTypes().get(0);
-    internal_static_akka_cluster_ddata_DataEnvelope_PruningEntry_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_DataEnvelope_PruningEntry_descriptor =
+      internal_static_org_apache_pekko_cluster_ddata_DataEnvelope_descriptor.getNestedTypes().get(0);
+    internal_static_org_apache_pekko_cluster_ddata_DataEnvelope_PruningEntry_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_DataEnvelope_PruningEntry_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_DataEnvelope_PruningEntry_descriptor,
         new java.lang.String[] { "RemovedAddress", "OwnerAddress", "Performed", "Seen", "ObsoleteTime", });
-    internal_static_akka_cluster_ddata_Status_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_Status_descriptor =
       getDescriptor().getMessageTypes().get(12);
-    internal_static_akka_cluster_ddata_Status_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_Status_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_Status_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_Status_descriptor,
         new java.lang.String[] { "Chunk", "TotChunks", "Entries", "ToSystemUid", "FromSystemUid", });
-    internal_static_akka_cluster_ddata_Status_Entry_descriptor =
-      internal_static_akka_cluster_ddata_Status_descriptor.getNestedTypes().get(0);
-    internal_static_akka_cluster_ddata_Status_Entry_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_Status_Entry_descriptor =
+      internal_static_org_apache_pekko_cluster_ddata_Status_descriptor.getNestedTypes().get(0);
+    internal_static_org_apache_pekko_cluster_ddata_Status_Entry_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_Status_Entry_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_Status_Entry_descriptor,
         new java.lang.String[] { "Key", "Digest", });
-    internal_static_akka_cluster_ddata_Gossip_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_Gossip_descriptor =
       getDescriptor().getMessageTypes().get(13);
-    internal_static_akka_cluster_ddata_Gossip_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_Gossip_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_Gossip_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_Gossip_descriptor,
         new java.lang.String[] { "SendBack", "Entries", "ToSystemUid", "FromSystemUid", });
-    internal_static_akka_cluster_ddata_Gossip_Entry_descriptor =
-      internal_static_akka_cluster_ddata_Gossip_descriptor.getNestedTypes().get(0);
-    internal_static_akka_cluster_ddata_Gossip_Entry_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_Gossip_Entry_descriptor =
+      internal_static_org_apache_pekko_cluster_ddata_Gossip_descriptor.getNestedTypes().get(0);
+    internal_static_org_apache_pekko_cluster_ddata_Gossip_Entry_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_Gossip_Entry_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_Gossip_Entry_descriptor,
         new java.lang.String[] { "Key", "Envelope", });
-    internal_static_akka_cluster_ddata_DeltaPropagation_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_DeltaPropagation_descriptor =
       getDescriptor().getMessageTypes().get(14);
-    internal_static_akka_cluster_ddata_DeltaPropagation_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_DeltaPropagation_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_DeltaPropagation_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_DeltaPropagation_descriptor,
         new java.lang.String[] { "FromNode", "Entries", "Reply", });
-    internal_static_akka_cluster_ddata_DeltaPropagation_Entry_descriptor =
-      internal_static_akka_cluster_ddata_DeltaPropagation_descriptor.getNestedTypes().get(0);
-    internal_static_akka_cluster_ddata_DeltaPropagation_Entry_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_DeltaPropagation_Entry_descriptor =
+      internal_static_org_apache_pekko_cluster_ddata_DeltaPropagation_descriptor.getNestedTypes().get(0);
+    internal_static_org_apache_pekko_cluster_ddata_DeltaPropagation_Entry_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_DeltaPropagation_Entry_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_DeltaPropagation_Entry_descriptor,
         new java.lang.String[] { "Key", "Envelope", "FromSeqNr", "ToSeqNr", });
-    internal_static_akka_cluster_ddata_UniqueAddress_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_UniqueAddress_descriptor =
       getDescriptor().getMessageTypes().get(15);
-    internal_static_akka_cluster_ddata_UniqueAddress_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_UniqueAddress_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_UniqueAddress_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_UniqueAddress_descriptor,
         new java.lang.String[] { "Address", "Uid", "Uid2", });
-    internal_static_akka_cluster_ddata_Address_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_Address_descriptor =
       getDescriptor().getMessageTypes().get(16);
-    internal_static_akka_cluster_ddata_Address_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_Address_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_Address_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_Address_descriptor,
         new java.lang.String[] { "Hostname", "Port", });
-    internal_static_akka_cluster_ddata_VersionVector_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_VersionVector_descriptor =
       getDescriptor().getMessageTypes().get(17);
-    internal_static_akka_cluster_ddata_VersionVector_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_VersionVector_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_VersionVector_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_VersionVector_descriptor,
         new java.lang.String[] { "Entries", });
-    internal_static_akka_cluster_ddata_VersionVector_Entry_descriptor =
-      internal_static_akka_cluster_ddata_VersionVector_descriptor.getNestedTypes().get(0);
-    internal_static_akka_cluster_ddata_VersionVector_Entry_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_VersionVector_Entry_descriptor =
+      internal_static_org_apache_pekko_cluster_ddata_VersionVector_descriptor.getNestedTypes().get(0);
+    internal_static_org_apache_pekko_cluster_ddata_VersionVector_Entry_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_VersionVector_Entry_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_VersionVector_Entry_descriptor,
         new java.lang.String[] { "Node", "Version", });
-    internal_static_akka_cluster_ddata_OtherMessage_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_OtherMessage_descriptor =
       getDescriptor().getMessageTypes().get(18);
-    internal_static_akka_cluster_ddata_OtherMessage_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_OtherMessage_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_OtherMessage_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_OtherMessage_descriptor,
         new java.lang.String[] { "EnclosedMessage", "SerializerId", "MessageManifest", });
-    internal_static_akka_cluster_ddata_StringGSet_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_StringGSet_descriptor =
       getDescriptor().getMessageTypes().get(19);
-    internal_static_akka_cluster_ddata_StringGSet_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_StringGSet_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_StringGSet_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_StringGSet_descriptor,
         new java.lang.String[] { "Elements", });
-    internal_static_akka_cluster_ddata_DurableDataEnvelope_descriptor =
+    internal_static_org_apache_pekko_cluster_ddata_DurableDataEnvelope_descriptor =
       getDescriptor().getMessageTypes().get(20);
-    internal_static_akka_cluster_ddata_DurableDataEnvelope_fieldAccessorTable = new
+    internal_static_org_apache_pekko_cluster_ddata_DurableDataEnvelope_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_akka_cluster_ddata_DurableDataEnvelope_descriptor,
+        internal_static_org_apache_pekko_cluster_ddata_DurableDataEnvelope_descriptor,
         new java.lang.String[] { "Data", "Pruning", });
   }
 

--- a/multi-node-testkit/src/main/java/org/apache/pekko/remote/testconductor/TestConductorProtocol.java
+++ b/multi-node-testkit/src/main/java/org/apache/pekko/remote/testconductor/TestConductorProtocol.java
@@ -6521,7 +6521,8 @@ public final class TestConductorProtocol {
       "\n\010Throttle\020\001\022\016\n\nDisconnect\020\002\022\t\n\005Abort\020\003\022" +
       "\010\n\004Exit\020\004\022\014\n\010Shutdown\020\005\022\022\n\016ShutdownAbrup" +
       "t\020\006*,\n\tDirection\022\010\n\004Send\020\001\022\013\n\007Receive\020\002\022" +
-      "\010\n\004Both\020\003B\035\n\031org.apache.pekko.remote.testconductorH\001"
+      "\010\n\004Both\020\003B)\n%org.apache.pekko.remote.tes" +
+      "tconductorH\001"
     };
     descriptor = org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/persistence-query/src/main/java/org/apache/pekko/persistence/query/internal/protobuf/QueryMessages.java
+++ b/persistence-query/src/main/java/org/apache/pekko/persistence/query/internal/protobuf/QueryMessages.java
@@ -337,14 +337,14 @@ public final class QueryMessages {
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return org.apache.pekko.persistence.query.internal.protobuf.QueryMessages
-          .internal_static_akka_persistence_query_EventEnvelope_descriptor;
+          .internal_static_org_apache_pekko_persistence_query_EventEnvelope_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.pekko.persistence.query.internal.protobuf.QueryMessages
-          .internal_static_akka_persistence_query_EventEnvelope_fieldAccessorTable
+          .internal_static_org_apache_pekko_persistence_query_EventEnvelope_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               org.apache.pekko.persistence.query.internal.protobuf.QueryMessages.EventEnvelope
                   .class,
@@ -1019,14 +1019,14 @@ public final class QueryMessages {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return org.apache.pekko.persistence.query.internal.protobuf.QueryMessages
-            .internal_static_akka_persistence_query_EventEnvelope_descriptor;
+            .internal_static_org_apache_pekko_persistence_query_EventEnvelope_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.pekko.persistence.query.internal.protobuf.QueryMessages
-            .internal_static_akka_persistence_query_EventEnvelope_fieldAccessorTable
+            .internal_static_org_apache_pekko_persistence_query_EventEnvelope_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 org.apache.pekko.persistence.query.internal.protobuf.QueryMessages.EventEnvelope
                     .class,
@@ -1088,7 +1088,7 @@ public final class QueryMessages {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor getDescriptorForType() {
         return org.apache.pekko.persistence.query.internal.protobuf.QueryMessages
-            .internal_static_akka_persistence_query_EventEnvelope_descriptor;
+            .internal_static_org_apache_pekko_persistence_query_EventEnvelope_descriptor;
       }
 
       @java.lang.Override
@@ -2089,9 +2089,9 @@ public final class QueryMessages {
   }
 
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-      internal_static_akka_persistence_query_EventEnvelope_descriptor;
+      internal_static_org_apache_pekko_persistence_query_EventEnvelope_descriptor;
   private static final org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_akka_persistence_query_EventEnvelope_fieldAccessorTable;
+      internal_static_org_apache_pekko_persistence_query_EventEnvelope_fieldAccessorTable;
 
   public static org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor getDescriptor() {
     return descriptor;
@@ -2101,15 +2101,15 @@ public final class QueryMessages {
 
   static {
     java.lang.String[] descriptorData = {
-      "\n\023QueryMessages.proto\022\026org.apache.pekko.persistence."
-          + "query\032\026ContainerFormats.proto\"\321\001\n\rEventE"
-          + "nvelope\022\026\n\016persistence_id\030\001 \002(\t\022\023\n\013entit"
-          + "y_type\030\002 \002(\t\022\r\n\005slice\030\003 \002(\005\022\023\n\013sequence_"
-          + "nr\030\004 \002(\003\022\021\n\ttimestamp\030\005 \002(\003\022\016\n\006offset\030\006 "
-          + "\002(\t\022\027\n\017offset_manifest\030\007 \002(\t\022\027\n\005event\030\010 "
-          + "\001(\0132\010.Payload\022\032\n\010metadata\030\t \001(\0132\010.Payloa"
-          + "dB,\n(org.apache.pekko.persistence.query.internal.pro"
-          + "tobufH\001"
+      "\n\023QueryMessages.proto\022\"org.apache.pekko."
+          + "persistence.query\032\026ContainerFormats.prot"
+          + "o\"\321\001\n\rEventEnvelope\022\026\n\016persistence_id\030\001 "
+          + "\002(\t\022\023\n\013entity_type\030\002 \002(\t\022\r\n\005slice\030\003 \002(\005\022"
+          + "\023\n\013sequence_nr\030\004 \002(\003\022\021\n\ttimestamp\030\005 \002(\003\022"
+          + "\016\n\006offset\030\006 \002(\t\022\027\n\017offset_manifest\030\007 \002(\t"
+          + "\022\027\n\005event\030\010 \001(\0132\010.Payload\022\032\n\010metadata\030\t "
+          + "\001(\0132\010.PayloadB8\n4org.apache.pekko.persis"
+          + "tence.query.internal.protobufH\001"
     };
     descriptor =
         org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor
@@ -2118,11 +2118,11 @@ public final class QueryMessages {
                 new org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor[] {
                   org.apache.pekko.remote.ContainerFormats.getDescriptor(),
                 });
-    internal_static_akka_persistence_query_EventEnvelope_descriptor =
+    internal_static_org_apache_pekko_persistence_query_EventEnvelope_descriptor =
         getDescriptor().getMessageTypes().get(0);
-    internal_static_akka_persistence_query_EventEnvelope_fieldAccessorTable =
+    internal_static_org_apache_pekko_persistence_query_EventEnvelope_fieldAccessorTable =
         new org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-            internal_static_akka_persistence_query_EventEnvelope_descriptor,
+            internal_static_org_apache_pekko_persistence_query_EventEnvelope_descriptor,
             new java.lang.String[] {
               "PersistenceId",
               "EntityType",

--- a/persistence-typed/src/main/java/org/apache/pekko/persistence/typed/serialization/ReplicatedEventSourcing.java
+++ b/persistence-typed/src/main/java/org/apache/pekko/persistence/typed/serialization/ReplicatedEventSourcing.java
@@ -13046,8 +13046,8 @@ public final class ReplicatedEventSourcing {
           + "\022\031\n\007payload\030\003 \001(\0132\010.Payload\022\021\n\ttimestamp"
           + "\030\004 \001(\003\0223\n\010metadata\030\005 \001(\0132!.ReplicatedPub"
           + "lishedEventMetaData*-\n\014ORSetDeltaOp\022\007\n\003A"
-          + "dd\020\000\022\n\n\006Remove\020\001\022\010\n\004Full\020\002B(\n$org.apache.pekko.persi"
-          + "stence.typed.serializationH\001"
+          + "dd\020\000\022\n\n\006Remove\020\001\022\010\n\004Full\020\002B4\n0org.apache"
+          + ".pekko.persistence.typed.serializationH\001"
     };
     descriptor =
         org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor

--- a/persistence/src/main/java/org/apache/pekko/persistence/serialization/MessageFormats.java
+++ b/persistence/src/main/java/org/apache/pekko/persistence/serialization/MessageFormats.java
@@ -18,96 +18,82 @@ package org.apache.pekko.persistence.serialization;
 
 public final class MessageFormats {
   private MessageFormats() {}
-
   public static void registerAllExtensions(
-      org.apache.pekko.protobufv3.internal.ExtensionRegistryLite registry) {}
+      org.apache.pekko.protobufv3.internal.ExtensionRegistryLite registry) {
+  }
 
   public static void registerAllExtensions(
       org.apache.pekko.protobufv3.internal.ExtensionRegistry registry) {
-    registerAllExtensions((org.apache.pekko.protobufv3.internal.ExtensionRegistryLite) registry);
+    registerAllExtensions(
+        (org.apache.pekko.protobufv3.internal.ExtensionRegistryLite) registry);
   }
-
-  public interface PersistentMessageOrBuilder
-      extends
+  public interface PersistentMessageOrBuilder extends
       // @@protoc_insertion_point(interface_extends:PersistentMessage)
       org.apache.pekko.protobufv3.internal.MessageOrBuilder {
 
     /**
      * <code>optional .PersistentPayload payload = 1;</code>
-     *
      * @return Whether the payload field is set.
      */
     boolean hasPayload();
     /**
      * <code>optional .PersistentPayload payload = 1;</code>
-     *
      * @return The payload.
      */
     org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload getPayload();
-    /** <code>optional .PersistentPayload payload = 1;</code> */
-    org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder
-        getPayloadOrBuilder();
+    /**
+     * <code>optional .PersistentPayload payload = 1;</code>
+     */
+    org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder getPayloadOrBuilder();
 
     /**
      * <code>optional int64 sequenceNr = 2;</code>
-     *
      * @return Whether the sequenceNr field is set.
      */
     boolean hasSequenceNr();
     /**
      * <code>optional int64 sequenceNr = 2;</code>
-     *
      * @return The sequenceNr.
      */
     long getSequenceNr();
 
     /**
      * <code>optional string persistenceId = 3;</code>
-     *
      * @return Whether the persistenceId field is set.
      */
     boolean hasPersistenceId();
     /**
      * <code>optional string persistenceId = 3;</code>
-     *
      * @return The persistenceId.
      */
     java.lang.String getPersistenceId();
     /**
      * <code>optional string persistenceId = 3;</code>
-     *
      * @return The bytes for persistenceId.
      */
-    org.apache.pekko.protobufv3.internal.ByteString getPersistenceIdBytes();
+    org.apache.pekko.protobufv3.internal.ByteString
+        getPersistenceIdBytes();
 
     /**
-     *
-     *
      * <pre>
      * not used in new records from 2.4
      * </pre>
      *
      * <code>optional bool deleted = 4;</code>
-     *
      * @return Whether the deleted field is set.
      */
     boolean hasDeleted();
     /**
-     *
-     *
      * <pre>
      * not used in new records from 2.4
      * </pre>
      *
      * <code>optional bool deleted = 4;</code>
-     *
      * @return The deleted.
      */
     boolean getDeleted();
 
     /**
-     *
-     *
      * <pre>
      * optional int32 redeliveries = 6; // Removed in 2.4
      * repeated string confirms = 7; // Removed in 2.4
@@ -117,13 +103,10 @@ public final class MessageFormats {
      * </pre>
      *
      * <code>optional string sender = 11;</code>
-     *
      * @return Whether the sender field is set.
      */
     boolean hasSender();
     /**
-     *
-     *
      * <pre>
      * optional int32 redeliveries = 6; // Removed in 2.4
      * repeated string confirms = 7; // Removed in 2.4
@@ -133,13 +116,10 @@ public final class MessageFormats {
      * </pre>
      *
      * <code>optional string sender = 11;</code>
-     *
      * @return The sender.
      */
     java.lang.String getSender();
     /**
-     *
-     *
      * <pre>
      * optional int32 redeliveries = 6; // Removed in 2.4
      * repeated string confirms = 7; // Removed in 2.4
@@ -149,91 +129,83 @@ public final class MessageFormats {
      * </pre>
      *
      * <code>optional string sender = 11;</code>
-     *
      * @return The bytes for sender.
      */
-    org.apache.pekko.protobufv3.internal.ByteString getSenderBytes();
+    org.apache.pekko.protobufv3.internal.ByteString
+        getSenderBytes();
 
     /**
      * <code>optional string manifest = 12;</code>
-     *
      * @return Whether the manifest field is set.
      */
     boolean hasManifest();
     /**
      * <code>optional string manifest = 12;</code>
-     *
      * @return The manifest.
      */
     java.lang.String getManifest();
     /**
      * <code>optional string manifest = 12;</code>
-     *
      * @return The bytes for manifest.
      */
-    org.apache.pekko.protobufv3.internal.ByteString getManifestBytes();
+    org.apache.pekko.protobufv3.internal.ByteString
+        getManifestBytes();
 
     /**
      * <code>optional string writerUuid = 13;</code>
-     *
      * @return Whether the writerUuid field is set.
      */
     boolean hasWriterUuid();
     /**
      * <code>optional string writerUuid = 13;</code>
-     *
      * @return The writerUuid.
      */
     java.lang.String getWriterUuid();
     /**
      * <code>optional string writerUuid = 13;</code>
-     *
      * @return The bytes for writerUuid.
      */
-    org.apache.pekko.protobufv3.internal.ByteString getWriterUuidBytes();
+    org.apache.pekko.protobufv3.internal.ByteString
+        getWriterUuidBytes();
 
     /**
      * <code>optional sint64 timestamp = 14;</code>
-     *
      * @return Whether the timestamp field is set.
      */
     boolean hasTimestamp();
     /**
      * <code>optional sint64 timestamp = 14;</code>
-     *
      * @return The timestamp.
      */
     long getTimestamp();
 
     /**
      * <code>optional .PersistentPayload metadata = 15;</code>
-     *
      * @return Whether the metadata field is set.
      */
     boolean hasMetadata();
     /**
      * <code>optional .PersistentPayload metadata = 15;</code>
-     *
      * @return The metadata.
      */
     org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload getMetadata();
-    /** <code>optional .PersistentPayload metadata = 15;</code> */
-    org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder
-        getMetadataOrBuilder();
+    /**
+     * <code>optional .PersistentPayload metadata = 15;</code>
+     */
+    org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder getMetadataOrBuilder();
   }
-  /** Protobuf type {@code PersistentMessage} */
-  public static final class PersistentMessage
-      extends org.apache.pekko.protobufv3.internal.GeneratedMessageV3
-      implements
+  /**
+   * Protobuf type {@code PersistentMessage}
+   */
+  public  static final class PersistentMessage extends
+      org.apache.pekko.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:PersistentMessage)
       PersistentMessageOrBuilder {
-    private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     // Use PersistentMessage.newBuilder() to construct.
-    private PersistentMessage(
-        org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
+    private PersistentMessage(org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
-
     private PersistentMessage() {
       persistenceId_ = "";
       sender_ = "";
@@ -249,10 +221,10 @@ public final class MessageFormats {
     }
 
     @java.lang.Override
-    public final org.apache.pekko.protobufv3.internal.UnknownFieldSet getUnknownFields() {
+    public final org.apache.pekko.protobufv3.internal.UnknownFieldSet
+    getUnknownFields() {
       return this.unknownFields;
     }
-
     private PersistentMessage(
         org.apache.pekko.protobufv3.internal.CodedInputStream input,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -272,125 +244,101 @@ public final class MessageFormats {
             case 0:
               done = true;
               break;
-            case 10:
-              {
-                org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder
-                    subBuilder = null;
-                if (((bitField0_ & 0x00000001) != 0)) {
-                  subBuilder = payload_.toBuilder();
-                }
-                payload_ =
-                    input.readMessage(
-                        org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                            .PARSER,
-                        extensionRegistry);
-                if (subBuilder != null) {
-                  subBuilder.mergeFrom(payload_);
-                  payload_ = subBuilder.buildPartial();
-                }
-                bitField0_ |= 0x00000001;
-                break;
+            case 10: {
+              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000001) != 0)) {
+                subBuilder = payload_.toBuilder();
               }
-            case 16:
-              {
-                bitField0_ |= 0x00000002;
-                sequenceNr_ = input.readInt64();
-                break;
+              payload_ = input.readMessage(org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(payload_);
+                payload_ = subBuilder.buildPartial();
               }
-            case 26:
-              {
-                org.apache.pekko.protobufv3.internal.ByteString bs = input.readBytes();
-                bitField0_ |= 0x00000004;
-                persistenceId_ = bs;
-                break;
+              bitField0_ |= 0x00000001;
+              break;
+            }
+            case 16: {
+              bitField0_ |= 0x00000002;
+              sequenceNr_ = input.readInt64();
+              break;
+            }
+            case 26: {
+              org.apache.pekko.protobufv3.internal.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000004;
+              persistenceId_ = bs;
+              break;
+            }
+            case 32: {
+              bitField0_ |= 0x00000008;
+              deleted_ = input.readBool();
+              break;
+            }
+            case 90: {
+              org.apache.pekko.protobufv3.internal.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000010;
+              sender_ = bs;
+              break;
+            }
+            case 98: {
+              org.apache.pekko.protobufv3.internal.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000020;
+              manifest_ = bs;
+              break;
+            }
+            case 106: {
+              org.apache.pekko.protobufv3.internal.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000040;
+              writerUuid_ = bs;
+              break;
+            }
+            case 112: {
+              bitField0_ |= 0x00000080;
+              timestamp_ = input.readSInt64();
+              break;
+            }
+            case 122: {
+              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000100) != 0)) {
+                subBuilder = metadata_.toBuilder();
               }
-            case 32:
-              {
-                bitField0_ |= 0x00000008;
-                deleted_ = input.readBool();
-                break;
+              metadata_ = input.readMessage(org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(metadata_);
+                metadata_ = subBuilder.buildPartial();
               }
-            case 90:
-              {
-                org.apache.pekko.protobufv3.internal.ByteString bs = input.readBytes();
-                bitField0_ |= 0x00000010;
-                sender_ = bs;
-                break;
+              bitField0_ |= 0x00000100;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
               }
-            case 98:
-              {
-                org.apache.pekko.protobufv3.internal.ByteString bs = input.readBytes();
-                bitField0_ |= 0x00000020;
-                manifest_ = bs;
-                break;
-              }
-            case 106:
-              {
-                org.apache.pekko.protobufv3.internal.ByteString bs = input.readBytes();
-                bitField0_ |= 0x00000040;
-                writerUuid_ = bs;
-                break;
-              }
-            case 112:
-              {
-                bitField0_ |= 0x00000080;
-                timestamp_ = input.readSInt64();
-                break;
-              }
-            case 122:
-              {
-                org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder
-                    subBuilder = null;
-                if (((bitField0_ & 0x00000100) != 0)) {
-                  subBuilder = metadata_.toBuilder();
-                }
-                metadata_ =
-                    input.readMessage(
-                        org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                            .PARSER,
-                        extensionRegistry);
-                if (subBuilder != null) {
-                  subBuilder.mergeFrom(metadata_);
-                  metadata_ = subBuilder.buildPartial();
-                }
-                bitField0_ |= 0x00000100;
-                break;
-              }
-            default:
-              {
-                if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
-                  done = true;
-                }
-                break;
-              }
+              break;
+            }
           }
         }
       } catch (org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException(e)
-            .setUnfinishedMessage(this);
+        throw new org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
     }
-
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.persistence.serialization.MessageFormats
-          .internal_static_PersistentMessage_descriptor;
+      return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_PersistentMessage_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.persistence.serialization.MessageFormats
-          .internal_static_PersistentMessage_fieldAccessorTable
+      return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_PersistentMessage_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.class,
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder
-                  .class);
+              org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.class, org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder.class);
     }
 
     private int bitField0_;
@@ -398,7 +346,6 @@ public final class MessageFormats {
     private org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload payload_;
     /**
      * <code>optional .PersistentPayload payload = 1;</code>
-     *
      * @return Whether the payload field is set.
      */
     public boolean hasPayload() {
@@ -406,30 +353,22 @@ public final class MessageFormats {
     }
     /**
      * <code>optional .PersistentPayload payload = 1;</code>
-     *
      * @return The payload.
      */
-    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-        getPayload() {
-      return payload_ == null
-          ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-              .getDefaultInstance()
-          : payload_;
+    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload getPayload() {
+      return payload_ == null ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance() : payload_;
     }
-    /** <code>optional .PersistentPayload payload = 1;</code> */
-    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder
-        getPayloadOrBuilder() {
-      return payload_ == null
-          ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-              .getDefaultInstance()
-          : payload_;
+    /**
+     * <code>optional .PersistentPayload payload = 1;</code>
+     */
+    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder getPayloadOrBuilder() {
+      return payload_ == null ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance() : payload_;
     }
 
     public static final int SEQUENCENR_FIELD_NUMBER = 2;
     private long sequenceNr_;
     /**
      * <code>optional int64 sequenceNr = 2;</code>
-     *
      * @return Whether the sequenceNr field is set.
      */
     public boolean hasSequenceNr() {
@@ -437,7 +376,6 @@ public final class MessageFormats {
     }
     /**
      * <code>optional int64 sequenceNr = 2;</code>
-     *
      * @return The sequenceNr.
      */
     public long getSequenceNr() {
@@ -448,7 +386,6 @@ public final class MessageFormats {
     private volatile java.lang.Object persistenceId_;
     /**
      * <code>optional string persistenceId = 3;</code>
-     *
      * @return Whether the persistenceId field is set.
      */
     public boolean hasPersistenceId() {
@@ -456,7 +393,6 @@ public final class MessageFormats {
     }
     /**
      * <code>optional string persistenceId = 3;</code>
-     *
      * @return The persistenceId.
      */
     public java.lang.String getPersistenceId() {
@@ -464,7 +400,7 @@ public final class MessageFormats {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        org.apache.pekko.protobufv3.internal.ByteString bs =
+        org.apache.pekko.protobufv3.internal.ByteString bs = 
             (org.apache.pekko.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -475,14 +411,15 @@ public final class MessageFormats {
     }
     /**
      * <code>optional string persistenceId = 3;</code>
-     *
      * @return The bytes for persistenceId.
      */
-    public org.apache.pekko.protobufv3.internal.ByteString getPersistenceIdBytes() {
+    public org.apache.pekko.protobufv3.internal.ByteString
+        getPersistenceIdBytes() {
       java.lang.Object ref = persistenceId_;
       if (ref instanceof java.lang.String) {
-        org.apache.pekko.protobufv3.internal.ByteString b =
-            org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
+        org.apache.pekko.protobufv3.internal.ByteString b = 
+            org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
         persistenceId_ = b;
         return b;
       } else {
@@ -493,28 +430,22 @@ public final class MessageFormats {
     public static final int DELETED_FIELD_NUMBER = 4;
     private boolean deleted_;
     /**
-     *
-     *
      * <pre>
      * not used in new records from 2.4
      * </pre>
      *
      * <code>optional bool deleted = 4;</code>
-     *
      * @return Whether the deleted field is set.
      */
     public boolean hasDeleted() {
       return ((bitField0_ & 0x00000008) != 0);
     }
     /**
-     *
-     *
      * <pre>
      * not used in new records from 2.4
      * </pre>
      *
      * <code>optional bool deleted = 4;</code>
-     *
      * @return The deleted.
      */
     public boolean getDeleted() {
@@ -524,8 +455,6 @@ public final class MessageFormats {
     public static final int SENDER_FIELD_NUMBER = 11;
     private volatile java.lang.Object sender_;
     /**
-     *
-     *
      * <pre>
      * optional int32 redeliveries = 6; // Removed in 2.4
      * repeated string confirms = 7; // Removed in 2.4
@@ -535,15 +464,12 @@ public final class MessageFormats {
      * </pre>
      *
      * <code>optional string sender = 11;</code>
-     *
      * @return Whether the sender field is set.
      */
     public boolean hasSender() {
       return ((bitField0_ & 0x00000010) != 0);
     }
     /**
-     *
-     *
      * <pre>
      * optional int32 redeliveries = 6; // Removed in 2.4
      * repeated string confirms = 7; // Removed in 2.4
@@ -553,7 +479,6 @@ public final class MessageFormats {
      * </pre>
      *
      * <code>optional string sender = 11;</code>
-     *
      * @return The sender.
      */
     public java.lang.String getSender() {
@@ -561,7 +486,7 @@ public final class MessageFormats {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        org.apache.pekko.protobufv3.internal.ByteString bs =
+        org.apache.pekko.protobufv3.internal.ByteString bs = 
             (org.apache.pekko.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -571,8 +496,6 @@ public final class MessageFormats {
       }
     }
     /**
-     *
-     *
      * <pre>
      * optional int32 redeliveries = 6; // Removed in 2.4
      * repeated string confirms = 7; // Removed in 2.4
@@ -582,14 +505,15 @@ public final class MessageFormats {
      * </pre>
      *
      * <code>optional string sender = 11;</code>
-     *
      * @return The bytes for sender.
      */
-    public org.apache.pekko.protobufv3.internal.ByteString getSenderBytes() {
+    public org.apache.pekko.protobufv3.internal.ByteString
+        getSenderBytes() {
       java.lang.Object ref = sender_;
       if (ref instanceof java.lang.String) {
-        org.apache.pekko.protobufv3.internal.ByteString b =
-            org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
+        org.apache.pekko.protobufv3.internal.ByteString b = 
+            org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
         sender_ = b;
         return b;
       } else {
@@ -601,7 +525,6 @@ public final class MessageFormats {
     private volatile java.lang.Object manifest_;
     /**
      * <code>optional string manifest = 12;</code>
-     *
      * @return Whether the manifest field is set.
      */
     public boolean hasManifest() {
@@ -609,7 +532,6 @@ public final class MessageFormats {
     }
     /**
      * <code>optional string manifest = 12;</code>
-     *
      * @return The manifest.
      */
     public java.lang.String getManifest() {
@@ -617,7 +539,7 @@ public final class MessageFormats {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        org.apache.pekko.protobufv3.internal.ByteString bs =
+        org.apache.pekko.protobufv3.internal.ByteString bs = 
             (org.apache.pekko.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -628,14 +550,15 @@ public final class MessageFormats {
     }
     /**
      * <code>optional string manifest = 12;</code>
-     *
      * @return The bytes for manifest.
      */
-    public org.apache.pekko.protobufv3.internal.ByteString getManifestBytes() {
+    public org.apache.pekko.protobufv3.internal.ByteString
+        getManifestBytes() {
       java.lang.Object ref = manifest_;
       if (ref instanceof java.lang.String) {
-        org.apache.pekko.protobufv3.internal.ByteString b =
-            org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
+        org.apache.pekko.protobufv3.internal.ByteString b = 
+            org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
         manifest_ = b;
         return b;
       } else {
@@ -647,7 +570,6 @@ public final class MessageFormats {
     private volatile java.lang.Object writerUuid_;
     /**
      * <code>optional string writerUuid = 13;</code>
-     *
      * @return Whether the writerUuid field is set.
      */
     public boolean hasWriterUuid() {
@@ -655,7 +577,6 @@ public final class MessageFormats {
     }
     /**
      * <code>optional string writerUuid = 13;</code>
-     *
      * @return The writerUuid.
      */
     public java.lang.String getWriterUuid() {
@@ -663,7 +584,7 @@ public final class MessageFormats {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        org.apache.pekko.protobufv3.internal.ByteString bs =
+        org.apache.pekko.protobufv3.internal.ByteString bs = 
             (org.apache.pekko.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -674,14 +595,15 @@ public final class MessageFormats {
     }
     /**
      * <code>optional string writerUuid = 13;</code>
-     *
      * @return The bytes for writerUuid.
      */
-    public org.apache.pekko.protobufv3.internal.ByteString getWriterUuidBytes() {
+    public org.apache.pekko.protobufv3.internal.ByteString
+        getWriterUuidBytes() {
       java.lang.Object ref = writerUuid_;
       if (ref instanceof java.lang.String) {
-        org.apache.pekko.protobufv3.internal.ByteString b =
-            org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
+        org.apache.pekko.protobufv3.internal.ByteString b = 
+            org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
         writerUuid_ = b;
         return b;
       } else {
@@ -693,7 +615,6 @@ public final class MessageFormats {
     private long timestamp_;
     /**
      * <code>optional sint64 timestamp = 14;</code>
-     *
      * @return Whether the timestamp field is set.
      */
     public boolean hasTimestamp() {
@@ -701,7 +622,6 @@ public final class MessageFormats {
     }
     /**
      * <code>optional sint64 timestamp = 14;</code>
-     *
      * @return The timestamp.
      */
     public long getTimestamp() {
@@ -712,7 +632,6 @@ public final class MessageFormats {
     private org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload metadata_;
     /**
      * <code>optional .PersistentPayload metadata = 15;</code>
-     *
      * @return Whether the metadata field is set.
      */
     public boolean hasMetadata() {
@@ -720,27 +639,19 @@ public final class MessageFormats {
     }
     /**
      * <code>optional .PersistentPayload metadata = 15;</code>
-     *
      * @return The metadata.
      */
-    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-        getMetadata() {
-      return metadata_ == null
-          ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-              .getDefaultInstance()
-          : metadata_;
+    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload getMetadata() {
+      return metadata_ == null ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance() : metadata_;
     }
-    /** <code>optional .PersistentPayload metadata = 15;</code> */
-    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder
-        getMetadataOrBuilder() {
-      return metadata_ == null
-          ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-              .getDefaultInstance()
-          : metadata_;
+    /**
+     * <code>optional .PersistentPayload metadata = 15;</code>
+     */
+    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder getMetadataOrBuilder() {
+      return metadata_ == null ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance() : metadata_;
     }
 
     private byte memoizedIsInitialized = -1;
-
     @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -765,7 +676,7 @@ public final class MessageFormats {
 
     @java.lang.Override
     public void writeTo(org.apache.pekko.protobufv3.internal.CodedOutputStream output)
-        throws java.io.IOException {
+                        throws java.io.IOException {
       if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getPayload());
       }
@@ -773,8 +684,7 @@ public final class MessageFormats {
         output.writeInt64(2, sequenceNr_);
       }
       if (((bitField0_ & 0x00000004) != 0)) {
-        org.apache.pekko.protobufv3.internal.GeneratedMessageV3.writeString(
-            output, 3, persistenceId_);
+        org.apache.pekko.protobufv3.internal.GeneratedMessageV3.writeString(output, 3, persistenceId_);
       }
       if (((bitField0_ & 0x00000008) != 0)) {
         output.writeBool(4, deleted_);
@@ -786,8 +696,7 @@ public final class MessageFormats {
         org.apache.pekko.protobufv3.internal.GeneratedMessageV3.writeString(output, 12, manifest_);
       }
       if (((bitField0_ & 0x00000040) != 0)) {
-        org.apache.pekko.protobufv3.internal.GeneratedMessageV3.writeString(
-            output, 13, writerUuid_);
+        org.apache.pekko.protobufv3.internal.GeneratedMessageV3.writeString(output, 13, writerUuid_);
       }
       if (((bitField0_ & 0x00000080) != 0)) {
         output.writeSInt64(14, timestamp_);
@@ -805,45 +714,36 @@ public final class MessageFormats {
 
       size = 0;
       if (((bitField0_ & 0x00000001) != 0)) {
-        size +=
-            org.apache.pekko.protobufv3.internal.CodedOutputStream.computeMessageSize(
-                1, getPayload());
+        size += org.apache.pekko.protobufv3.internal.CodedOutputStream
+          .computeMessageSize(1, getPayload());
       }
       if (((bitField0_ & 0x00000002) != 0)) {
-        size +=
-            org.apache.pekko.protobufv3.internal.CodedOutputStream.computeInt64Size(2, sequenceNr_);
+        size += org.apache.pekko.protobufv3.internal.CodedOutputStream
+          .computeInt64Size(2, sequenceNr_);
       }
       if (((bitField0_ & 0x00000004) != 0)) {
-        size +=
-            org.apache.pekko.protobufv3.internal.GeneratedMessageV3.computeStringSize(
-                3, persistenceId_);
+        size += org.apache.pekko.protobufv3.internal.GeneratedMessageV3.computeStringSize(3, persistenceId_);
       }
       if (((bitField0_ & 0x00000008) != 0)) {
-        size += org.apache.pekko.protobufv3.internal.CodedOutputStream.computeBoolSize(4, deleted_);
+        size += org.apache.pekko.protobufv3.internal.CodedOutputStream
+          .computeBoolSize(4, deleted_);
       }
       if (((bitField0_ & 0x00000010) != 0)) {
-        size +=
-            org.apache.pekko.protobufv3.internal.GeneratedMessageV3.computeStringSize(11, sender_);
+        size += org.apache.pekko.protobufv3.internal.GeneratedMessageV3.computeStringSize(11, sender_);
       }
       if (((bitField0_ & 0x00000020) != 0)) {
-        size +=
-            org.apache.pekko.protobufv3.internal.GeneratedMessageV3.computeStringSize(
-                12, manifest_);
+        size += org.apache.pekko.protobufv3.internal.GeneratedMessageV3.computeStringSize(12, manifest_);
       }
       if (((bitField0_ & 0x00000040) != 0)) {
-        size +=
-            org.apache.pekko.protobufv3.internal.GeneratedMessageV3.computeStringSize(
-                13, writerUuid_);
+        size += org.apache.pekko.protobufv3.internal.GeneratedMessageV3.computeStringSize(13, writerUuid_);
       }
       if (((bitField0_ & 0x00000080) != 0)) {
-        size +=
-            org.apache.pekko.protobufv3.internal.CodedOutputStream.computeSInt64Size(
-                14, timestamp_);
+        size += org.apache.pekko.protobufv3.internal.CodedOutputStream
+          .computeSInt64Size(14, timestamp_);
       }
       if (((bitField0_ & 0x00000100) != 0)) {
-        size +=
-            org.apache.pekko.protobufv3.internal.CodedOutputStream.computeMessageSize(
-                15, getMetadata());
+        size += org.apache.pekko.protobufv3.internal.CodedOutputStream
+          .computeMessageSize(15, getMetadata());
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -853,50 +753,57 @@ public final class MessageFormats {
     @java.lang.Override
     public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
-        return true;
+       return true;
       }
-      if (!(obj
-          instanceof org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage)) {
+      if (!(obj instanceof org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage)) {
         return super.equals(obj);
       }
-      org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage other =
-          (org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage) obj;
+      org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage other = (org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage) obj;
 
       if (hasPayload() != other.hasPayload()) return false;
       if (hasPayload()) {
-        if (!getPayload().equals(other.getPayload())) return false;
+        if (!getPayload()
+            .equals(other.getPayload())) return false;
       }
       if (hasSequenceNr() != other.hasSequenceNr()) return false;
       if (hasSequenceNr()) {
-        if (getSequenceNr() != other.getSequenceNr()) return false;
+        if (getSequenceNr()
+            != other.getSequenceNr()) return false;
       }
       if (hasPersistenceId() != other.hasPersistenceId()) return false;
       if (hasPersistenceId()) {
-        if (!getPersistenceId().equals(other.getPersistenceId())) return false;
+        if (!getPersistenceId()
+            .equals(other.getPersistenceId())) return false;
       }
       if (hasDeleted() != other.hasDeleted()) return false;
       if (hasDeleted()) {
-        if (getDeleted() != other.getDeleted()) return false;
+        if (getDeleted()
+            != other.getDeleted()) return false;
       }
       if (hasSender() != other.hasSender()) return false;
       if (hasSender()) {
-        if (!getSender().equals(other.getSender())) return false;
+        if (!getSender()
+            .equals(other.getSender())) return false;
       }
       if (hasManifest() != other.hasManifest()) return false;
       if (hasManifest()) {
-        if (!getManifest().equals(other.getManifest())) return false;
+        if (!getManifest()
+            .equals(other.getManifest())) return false;
       }
       if (hasWriterUuid() != other.hasWriterUuid()) return false;
       if (hasWriterUuid()) {
-        if (!getWriterUuid().equals(other.getWriterUuid())) return false;
+        if (!getWriterUuid()
+            .equals(other.getWriterUuid())) return false;
       }
       if (hasTimestamp() != other.hasTimestamp()) return false;
       if (hasTimestamp()) {
-        if (getTimestamp() != other.getTimestamp()) return false;
+        if (getTimestamp()
+            != other.getTimestamp()) return false;
       }
       if (hasMetadata() != other.hasMetadata()) return false;
       if (hasMetadata()) {
-        if (!getMetadata().equals(other.getMetadata())) return false;
+        if (!getMetadata()
+            .equals(other.getMetadata())) return false;
       }
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
@@ -915,8 +822,8 @@ public final class MessageFormats {
       }
       if (hasSequenceNr()) {
         hash = (37 * hash) + SEQUENCENR_FIELD_NUMBER;
-        hash =
-            (53 * hash) + org.apache.pekko.protobufv3.internal.Internal.hashLong(getSequenceNr());
+        hash = (53 * hash) + org.apache.pekko.protobufv3.internal.Internal.hashLong(
+            getSequenceNr());
       }
       if (hasPersistenceId()) {
         hash = (37 * hash) + PERSISTENCEID_FIELD_NUMBER;
@@ -924,8 +831,8 @@ public final class MessageFormats {
       }
       if (hasDeleted()) {
         hash = (37 * hash) + DELETED_FIELD_NUMBER;
-        hash =
-            (53 * hash) + org.apache.pekko.protobufv3.internal.Internal.hashBoolean(getDeleted());
+        hash = (53 * hash) + org.apache.pekko.protobufv3.internal.Internal.hashBoolean(
+            getDeleted());
       }
       if (hasSender()) {
         hash = (37 * hash) + SENDER_FIELD_NUMBER;
@@ -941,7 +848,8 @@ public final class MessageFormats {
       }
       if (hasTimestamp()) {
         hash = (37 * hash) + TIMESTAMP_FIELD_NUMBER;
-        hash = (53 * hash) + org.apache.pekko.protobufv3.internal.Internal.hashLong(getTimestamp());
+        hash = (53 * hash) + org.apache.pekko.protobufv3.internal.Internal.hashLong(
+            getTimestamp());
       }
       if (hasMetadata()) {
         hash = (37 * hash) + METADATA_FIELD_NUMBER;
@@ -952,111 +860,88 @@ public final class MessageFormats {
       return hash;
     }
 
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-        parseFrom(java.nio.ByteBuffer data)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage parseFrom(
+        java.nio.ByteBuffer data)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-        parseFrom(
-            java.nio.ByteBuffer data,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage parseFrom(
+        java.nio.ByteBuffer data,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-        parseFrom(org.apache.pekko.protobufv3.internal.ByteString data)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage parseFrom(
+        org.apache.pekko.protobufv3.internal.ByteString data)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-        parseFrom(
-            org.apache.pekko.protobufv3.internal.ByteString data,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage parseFrom(
+        org.apache.pekko.protobufv3.internal.ByteString data,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-        parseFrom(byte[] data)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage parseFrom(byte[] data)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-        parseFrom(
-            byte[] data,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage parseFrom(
+        byte[] data,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-        parseFrom(java.io.InputStream input) throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-        parseFrom(
-            java.io.InputStream input,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input, extensionRegistry);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage parseFrom(
+        java.io.InputStream input,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
-          PARSER, input);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-        parseDelimitedFrom(
-            java.io.InputStream input,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
-          PARSER, input, extensionRegistry);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage parseDelimitedFrom(
+        java.io.InputStream input,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-        parseFrom(org.apache.pekko.protobufv3.internal.CodedInputStream input)
-            throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage parseFrom(
+        org.apache.pekko.protobufv3.internal.CodedInputStream input)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-        parseFrom(
-            org.apache.pekko.protobufv3.internal.CodedInputStream input,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input, extensionRegistry);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage parseFrom(
+        org.apache.pekko.protobufv3.internal.CodedInputStream input,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
     @java.lang.Override
-    public Builder newBuilderForType() {
-      return newBuilder();
-    }
-
+    public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-
-    public static Builder newBuilder(
-        org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage prototype) {
+    public static Builder newBuilder(org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-
     @java.lang.Override
     public Builder toBuilder() {
-      return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
     }
 
     @java.lang.Override
@@ -1065,31 +950,27 @@ public final class MessageFormats {
       Builder builder = new Builder(parent);
       return builder;
     }
-    /** Protobuf type {@code PersistentMessage} */
-    public static final class Builder
-        extends org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<Builder>
-        implements
+    /**
+     * Protobuf type {@code PersistentMessage}
+     */
+    public static final class Builder extends
+        org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:PersistentMessage)
         org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessageOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.persistence.serialization.MessageFormats
-            .internal_static_PersistentMessage_descriptor;
+        return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_PersistentMessage_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.persistence.serialization.MessageFormats
-            .internal_static_PersistentMessage_fieldAccessorTable
+        return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_PersistentMessage_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.class,
-                org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder
-                    .class);
+                org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.class, org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder.class);
       }
 
-      // Construct using
-      // org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.newBuilder()
+      // Construct using org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
@@ -1099,14 +980,13 @@ public final class MessageFormats {
         super(parent);
         maybeForceBuilderInitialization();
       }
-
       private void maybeForceBuilderInitialization() {
-        if (org.apache.pekko.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders) {
+        if (org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
           getPayloadFieldBuilder();
           getMetadataFieldBuilder();
         }
       }
-
       @java.lang.Override
       public Builder clear() {
         super.clear();
@@ -1140,22 +1020,19 @@ public final class MessageFormats {
       }
 
       @java.lang.Override
-      public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor getDescriptorForType() {
-        return org.apache.pekko.persistence.serialization.MessageFormats
-            .internal_static_PersistentMessage_descriptor;
+      public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_PersistentMessage_descriptor;
       }
 
       @java.lang.Override
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-          getDefaultInstanceForType() {
-        return org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-            .getDefaultInstance();
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage getDefaultInstanceForType() {
+        return org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.getDefaultInstance();
       }
 
       @java.lang.Override
       public org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage build() {
-        org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage result =
-            buildPartial();
+        org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
@@ -1163,10 +1040,8 @@ public final class MessageFormats {
       }
 
       @java.lang.Override
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-          buildPartial() {
-        org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage result =
-            new org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage(this);
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage buildPartial() {
+        org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage result = new org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
@@ -1222,59 +1097,46 @@ public final class MessageFormats {
       public Builder clone() {
         return super.clone();
       }
-
       @java.lang.Override
       public Builder setField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return super.setField(field, value);
       }
-
       @java.lang.Override
       public Builder clearField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-
       @java.lang.Override
       public Builder clearOneof(
           org.apache.pekko.protobufv3.internal.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-
       @java.lang.Override
       public Builder setRepeatedField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field,
-          int index,
-          java.lang.Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-
       @java.lang.Override
       public Builder addRepeatedField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-
       @java.lang.Override
       public Builder mergeFrom(org.apache.pekko.protobufv3.internal.Message other) {
-        if (other
-            instanceof
-            org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage) {
-          return mergeFrom(
-              (org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage) other);
+        if (other instanceof org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage) {
+          return mergeFrom((org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(
-          org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage other) {
-        if (other
-            == org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-                .getDefaultInstance()) return this;
+      public Builder mergeFrom(org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage other) {
+        if (other == org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.getDefaultInstance()) return this;
         if (other.hasPayload()) {
           mergePayload(other.getPayload());
         }
@@ -1335,14 +1197,11 @@ public final class MessageFormats {
           org.apache.pekko.protobufv3.internal.CodedInputStream input,
           org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage parsedMessage =
-            null;
+        org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException e) {
-          parsedMessage =
-              (org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage)
-                  e.getUnfinishedMessage();
+          parsedMessage = (org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -1351,18 +1210,13 @@ public final class MessageFormats {
         }
         return this;
       }
-
       private int bitField0_;
 
       private org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload payload_;
       private org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload,
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder,
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder>
-          payloadBuilder_;
+          org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder> payloadBuilder_;
       /**
        * <code>optional .PersistentPayload payload = 1;</code>
-       *
        * @return Whether the payload field is set.
        */
       public boolean hasPayload() {
@@ -1370,23 +1224,19 @@ public final class MessageFormats {
       }
       /**
        * <code>optional .PersistentPayload payload = 1;</code>
-       *
        * @return The payload.
        */
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-          getPayload() {
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload getPayload() {
         if (payloadBuilder_ == null) {
-          return payload_ == null
-              ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                  .getDefaultInstance()
-              : payload_;
+          return payload_ == null ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance() : payload_;
         } else {
           return payloadBuilder_.getMessage();
         }
       }
-      /** <code>optional .PersistentPayload payload = 1;</code> */
-      public Builder setPayload(
-          org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload value) {
+      /**
+       * <code>optional .PersistentPayload payload = 1;</code>
+       */
+      public Builder setPayload(org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload value) {
         if (payloadBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -1399,10 +1249,11 @@ public final class MessageFormats {
         bitField0_ |= 0x00000001;
         return this;
       }
-      /** <code>optional .PersistentPayload payload = 1;</code> */
+      /**
+       * <code>optional .PersistentPayload payload = 1;</code>
+       */
       public Builder setPayload(
-          org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder
-              builderForValue) {
+          org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder builderForValue) {
         if (payloadBuilder_ == null) {
           payload_ = builderForValue.build();
           onChanged();
@@ -1412,20 +1263,16 @@ public final class MessageFormats {
         bitField0_ |= 0x00000001;
         return this;
       }
-      /** <code>optional .PersistentPayload payload = 1;</code> */
-      public Builder mergePayload(
-          org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload value) {
+      /**
+       * <code>optional .PersistentPayload payload = 1;</code>
+       */
+      public Builder mergePayload(org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload value) {
         if (payloadBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) != 0)
-              && payload_ != null
-              && payload_
-                  != org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                      .getDefaultInstance()) {
+          if (((bitField0_ & 0x00000001) != 0) &&
+              payload_ != null &&
+              payload_ != org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance()) {
             payload_ =
-                org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                    .newBuilder(payload_)
-                    .mergeFrom(value)
-                    .buildPartial();
+              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.newBuilder(payload_).mergeFrom(value).buildPartial();
           } else {
             payload_ = value;
           }
@@ -1436,7 +1283,9 @@ public final class MessageFormats {
         bitField0_ |= 0x00000001;
         return this;
       }
-      /** <code>optional .PersistentPayload payload = 1;</code> */
+      /**
+       * <code>optional .PersistentPayload payload = 1;</code>
+       */
       public Builder clearPayload() {
         if (payloadBuilder_ == null) {
           payload_ = null;
@@ -1447,48 +1296,45 @@ public final class MessageFormats {
         bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
-      /** <code>optional .PersistentPayload payload = 1;</code> */
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder
-          getPayloadBuilder() {
+      /**
+       * <code>optional .PersistentPayload payload = 1;</code>
+       */
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder getPayloadBuilder() {
         bitField0_ |= 0x00000001;
         onChanged();
         return getPayloadFieldBuilder().getBuilder();
       }
-      /** <code>optional .PersistentPayload payload = 1;</code> */
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder
-          getPayloadOrBuilder() {
+      /**
+       * <code>optional .PersistentPayload payload = 1;</code>
+       */
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder getPayloadOrBuilder() {
         if (payloadBuilder_ != null) {
           return payloadBuilder_.getMessageOrBuilder();
         } else {
-          return payload_ == null
-              ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                  .getDefaultInstance()
-              : payload_;
+          return payload_ == null ?
+              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance() : payload_;
         }
       }
-      /** <code>optional .PersistentPayload payload = 1;</code> */
+      /**
+       * <code>optional .PersistentPayload payload = 1;</code>
+       */
       private org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload,
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder,
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder>
+          org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder> 
           getPayloadFieldBuilder() {
         if (payloadBuilder_ == null) {
-          payloadBuilder_ =
-              new org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
-                  org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload,
-                  org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                      .Builder,
-                  org.apache.pekko.persistence.serialization.MessageFormats
-                      .PersistentPayloadOrBuilder>(getPayload(), getParentForChildren(), isClean());
+          payloadBuilder_ = new org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
+              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder>(
+                  getPayload(),
+                  getParentForChildren(),
+                  isClean());
           payload_ = null;
         }
         return payloadBuilder_;
       }
 
-      private long sequenceNr_;
+      private long sequenceNr_ ;
       /**
        * <code>optional int64 sequenceNr = 2;</code>
-       *
        * @return Whether the sequenceNr field is set.
        */
       public boolean hasSequenceNr() {
@@ -1496,7 +1342,6 @@ public final class MessageFormats {
       }
       /**
        * <code>optional int64 sequenceNr = 2;</code>
-       *
        * @return The sequenceNr.
        */
       public long getSequenceNr() {
@@ -1504,7 +1349,6 @@ public final class MessageFormats {
       }
       /**
        * <code>optional int64 sequenceNr = 2;</code>
-       *
        * @param value The sequenceNr to set.
        * @return This builder for chaining.
        */
@@ -1516,7 +1360,6 @@ public final class MessageFormats {
       }
       /**
        * <code>optional int64 sequenceNr = 2;</code>
-       *
        * @return This builder for chaining.
        */
       public Builder clearSequenceNr() {
@@ -1529,7 +1372,6 @@ public final class MessageFormats {
       private java.lang.Object persistenceId_ = "";
       /**
        * <code>optional string persistenceId = 3;</code>
-       *
        * @return Whether the persistenceId field is set.
        */
       public boolean hasPersistenceId() {
@@ -1537,7 +1379,6 @@ public final class MessageFormats {
       }
       /**
        * <code>optional string persistenceId = 3;</code>
-       *
        * @return The persistenceId.
        */
       public java.lang.String getPersistenceId() {
@@ -1556,14 +1397,15 @@ public final class MessageFormats {
       }
       /**
        * <code>optional string persistenceId = 3;</code>
-       *
        * @return The bytes for persistenceId.
        */
-      public org.apache.pekko.protobufv3.internal.ByteString getPersistenceIdBytes() {
+      public org.apache.pekko.protobufv3.internal.ByteString
+          getPersistenceIdBytes() {
         java.lang.Object ref = persistenceId_;
         if (ref instanceof String) {
-          org.apache.pekko.protobufv3.internal.ByteString b =
-              org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
+          org.apache.pekko.protobufv3.internal.ByteString b = 
+              org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
           persistenceId_ = b;
           return b;
         } else {
@@ -1572,22 +1414,21 @@ public final class MessageFormats {
       }
       /**
        * <code>optional string persistenceId = 3;</code>
-       *
        * @param value The persistenceId to set.
        * @return This builder for chaining.
        */
-      public Builder setPersistenceId(java.lang.String value) {
+      public Builder setPersistenceId(
+          java.lang.String value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000004;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
         persistenceId_ = value;
         onChanged();
         return this;
       }
       /**
        * <code>optional string persistenceId = 3;</code>
-       *
        * @return This builder for chaining.
        */
       public Builder clearPersistenceId() {
@@ -1598,58 +1439,49 @@ public final class MessageFormats {
       }
       /**
        * <code>optional string persistenceId = 3;</code>
-       *
        * @param value The bytes for persistenceId to set.
        * @return This builder for chaining.
        */
-      public Builder setPersistenceIdBytes(org.apache.pekko.protobufv3.internal.ByteString value) {
+      public Builder setPersistenceIdBytes(
+          org.apache.pekko.protobufv3.internal.ByteString value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000004;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
         persistenceId_ = value;
         onChanged();
         return this;
       }
 
-      private boolean deleted_;
+      private boolean deleted_ ;
       /**
-       *
-       *
        * <pre>
        * not used in new records from 2.4
        * </pre>
        *
        * <code>optional bool deleted = 4;</code>
-       *
        * @return Whether the deleted field is set.
        */
       public boolean hasDeleted() {
         return ((bitField0_ & 0x00000008) != 0);
       }
       /**
-       *
-       *
        * <pre>
        * not used in new records from 2.4
        * </pre>
        *
        * <code>optional bool deleted = 4;</code>
-       *
        * @return The deleted.
        */
       public boolean getDeleted() {
         return deleted_;
       }
       /**
-       *
-       *
        * <pre>
        * not used in new records from 2.4
        * </pre>
        *
        * <code>optional bool deleted = 4;</code>
-       *
        * @param value The deleted to set.
        * @return This builder for chaining.
        */
@@ -1660,14 +1492,11 @@ public final class MessageFormats {
         return this;
       }
       /**
-       *
-       *
        * <pre>
        * not used in new records from 2.4
        * </pre>
        *
        * <code>optional bool deleted = 4;</code>
-       *
        * @return This builder for chaining.
        */
       public Builder clearDeleted() {
@@ -1679,8 +1508,6 @@ public final class MessageFormats {
 
       private java.lang.Object sender_ = "";
       /**
-       *
-       *
        * <pre>
        * optional int32 redeliveries = 6; // Removed in 2.4
        * repeated string confirms = 7; // Removed in 2.4
@@ -1690,15 +1517,12 @@ public final class MessageFormats {
        * </pre>
        *
        * <code>optional string sender = 11;</code>
-       *
        * @return Whether the sender field is set.
        */
       public boolean hasSender() {
         return ((bitField0_ & 0x00000010) != 0);
       }
       /**
-       *
-       *
        * <pre>
        * optional int32 redeliveries = 6; // Removed in 2.4
        * repeated string confirms = 7; // Removed in 2.4
@@ -1708,7 +1532,6 @@ public final class MessageFormats {
        * </pre>
        *
        * <code>optional string sender = 11;</code>
-       *
        * @return The sender.
        */
       public java.lang.String getSender() {
@@ -1726,8 +1549,6 @@ public final class MessageFormats {
         }
       }
       /**
-       *
-       *
        * <pre>
        * optional int32 redeliveries = 6; // Removed in 2.4
        * repeated string confirms = 7; // Removed in 2.4
@@ -1737,14 +1558,15 @@ public final class MessageFormats {
        * </pre>
        *
        * <code>optional string sender = 11;</code>
-       *
        * @return The bytes for sender.
        */
-      public org.apache.pekko.protobufv3.internal.ByteString getSenderBytes() {
+      public org.apache.pekko.protobufv3.internal.ByteString
+          getSenderBytes() {
         java.lang.Object ref = sender_;
         if (ref instanceof String) {
-          org.apache.pekko.protobufv3.internal.ByteString b =
-              org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
+          org.apache.pekko.protobufv3.internal.ByteString b = 
+              org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
           sender_ = b;
           return b;
         } else {
@@ -1752,8 +1574,6 @@ public final class MessageFormats {
         }
       }
       /**
-       *
-       *
        * <pre>
        * optional int32 redeliveries = 6; // Removed in 2.4
        * repeated string confirms = 7; // Removed in 2.4
@@ -1763,22 +1583,20 @@ public final class MessageFormats {
        * </pre>
        *
        * <code>optional string sender = 11;</code>
-       *
        * @param value The sender to set.
        * @return This builder for chaining.
        */
-      public Builder setSender(java.lang.String value) {
+      public Builder setSender(
+          java.lang.String value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000010;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000010;
         sender_ = value;
         onChanged();
         return this;
       }
       /**
-       *
-       *
        * <pre>
        * optional int32 redeliveries = 6; // Removed in 2.4
        * repeated string confirms = 7; // Removed in 2.4
@@ -1788,7 +1606,6 @@ public final class MessageFormats {
        * </pre>
        *
        * <code>optional string sender = 11;</code>
-       *
        * @return This builder for chaining.
        */
       public Builder clearSender() {
@@ -1798,8 +1615,6 @@ public final class MessageFormats {
         return this;
       }
       /**
-       *
-       *
        * <pre>
        * optional int32 redeliveries = 6; // Removed in 2.4
        * repeated string confirms = 7; // Removed in 2.4
@@ -1809,15 +1624,15 @@ public final class MessageFormats {
        * </pre>
        *
        * <code>optional string sender = 11;</code>
-       *
        * @param value The bytes for sender to set.
        * @return This builder for chaining.
        */
-      public Builder setSenderBytes(org.apache.pekko.protobufv3.internal.ByteString value) {
+      public Builder setSenderBytes(
+          org.apache.pekko.protobufv3.internal.ByteString value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000010;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000010;
         sender_ = value;
         onChanged();
         return this;
@@ -1826,7 +1641,6 @@ public final class MessageFormats {
       private java.lang.Object manifest_ = "";
       /**
        * <code>optional string manifest = 12;</code>
-       *
        * @return Whether the manifest field is set.
        */
       public boolean hasManifest() {
@@ -1834,7 +1648,6 @@ public final class MessageFormats {
       }
       /**
        * <code>optional string manifest = 12;</code>
-       *
        * @return The manifest.
        */
       public java.lang.String getManifest() {
@@ -1853,14 +1666,15 @@ public final class MessageFormats {
       }
       /**
        * <code>optional string manifest = 12;</code>
-       *
        * @return The bytes for manifest.
        */
-      public org.apache.pekko.protobufv3.internal.ByteString getManifestBytes() {
+      public org.apache.pekko.protobufv3.internal.ByteString
+          getManifestBytes() {
         java.lang.Object ref = manifest_;
         if (ref instanceof String) {
-          org.apache.pekko.protobufv3.internal.ByteString b =
-              org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
+          org.apache.pekko.protobufv3.internal.ByteString b = 
+              org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
           manifest_ = b;
           return b;
         } else {
@@ -1869,22 +1683,21 @@ public final class MessageFormats {
       }
       /**
        * <code>optional string manifest = 12;</code>
-       *
        * @param value The manifest to set.
        * @return This builder for chaining.
        */
-      public Builder setManifest(java.lang.String value) {
+      public Builder setManifest(
+          java.lang.String value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000020;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000020;
         manifest_ = value;
         onChanged();
         return this;
       }
       /**
        * <code>optional string manifest = 12;</code>
-       *
        * @return This builder for chaining.
        */
       public Builder clearManifest() {
@@ -1895,15 +1708,15 @@ public final class MessageFormats {
       }
       /**
        * <code>optional string manifest = 12;</code>
-       *
        * @param value The bytes for manifest to set.
        * @return This builder for chaining.
        */
-      public Builder setManifestBytes(org.apache.pekko.protobufv3.internal.ByteString value) {
+      public Builder setManifestBytes(
+          org.apache.pekko.protobufv3.internal.ByteString value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000020;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000020;
         manifest_ = value;
         onChanged();
         return this;
@@ -1912,7 +1725,6 @@ public final class MessageFormats {
       private java.lang.Object writerUuid_ = "";
       /**
        * <code>optional string writerUuid = 13;</code>
-       *
        * @return Whether the writerUuid field is set.
        */
       public boolean hasWriterUuid() {
@@ -1920,7 +1732,6 @@ public final class MessageFormats {
       }
       /**
        * <code>optional string writerUuid = 13;</code>
-       *
        * @return The writerUuid.
        */
       public java.lang.String getWriterUuid() {
@@ -1939,14 +1750,15 @@ public final class MessageFormats {
       }
       /**
        * <code>optional string writerUuid = 13;</code>
-       *
        * @return The bytes for writerUuid.
        */
-      public org.apache.pekko.protobufv3.internal.ByteString getWriterUuidBytes() {
+      public org.apache.pekko.protobufv3.internal.ByteString
+          getWriterUuidBytes() {
         java.lang.Object ref = writerUuid_;
         if (ref instanceof String) {
-          org.apache.pekko.protobufv3.internal.ByteString b =
-              org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
+          org.apache.pekko.protobufv3.internal.ByteString b = 
+              org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
           writerUuid_ = b;
           return b;
         } else {
@@ -1955,22 +1767,21 @@ public final class MessageFormats {
       }
       /**
        * <code>optional string writerUuid = 13;</code>
-       *
        * @param value The writerUuid to set.
        * @return This builder for chaining.
        */
-      public Builder setWriterUuid(java.lang.String value) {
+      public Builder setWriterUuid(
+          java.lang.String value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000040;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000040;
         writerUuid_ = value;
         onChanged();
         return this;
       }
       /**
        * <code>optional string writerUuid = 13;</code>
-       *
        * @return This builder for chaining.
        */
       public Builder clearWriterUuid() {
@@ -1981,24 +1792,23 @@ public final class MessageFormats {
       }
       /**
        * <code>optional string writerUuid = 13;</code>
-       *
        * @param value The bytes for writerUuid to set.
        * @return This builder for chaining.
        */
-      public Builder setWriterUuidBytes(org.apache.pekko.protobufv3.internal.ByteString value) {
+      public Builder setWriterUuidBytes(
+          org.apache.pekko.protobufv3.internal.ByteString value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000040;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000040;
         writerUuid_ = value;
         onChanged();
         return this;
       }
 
-      private long timestamp_;
+      private long timestamp_ ;
       /**
        * <code>optional sint64 timestamp = 14;</code>
-       *
        * @return Whether the timestamp field is set.
        */
       public boolean hasTimestamp() {
@@ -2006,7 +1816,6 @@ public final class MessageFormats {
       }
       /**
        * <code>optional sint64 timestamp = 14;</code>
-       *
        * @return The timestamp.
        */
       public long getTimestamp() {
@@ -2014,7 +1823,6 @@ public final class MessageFormats {
       }
       /**
        * <code>optional sint64 timestamp = 14;</code>
-       *
        * @param value The timestamp to set.
        * @return This builder for chaining.
        */
@@ -2026,7 +1834,6 @@ public final class MessageFormats {
       }
       /**
        * <code>optional sint64 timestamp = 14;</code>
-       *
        * @return This builder for chaining.
        */
       public Builder clearTimestamp() {
@@ -2038,13 +1845,9 @@ public final class MessageFormats {
 
       private org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload metadata_;
       private org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload,
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder,
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder>
-          metadataBuilder_;
+          org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder> metadataBuilder_;
       /**
        * <code>optional .PersistentPayload metadata = 15;</code>
-       *
        * @return Whether the metadata field is set.
        */
       public boolean hasMetadata() {
@@ -2052,23 +1855,19 @@ public final class MessageFormats {
       }
       /**
        * <code>optional .PersistentPayload metadata = 15;</code>
-       *
        * @return The metadata.
        */
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-          getMetadata() {
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload getMetadata() {
         if (metadataBuilder_ == null) {
-          return metadata_ == null
-              ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                  .getDefaultInstance()
-              : metadata_;
+          return metadata_ == null ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance() : metadata_;
         } else {
           return metadataBuilder_.getMessage();
         }
       }
-      /** <code>optional .PersistentPayload metadata = 15;</code> */
-      public Builder setMetadata(
-          org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload value) {
+      /**
+       * <code>optional .PersistentPayload metadata = 15;</code>
+       */
+      public Builder setMetadata(org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload value) {
         if (metadataBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -2081,10 +1880,11 @@ public final class MessageFormats {
         bitField0_ |= 0x00000100;
         return this;
       }
-      /** <code>optional .PersistentPayload metadata = 15;</code> */
+      /**
+       * <code>optional .PersistentPayload metadata = 15;</code>
+       */
       public Builder setMetadata(
-          org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder
-              builderForValue) {
+          org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder builderForValue) {
         if (metadataBuilder_ == null) {
           metadata_ = builderForValue.build();
           onChanged();
@@ -2094,20 +1894,16 @@ public final class MessageFormats {
         bitField0_ |= 0x00000100;
         return this;
       }
-      /** <code>optional .PersistentPayload metadata = 15;</code> */
-      public Builder mergeMetadata(
-          org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload value) {
+      /**
+       * <code>optional .PersistentPayload metadata = 15;</code>
+       */
+      public Builder mergeMetadata(org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload value) {
         if (metadataBuilder_ == null) {
-          if (((bitField0_ & 0x00000100) != 0)
-              && metadata_ != null
-              && metadata_
-                  != org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                      .getDefaultInstance()) {
+          if (((bitField0_ & 0x00000100) != 0) &&
+              metadata_ != null &&
+              metadata_ != org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance()) {
             metadata_ =
-                org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                    .newBuilder(metadata_)
-                    .mergeFrom(value)
-                    .buildPartial();
+              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.newBuilder(metadata_).mergeFrom(value).buildPartial();
           } else {
             metadata_ = value;
           }
@@ -2118,7 +1914,9 @@ public final class MessageFormats {
         bitField0_ |= 0x00000100;
         return this;
       }
-      /** <code>optional .PersistentPayload metadata = 15;</code> */
+      /**
+       * <code>optional .PersistentPayload metadata = 15;</code>
+       */
       public Builder clearMetadata() {
         if (metadataBuilder_ == null) {
           metadata_ = null;
@@ -2129,45 +1927,41 @@ public final class MessageFormats {
         bitField0_ = (bitField0_ & ~0x00000100);
         return this;
       }
-      /** <code>optional .PersistentPayload metadata = 15;</code> */
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder
-          getMetadataBuilder() {
+      /**
+       * <code>optional .PersistentPayload metadata = 15;</code>
+       */
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder getMetadataBuilder() {
         bitField0_ |= 0x00000100;
         onChanged();
         return getMetadataFieldBuilder().getBuilder();
       }
-      /** <code>optional .PersistentPayload metadata = 15;</code> */
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder
-          getMetadataOrBuilder() {
+      /**
+       * <code>optional .PersistentPayload metadata = 15;</code>
+       */
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder getMetadataOrBuilder() {
         if (metadataBuilder_ != null) {
           return metadataBuilder_.getMessageOrBuilder();
         } else {
-          return metadata_ == null
-              ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                  .getDefaultInstance()
-              : metadata_;
+          return metadata_ == null ?
+              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance() : metadata_;
         }
       }
-      /** <code>optional .PersistentPayload metadata = 15;</code> */
+      /**
+       * <code>optional .PersistentPayload metadata = 15;</code>
+       */
       private org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload,
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder,
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder>
+          org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder> 
           getMetadataFieldBuilder() {
         if (metadataBuilder_ == null) {
-          metadataBuilder_ =
-              new org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
-                  org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload,
-                  org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                      .Builder,
-                  org.apache.pekko.persistence.serialization.MessageFormats
-                      .PersistentPayloadOrBuilder>(
-                  getMetadata(), getParentForChildren(), isClean());
+          metadataBuilder_ = new org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
+              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder>(
+                  getMetadata(),
+                  getParentForChildren(),
+                  isClean());
           metadata_ = null;
         }
         return metadataBuilder_;
       }
-
       @java.lang.Override
       public final Builder setUnknownFields(
           final org.apache.pekko.protobufv3.internal.UnknownFieldSet unknownFields) {
@@ -2180,34 +1974,30 @@ public final class MessageFormats {
         return super.mergeUnknownFields(unknownFields);
       }
 
+
       // @@protoc_insertion_point(builder_scope:PersistentMessage)
     }
 
     // @@protoc_insertion_point(class_scope:PersistentMessage)
-    private static final org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-        DEFAULT_INSTANCE;
-
+    private static final org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE =
-          new org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage();
+      DEFAULT_INSTANCE = new org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage();
     }
 
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-        getDefaultInstance() {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
-    @java.lang.Deprecated
-    public static final org.apache.pekko.protobufv3.internal.Parser<PersistentMessage> PARSER =
-        new org.apache.pekko.protobufv3.internal.AbstractParser<PersistentMessage>() {
-          @java.lang.Override
-          public PersistentMessage parsePartialFrom(
-              org.apache.pekko.protobufv3.internal.CodedInputStream input,
-              org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-              throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
-            return new PersistentMessage(input, extensionRegistry);
-          }
-        };
+    @java.lang.Deprecated public static final org.apache.pekko.protobufv3.internal.Parser<PersistentMessage>
+        PARSER = new org.apache.pekko.protobufv3.internal.AbstractParser<PersistentMessage>() {
+      @java.lang.Override
+      public PersistentMessage parsePartialFrom(
+          org.apache.pekko.protobufv3.internal.CodedInputStream input,
+          org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+          throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+        return new PersistentMessage(input, extensionRegistry);
+      }
+    };
 
     public static org.apache.pekko.protobufv3.internal.Parser<PersistentMessage> parser() {
       return PARSER;
@@ -2219,69 +2009,61 @@ public final class MessageFormats {
     }
 
     @java.lang.Override
-    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-        getDefaultInstanceForType() {
+    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
+
   }
 
-  public interface PersistentPayloadOrBuilder
-      extends
+  public interface PersistentPayloadOrBuilder extends
       // @@protoc_insertion_point(interface_extends:PersistentPayload)
       org.apache.pekko.protobufv3.internal.MessageOrBuilder {
 
     /**
      * <code>required int32 serializerId = 1;</code>
-     *
      * @return Whether the serializerId field is set.
      */
     boolean hasSerializerId();
     /**
      * <code>required int32 serializerId = 1;</code>
-     *
      * @return The serializerId.
      */
     int getSerializerId();
 
     /**
      * <code>required bytes payload = 2;</code>
-     *
      * @return Whether the payload field is set.
      */
     boolean hasPayload();
     /**
      * <code>required bytes payload = 2;</code>
-     *
      * @return The payload.
      */
     org.apache.pekko.protobufv3.internal.ByteString getPayload();
 
     /**
      * <code>optional bytes payloadManifest = 3;</code>
-     *
      * @return Whether the payloadManifest field is set.
      */
     boolean hasPayloadManifest();
     /**
      * <code>optional bytes payloadManifest = 3;</code>
-     *
      * @return The payloadManifest.
      */
     org.apache.pekko.protobufv3.internal.ByteString getPayloadManifest();
   }
-  /** Protobuf type {@code PersistentPayload} */
-  public static final class PersistentPayload
-      extends org.apache.pekko.protobufv3.internal.GeneratedMessageV3
-      implements
+  /**
+   * Protobuf type {@code PersistentPayload}
+   */
+  public  static final class PersistentPayload extends
+      org.apache.pekko.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:PersistentPayload)
       PersistentPayloadOrBuilder {
-    private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     // Use PersistentPayload.newBuilder() to construct.
-    private PersistentPayload(
-        org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
+    private PersistentPayload(org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
-
     private PersistentPayload() {
       payload_ = org.apache.pekko.protobufv3.internal.ByteString.EMPTY;
       payloadManifest_ = org.apache.pekko.protobufv3.internal.ByteString.EMPTY;
@@ -2295,10 +2077,10 @@ public final class MessageFormats {
     }
 
     @java.lang.Override
-    public final org.apache.pekko.protobufv3.internal.UnknownFieldSet getUnknownFields() {
+    public final org.apache.pekko.protobufv3.internal.UnknownFieldSet
+    getUnknownFields() {
       return this.unknownFields;
     }
-
     private PersistentPayload(
         org.apache.pekko.protobufv3.internal.CodedInputStream input,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -2318,59 +2100,51 @@ public final class MessageFormats {
             case 0:
               done = true;
               break;
-            case 8:
-              {
-                bitField0_ |= 0x00000001;
-                serializerId_ = input.readInt32();
-                break;
+            case 8: {
+              bitField0_ |= 0x00000001;
+              serializerId_ = input.readInt32();
+              break;
+            }
+            case 18: {
+              bitField0_ |= 0x00000002;
+              payload_ = input.readBytes();
+              break;
+            }
+            case 26: {
+              bitField0_ |= 0x00000004;
+              payloadManifest_ = input.readBytes();
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
               }
-            case 18:
-              {
-                bitField0_ |= 0x00000002;
-                payload_ = input.readBytes();
-                break;
-              }
-            case 26:
-              {
-                bitField0_ |= 0x00000004;
-                payloadManifest_ = input.readBytes();
-                break;
-              }
-            default:
-              {
-                if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
-                  done = true;
-                }
-                break;
-              }
+              break;
+            }
           }
         }
       } catch (org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException(e)
-            .setUnfinishedMessage(this);
+        throw new org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
     }
-
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.persistence.serialization.MessageFormats
-          .internal_static_PersistentPayload_descriptor;
+      return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_PersistentPayload_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.persistence.serialization.MessageFormats
-          .internal_static_PersistentPayload_fieldAccessorTable
+      return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_PersistentPayload_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.class,
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder
-                  .class);
+              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.class, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder.class);
     }
 
     private int bitField0_;
@@ -2378,7 +2152,6 @@ public final class MessageFormats {
     private int serializerId_;
     /**
      * <code>required int32 serializerId = 1;</code>
-     *
      * @return Whether the serializerId field is set.
      */
     public boolean hasSerializerId() {
@@ -2386,7 +2159,6 @@ public final class MessageFormats {
     }
     /**
      * <code>required int32 serializerId = 1;</code>
-     *
      * @return The serializerId.
      */
     public int getSerializerId() {
@@ -2397,7 +2169,6 @@ public final class MessageFormats {
     private org.apache.pekko.protobufv3.internal.ByteString payload_;
     /**
      * <code>required bytes payload = 2;</code>
-     *
      * @return Whether the payload field is set.
      */
     public boolean hasPayload() {
@@ -2405,7 +2176,6 @@ public final class MessageFormats {
     }
     /**
      * <code>required bytes payload = 2;</code>
-     *
      * @return The payload.
      */
     public org.apache.pekko.protobufv3.internal.ByteString getPayload() {
@@ -2416,7 +2186,6 @@ public final class MessageFormats {
     private org.apache.pekko.protobufv3.internal.ByteString payloadManifest_;
     /**
      * <code>optional bytes payloadManifest = 3;</code>
-     *
      * @return Whether the payloadManifest field is set.
      */
     public boolean hasPayloadManifest() {
@@ -2424,7 +2193,6 @@ public final class MessageFormats {
     }
     /**
      * <code>optional bytes payloadManifest = 3;</code>
-     *
      * @return The payloadManifest.
      */
     public org.apache.pekko.protobufv3.internal.ByteString getPayloadManifest() {
@@ -2432,7 +2200,6 @@ public final class MessageFormats {
     }
 
     private byte memoizedIsInitialized = -1;
-
     @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -2453,7 +2220,7 @@ public final class MessageFormats {
 
     @java.lang.Override
     public void writeTo(org.apache.pekko.protobufv3.internal.CodedOutputStream output)
-        throws java.io.IOException {
+                        throws java.io.IOException {
       if (((bitField0_ & 0x00000001) != 0)) {
         output.writeInt32(1, serializerId_);
       }
@@ -2473,18 +2240,16 @@ public final class MessageFormats {
 
       size = 0;
       if (((bitField0_ & 0x00000001) != 0)) {
-        size +=
-            org.apache.pekko.protobufv3.internal.CodedOutputStream.computeInt32Size(
-                1, serializerId_);
+        size += org.apache.pekko.protobufv3.internal.CodedOutputStream
+          .computeInt32Size(1, serializerId_);
       }
       if (((bitField0_ & 0x00000002) != 0)) {
-        size +=
-            org.apache.pekko.protobufv3.internal.CodedOutputStream.computeBytesSize(2, payload_);
+        size += org.apache.pekko.protobufv3.internal.CodedOutputStream
+          .computeBytesSize(2, payload_);
       }
       if (((bitField0_ & 0x00000004) != 0)) {
-        size +=
-            org.apache.pekko.protobufv3.internal.CodedOutputStream.computeBytesSize(
-                3, payloadManifest_);
+        size += org.apache.pekko.protobufv3.internal.CodedOutputStream
+          .computeBytesSize(3, payloadManifest_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -2494,26 +2259,27 @@ public final class MessageFormats {
     @java.lang.Override
     public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
-        return true;
+       return true;
       }
-      if (!(obj
-          instanceof org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload)) {
+      if (!(obj instanceof org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload)) {
         return super.equals(obj);
       }
-      org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload other =
-          (org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload) obj;
+      org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload other = (org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload) obj;
 
       if (hasSerializerId() != other.hasSerializerId()) return false;
       if (hasSerializerId()) {
-        if (getSerializerId() != other.getSerializerId()) return false;
+        if (getSerializerId()
+            != other.getSerializerId()) return false;
       }
       if (hasPayload() != other.hasPayload()) return false;
       if (hasPayload()) {
-        if (!getPayload().equals(other.getPayload())) return false;
+        if (!getPayload()
+            .equals(other.getPayload())) return false;
       }
       if (hasPayloadManifest() != other.hasPayloadManifest()) return false;
       if (hasPayloadManifest()) {
-        if (!getPayloadManifest().equals(other.getPayloadManifest())) return false;
+        if (!getPayloadManifest()
+            .equals(other.getPayloadManifest())) return false;
       }
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
@@ -2543,111 +2309,88 @@ public final class MessageFormats {
       return hash;
     }
 
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-        parseFrom(java.nio.ByteBuffer data)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload parseFrom(
+        java.nio.ByteBuffer data)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-        parseFrom(
-            java.nio.ByteBuffer data,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload parseFrom(
+        java.nio.ByteBuffer data,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-        parseFrom(org.apache.pekko.protobufv3.internal.ByteString data)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload parseFrom(
+        org.apache.pekko.protobufv3.internal.ByteString data)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-        parseFrom(
-            org.apache.pekko.protobufv3.internal.ByteString data,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload parseFrom(
+        org.apache.pekko.protobufv3.internal.ByteString data,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-        parseFrom(byte[] data)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload parseFrom(byte[] data)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-        parseFrom(
-            byte[] data,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload parseFrom(
+        byte[] data,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-        parseFrom(java.io.InputStream input) throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-        parseFrom(
-            java.io.InputStream input,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input, extensionRegistry);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload parseFrom(
+        java.io.InputStream input,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
-          PARSER, input);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-        parseDelimitedFrom(
-            java.io.InputStream input,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
-          PARSER, input, extensionRegistry);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload parseDelimitedFrom(
+        java.io.InputStream input,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-        parseFrom(org.apache.pekko.protobufv3.internal.CodedInputStream input)
-            throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload parseFrom(
+        org.apache.pekko.protobufv3.internal.CodedInputStream input)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-        parseFrom(
-            org.apache.pekko.protobufv3.internal.CodedInputStream input,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input, extensionRegistry);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload parseFrom(
+        org.apache.pekko.protobufv3.internal.CodedInputStream input,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
     @java.lang.Override
-    public Builder newBuilderForType() {
-      return newBuilder();
-    }
-
+    public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-
-    public static Builder newBuilder(
-        org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload prototype) {
+    public static Builder newBuilder(org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-
     @java.lang.Override
     public Builder toBuilder() {
-      return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
     }
 
     @java.lang.Override
@@ -2656,31 +2399,27 @@ public final class MessageFormats {
       Builder builder = new Builder(parent);
       return builder;
     }
-    /** Protobuf type {@code PersistentPayload} */
-    public static final class Builder
-        extends org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<Builder>
-        implements
+    /**
+     * Protobuf type {@code PersistentPayload}
+     */
+    public static final class Builder extends
+        org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:PersistentPayload)
         org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.persistence.serialization.MessageFormats
-            .internal_static_PersistentPayload_descriptor;
+        return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_PersistentPayload_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.persistence.serialization.MessageFormats
-            .internal_static_PersistentPayload_fieldAccessorTable
+        return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_PersistentPayload_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.class,
-                org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder
-                    .class);
+                org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.class, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder.class);
       }
 
-      // Construct using
-      // org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.newBuilder()
+      // Construct using org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
@@ -2690,11 +2429,11 @@ public final class MessageFormats {
         super(parent);
         maybeForceBuilderInitialization();
       }
-
       private void maybeForceBuilderInitialization() {
-        if (org.apache.pekko.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders) {}
+        if (org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
       }
-
       @java.lang.Override
       public Builder clear() {
         super.clear();
@@ -2708,22 +2447,19 @@ public final class MessageFormats {
       }
 
       @java.lang.Override
-      public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor getDescriptorForType() {
-        return org.apache.pekko.persistence.serialization.MessageFormats
-            .internal_static_PersistentPayload_descriptor;
+      public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_PersistentPayload_descriptor;
       }
 
       @java.lang.Override
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-          getDefaultInstanceForType() {
-        return org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-            .getDefaultInstance();
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload getDefaultInstanceForType() {
+        return org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance();
       }
 
       @java.lang.Override
       public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload build() {
-        org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload result =
-            buildPartial();
+        org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
@@ -2731,10 +2467,8 @@ public final class MessageFormats {
       }
 
       @java.lang.Override
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-          buildPartial() {
-        org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload result =
-            new org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload(this);
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload buildPartial() {
+        org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload result = new org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
@@ -2758,59 +2492,46 @@ public final class MessageFormats {
       public Builder clone() {
         return super.clone();
       }
-
       @java.lang.Override
       public Builder setField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return super.setField(field, value);
       }
-
       @java.lang.Override
       public Builder clearField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-
       @java.lang.Override
       public Builder clearOneof(
           org.apache.pekko.protobufv3.internal.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-
       @java.lang.Override
       public Builder setRepeatedField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field,
-          int index,
-          java.lang.Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-
       @java.lang.Override
       public Builder addRepeatedField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-
       @java.lang.Override
       public Builder mergeFrom(org.apache.pekko.protobufv3.internal.Message other) {
-        if (other
-            instanceof
-            org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload) {
-          return mergeFrom(
-              (org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload) other);
+        if (other instanceof org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload) {
+          return mergeFrom((org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(
-          org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload other) {
-        if (other
-            == org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                .getDefaultInstance()) return this;
+      public Builder mergeFrom(org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload other) {
+        if (other == org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance()) return this;
         if (other.hasSerializerId()) {
           setSerializerId(other.getSerializerId());
         }
@@ -2841,14 +2562,11 @@ public final class MessageFormats {
           org.apache.pekko.protobufv3.internal.CodedInputStream input,
           org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload parsedMessage =
-            null;
+        org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException e) {
-          parsedMessage =
-              (org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload)
-                  e.getUnfinishedMessage();
+          parsedMessage = (org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -2857,13 +2575,11 @@ public final class MessageFormats {
         }
         return this;
       }
-
       private int bitField0_;
 
-      private int serializerId_;
+      private int serializerId_ ;
       /**
        * <code>required int32 serializerId = 1;</code>
-       *
        * @return Whether the serializerId field is set.
        */
       public boolean hasSerializerId() {
@@ -2871,7 +2587,6 @@ public final class MessageFormats {
       }
       /**
        * <code>required int32 serializerId = 1;</code>
-       *
        * @return The serializerId.
        */
       public int getSerializerId() {
@@ -2879,7 +2594,6 @@ public final class MessageFormats {
       }
       /**
        * <code>required int32 serializerId = 1;</code>
-       *
        * @param value The serializerId to set.
        * @return This builder for chaining.
        */
@@ -2891,7 +2605,6 @@ public final class MessageFormats {
       }
       /**
        * <code>required int32 serializerId = 1;</code>
-       *
        * @return This builder for chaining.
        */
       public Builder clearSerializerId() {
@@ -2901,11 +2614,9 @@ public final class MessageFormats {
         return this;
       }
 
-      private org.apache.pekko.protobufv3.internal.ByteString payload_ =
-          org.apache.pekko.protobufv3.internal.ByteString.EMPTY;
+      private org.apache.pekko.protobufv3.internal.ByteString payload_ = org.apache.pekko.protobufv3.internal.ByteString.EMPTY;
       /**
        * <code>required bytes payload = 2;</code>
-       *
        * @return Whether the payload field is set.
        */
       public boolean hasPayload() {
@@ -2913,7 +2624,6 @@ public final class MessageFormats {
       }
       /**
        * <code>required bytes payload = 2;</code>
-       *
        * @return The payload.
        */
       public org.apache.pekko.protobufv3.internal.ByteString getPayload() {
@@ -2921,22 +2631,20 @@ public final class MessageFormats {
       }
       /**
        * <code>required bytes payload = 2;</code>
-       *
        * @param value The payload to set.
        * @return This builder for chaining.
        */
       public Builder setPayload(org.apache.pekko.protobufv3.internal.ByteString value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000002;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
         payload_ = value;
         onChanged();
         return this;
       }
       /**
        * <code>required bytes payload = 2;</code>
-       *
        * @return This builder for chaining.
        */
       public Builder clearPayload() {
@@ -2946,11 +2654,9 @@ public final class MessageFormats {
         return this;
       }
 
-      private org.apache.pekko.protobufv3.internal.ByteString payloadManifest_ =
-          org.apache.pekko.protobufv3.internal.ByteString.EMPTY;
+      private org.apache.pekko.protobufv3.internal.ByteString payloadManifest_ = org.apache.pekko.protobufv3.internal.ByteString.EMPTY;
       /**
        * <code>optional bytes payloadManifest = 3;</code>
-       *
        * @return Whether the payloadManifest field is set.
        */
       public boolean hasPayloadManifest() {
@@ -2958,7 +2664,6 @@ public final class MessageFormats {
       }
       /**
        * <code>optional bytes payloadManifest = 3;</code>
-       *
        * @return The payloadManifest.
        */
       public org.apache.pekko.protobufv3.internal.ByteString getPayloadManifest() {
@@ -2966,22 +2671,20 @@ public final class MessageFormats {
       }
       /**
        * <code>optional bytes payloadManifest = 3;</code>
-       *
        * @param value The payloadManifest to set.
        * @return This builder for chaining.
        */
       public Builder setPayloadManifest(org.apache.pekko.protobufv3.internal.ByteString value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000004;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
         payloadManifest_ = value;
         onChanged();
         return this;
       }
       /**
        * <code>optional bytes payloadManifest = 3;</code>
-       *
        * @return This builder for chaining.
        */
       public Builder clearPayloadManifest() {
@@ -2990,7 +2693,6 @@ public final class MessageFormats {
         onChanged();
         return this;
       }
-
       @java.lang.Override
       public final Builder setUnknownFields(
           final org.apache.pekko.protobufv3.internal.UnknownFieldSet unknownFields) {
@@ -3003,34 +2705,30 @@ public final class MessageFormats {
         return super.mergeUnknownFields(unknownFields);
       }
 
+
       // @@protoc_insertion_point(builder_scope:PersistentPayload)
     }
 
     // @@protoc_insertion_point(class_scope:PersistentPayload)
-    private static final org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-        DEFAULT_INSTANCE;
-
+    private static final org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE =
-          new org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload();
+      DEFAULT_INSTANCE = new org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload();
     }
 
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-        getDefaultInstance() {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
-    @java.lang.Deprecated
-    public static final org.apache.pekko.protobufv3.internal.Parser<PersistentPayload> PARSER =
-        new org.apache.pekko.protobufv3.internal.AbstractParser<PersistentPayload>() {
-          @java.lang.Override
-          public PersistentPayload parsePartialFrom(
-              org.apache.pekko.protobufv3.internal.CodedInputStream input,
-              org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-              throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
-            return new PersistentPayload(input, extensionRegistry);
-          }
-        };
+    @java.lang.Deprecated public static final org.apache.pekko.protobufv3.internal.Parser<PersistentPayload>
+        PARSER = new org.apache.pekko.protobufv3.internal.AbstractParser<PersistentPayload>() {
+      @java.lang.Override
+      public PersistentPayload parsePartialFrom(
+          org.apache.pekko.protobufv3.internal.CodedInputStream input,
+          org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+          throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+        return new PersistentPayload(input, extensionRegistry);
+      }
+    };
 
     public static org.apache.pekko.protobufv3.internal.Parser<PersistentPayload> parser() {
       return PARSER;
@@ -3042,48 +2740,52 @@ public final class MessageFormats {
     }
 
     @java.lang.Override
-    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-        getDefaultInstanceForType() {
+    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
+
   }
 
-  public interface AtomicWriteOrBuilder
-      extends
+  public interface AtomicWriteOrBuilder extends
       // @@protoc_insertion_point(interface_extends:AtomicWrite)
       org.apache.pekko.protobufv3.internal.MessageOrBuilder {
 
-    /** <code>repeated .PersistentMessage payload = 1;</code> */
-    java.util.List<org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage>
+    /**
+     * <code>repeated .PersistentMessage payload = 1;</code>
+     */
+    java.util.List<org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage> 
         getPayloadList();
-    /** <code>repeated .PersistentMessage payload = 1;</code> */
-    org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage getPayload(
-        int index);
-    /** <code>repeated .PersistentMessage payload = 1;</code> */
+    /**
+     * <code>repeated .PersistentMessage payload = 1;</code>
+     */
+    org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage getPayload(int index);
+    /**
+     * <code>repeated .PersistentMessage payload = 1;</code>
+     */
     int getPayloadCount();
-    /** <code>repeated .PersistentMessage payload = 1;</code> */
-    java.util.List<
-            ? extends
-                org.apache.pekko.persistence.serialization.MessageFormats
-                    .PersistentMessageOrBuilder>
+    /**
+     * <code>repeated .PersistentMessage payload = 1;</code>
+     */
+    java.util.List<? extends org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessageOrBuilder> 
         getPayloadOrBuilderList();
-    /** <code>repeated .PersistentMessage payload = 1;</code> */
-    org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessageOrBuilder
-        getPayloadOrBuilder(int index);
+    /**
+     * <code>repeated .PersistentMessage payload = 1;</code>
+     */
+    org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessageOrBuilder getPayloadOrBuilder(
+        int index);
   }
-  /** Protobuf type {@code AtomicWrite} */
-  public static final class AtomicWrite
-      extends org.apache.pekko.protobufv3.internal.GeneratedMessageV3
-      implements
+  /**
+   * Protobuf type {@code AtomicWrite}
+   */
+  public  static final class AtomicWrite extends
+      org.apache.pekko.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:AtomicWrite)
       AtomicWriteOrBuilder {
-    private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     // Use AtomicWrite.newBuilder() to construct.
-    private AtomicWrite(
-        org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
+    private AtomicWrite(org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
-
     private AtomicWrite() {
       payload_ = java.util.Collections.emptyList();
     }
@@ -3096,10 +2798,10 @@ public final class MessageFormats {
     }
 
     @java.lang.Override
-    public final org.apache.pekko.protobufv3.internal.UnknownFieldSet getUnknownFields() {
+    public final org.apache.pekko.protobufv3.internal.UnknownFieldSet
+    getUnknownFields() {
       return this.unknownFields;
     }
-
     private AtomicWrite(
         org.apache.pekko.protobufv3.internal.CodedInputStream input,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -3119,36 +2821,29 @@ public final class MessageFormats {
             case 0:
               done = true;
               break;
-            case 10:
-              {
-                if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-                  payload_ =
-                      new java.util.ArrayList<
-                          org.apache.pekko.persistence.serialization.MessageFormats
-                              .PersistentMessage>();
-                  mutable_bitField0_ |= 0x00000001;
-                }
-                payload_.add(
-                    input.readMessage(
-                        org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-                            .PARSER,
-                        extensionRegistry));
-                break;
+            case 10: {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                payload_ = new java.util.ArrayList<org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage>();
+                mutable_bitField0_ |= 0x00000001;
               }
-            default:
-              {
-                if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
-                  done = true;
-                }
-                break;
+              payload_.add(
+                  input.readMessage(org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.PARSER, extensionRegistry));
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
               }
+              break;
+            }
           }
         }
       } catch (org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException(e)
-            .setUnfinishedMessage(this);
+        throw new org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
       } finally {
         if (((mutable_bitField0_ & 0x00000001) != 0)) {
           payload_ = java.util.Collections.unmodifiableList(payload_);
@@ -3157,58 +2852,55 @@ public final class MessageFormats {
         makeExtensionsImmutable();
       }
     }
-
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.persistence.serialization.MessageFormats
-          .internal_static_AtomicWrite_descriptor;
+      return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_AtomicWrite_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.persistence.serialization.MessageFormats
-          .internal_static_AtomicWrite_fieldAccessorTable
+      return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_AtomicWrite_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite.class,
-              org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite.Builder.class);
+              org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite.class, org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite.Builder.class);
     }
 
     public static final int PAYLOAD_FIELD_NUMBER = 1;
-    private java.util.List<
-            org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage>
-        payload_;
-    /** <code>repeated .PersistentMessage payload = 1;</code> */
-    public java.util.List<
-            org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage>
-        getPayloadList() {
+    private java.util.List<org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage> payload_;
+    /**
+     * <code>repeated .PersistentMessage payload = 1;</code>
+     */
+    public java.util.List<org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage> getPayloadList() {
       return payload_;
     }
-    /** <code>repeated .PersistentMessage payload = 1;</code> */
-    public java.util.List<
-            ? extends
-                org.apache.pekko.persistence.serialization.MessageFormats
-                    .PersistentMessageOrBuilder>
+    /**
+     * <code>repeated .PersistentMessage payload = 1;</code>
+     */
+    public java.util.List<? extends org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessageOrBuilder> 
         getPayloadOrBuilderList() {
       return payload_;
     }
-    /** <code>repeated .PersistentMessage payload = 1;</code> */
+    /**
+     * <code>repeated .PersistentMessage payload = 1;</code>
+     */
     public int getPayloadCount() {
       return payload_.size();
     }
-    /** <code>repeated .PersistentMessage payload = 1;</code> */
-    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage getPayload(
-        int index) {
+    /**
+     * <code>repeated .PersistentMessage payload = 1;</code>
+     */
+    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage getPayload(int index) {
       return payload_.get(index);
     }
-    /** <code>repeated .PersistentMessage payload = 1;</code> */
-    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessageOrBuilder
-        getPayloadOrBuilder(int index) {
+    /**
+     * <code>repeated .PersistentMessage payload = 1;</code>
+     */
+    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessageOrBuilder getPayloadOrBuilder(
+        int index) {
       return payload_.get(index);
     }
 
     private byte memoizedIsInitialized = -1;
-
     @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -3227,7 +2919,7 @@ public final class MessageFormats {
 
     @java.lang.Override
     public void writeTo(org.apache.pekko.protobufv3.internal.CodedOutputStream output)
-        throws java.io.IOException {
+                        throws java.io.IOException {
       for (int i = 0; i < payload_.size(); i++) {
         output.writeMessage(1, payload_.get(i));
       }
@@ -3241,9 +2933,8 @@ public final class MessageFormats {
 
       size = 0;
       for (int i = 0; i < payload_.size(); i++) {
-        size +=
-            org.apache.pekko.protobufv3.internal.CodedOutputStream.computeMessageSize(
-                1, payload_.get(i));
+        size += org.apache.pekko.protobufv3.internal.CodedOutputStream
+          .computeMessageSize(1, payload_.get(i));
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -3253,15 +2944,15 @@ public final class MessageFormats {
     @java.lang.Override
     public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
-        return true;
+       return true;
       }
       if (!(obj instanceof org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite)) {
         return super.equals(obj);
       }
-      org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite other =
-          (org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite) obj;
+      org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite other = (org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite) obj;
 
-      if (!getPayloadList().equals(other.getPayloadList())) return false;
+      if (!getPayloadList()
+          .equals(other.getPayloadList())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -3287,98 +2978,83 @@ public final class MessageFormats {
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-
     public static org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite parseFrom(
         java.nio.ByteBuffer data,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-
     public static org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite parseFrom(
         org.apache.pekko.protobufv3.internal.ByteString data)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-
     public static org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite parseFrom(
         org.apache.pekko.protobufv3.internal.ByteString data,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite parseFrom(
-        byte[] data) throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite parseFrom(byte[] data)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-
     public static org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite parseFrom(
-        byte[] data, org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        byte[] data,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite parseFrom(
-        java.io.InputStream input) throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
-
     public static org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite parseFrom(
         java.io.InputStream input,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input, extensionRegistry);
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite
-        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
-          PARSER, input);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite
-        parseDelimitedFrom(
-            java.io.InputStream input,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
-          PARSER, input, extensionRegistry);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite parseDelimitedFrom(
+        java.io.InputStream input,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-
     public static org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite parseFrom(
-        org.apache.pekko.protobufv3.internal.CodedInputStream input) throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input);
+        org.apache.pekko.protobufv3.internal.CodedInputStream input)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
-
     public static org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite parseFrom(
         org.apache.pekko.protobufv3.internal.CodedInputStream input,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input, extensionRegistry);
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
     @java.lang.Override
-    public Builder newBuilderForType() {
-      return newBuilder();
-    }
-
+    public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-
-    public static Builder newBuilder(
-        org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite prototype) {
+    public static Builder newBuilder(org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-
     @java.lang.Override
     public Builder toBuilder() {
-      return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
     }
 
     @java.lang.Override
@@ -3387,31 +3063,27 @@ public final class MessageFormats {
       Builder builder = new Builder(parent);
       return builder;
     }
-    /** Protobuf type {@code AtomicWrite} */
-    public static final class Builder
-        extends org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<Builder>
-        implements
+    /**
+     * Protobuf type {@code AtomicWrite}
+     */
+    public static final class Builder extends
+        org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:AtomicWrite)
         org.apache.pekko.persistence.serialization.MessageFormats.AtomicWriteOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.persistence.serialization.MessageFormats
-            .internal_static_AtomicWrite_descriptor;
+        return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_AtomicWrite_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.persistence.serialization.MessageFormats
-            .internal_static_AtomicWrite_fieldAccessorTable
+        return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_AtomicWrite_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite.class,
-                org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite.Builder
-                    .class);
+                org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite.class, org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite.Builder.class);
       }
 
-      // Construct using
-      // org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite.newBuilder()
+      // Construct using org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
@@ -3421,13 +3093,12 @@ public final class MessageFormats {
         super(parent);
         maybeForceBuilderInitialization();
       }
-
       private void maybeForceBuilderInitialization() {
-        if (org.apache.pekko.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders) {
+        if (org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
           getPayloadFieldBuilder();
         }
       }
-
       @java.lang.Override
       public Builder clear() {
         super.clear();
@@ -3441,22 +3112,19 @@ public final class MessageFormats {
       }
 
       @java.lang.Override
-      public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor getDescriptorForType() {
-        return org.apache.pekko.persistence.serialization.MessageFormats
-            .internal_static_AtomicWrite_descriptor;
+      public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_AtomicWrite_descriptor;
       }
 
       @java.lang.Override
-      public org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite
-          getDefaultInstanceForType() {
-        return org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite
-            .getDefaultInstance();
+      public org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite getDefaultInstanceForType() {
+        return org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite.getDefaultInstance();
       }
 
       @java.lang.Override
       public org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite build() {
-        org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite result =
-            buildPartial();
+        org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
@@ -3465,8 +3133,7 @@ public final class MessageFormats {
 
       @java.lang.Override
       public org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite buildPartial() {
-        org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite result =
-            new org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite(this);
+        org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite result = new org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite(this);
         int from_bitField0_ = bitField0_;
         if (payloadBuilder_ == null) {
           if (((bitField0_ & 0x00000001) != 0)) {
@@ -3485,58 +3152,46 @@ public final class MessageFormats {
       public Builder clone() {
         return super.clone();
       }
-
       @java.lang.Override
       public Builder setField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return super.setField(field, value);
       }
-
       @java.lang.Override
       public Builder clearField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-
       @java.lang.Override
       public Builder clearOneof(
           org.apache.pekko.protobufv3.internal.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-
       @java.lang.Override
       public Builder setRepeatedField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field,
-          int index,
-          java.lang.Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-
       @java.lang.Override
       public Builder addRepeatedField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-
       @java.lang.Override
       public Builder mergeFrom(org.apache.pekko.protobufv3.internal.Message other) {
-        if (other
-            instanceof org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite) {
-          return mergeFrom(
-              (org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite) other);
+        if (other instanceof org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite) {
+          return mergeFrom((org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(
-          org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite other) {
-        if (other
-            == org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite
-                .getDefaultInstance()) return this;
+      public Builder mergeFrom(org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite other) {
+        if (other == org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite.getDefaultInstance()) return this;
         if (payloadBuilder_ == null) {
           if (!other.payload_.isEmpty()) {
             if (payload_.isEmpty()) {
@@ -3555,10 +3210,9 @@ public final class MessageFormats {
               payloadBuilder_ = null;
               payload_ = other.payload_;
               bitField0_ = (bitField0_ & ~0x00000001);
-              payloadBuilder_ =
-                  org.apache.pekko.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders
-                      ? getPayloadFieldBuilder()
-                      : null;
+              payloadBuilder_ = 
+                org.apache.pekko.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders ?
+                   getPayloadFieldBuilder() : null;
             } else {
               payloadBuilder_.addAllMessages(other.payload_);
             }
@@ -3588,9 +3242,7 @@ public final class MessageFormats {
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException e) {
-          parsedMessage =
-              (org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite)
-                  e.getUnfinishedMessage();
+          parsedMessage = (org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -3599,40 +3251,33 @@ public final class MessageFormats {
         }
         return this;
       }
-
       private int bitField0_;
 
-      private java.util.List<
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage>
-          payload_ = java.util.Collections.emptyList();
-
+      private java.util.List<org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage> payload_ =
+        java.util.Collections.emptyList();
       private void ensurePayloadIsMutable() {
         if (!((bitField0_ & 0x00000001) != 0)) {
-          payload_ =
-              new java.util.ArrayList<
-                  org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage>(
-                  payload_);
+          payload_ = new java.util.ArrayList<org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage>(payload_);
           bitField0_ |= 0x00000001;
-        }
+         }
       }
 
       private org.apache.pekko.protobufv3.internal.RepeatedFieldBuilderV3<
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage,
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder,
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessageOrBuilder>
-          payloadBuilder_;
+          org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage, org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder, org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessageOrBuilder> payloadBuilder_;
 
-      /** <code>repeated .PersistentMessage payload = 1;</code> */
-      public java.util.List<
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage>
-          getPayloadList() {
+      /**
+       * <code>repeated .PersistentMessage payload = 1;</code>
+       */
+      public java.util.List<org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage> getPayloadList() {
         if (payloadBuilder_ == null) {
           return java.util.Collections.unmodifiableList(payload_);
         } else {
           return payloadBuilder_.getMessageList();
         }
       }
-      /** <code>repeated .PersistentMessage payload = 1;</code> */
+      /**
+       * <code>repeated .PersistentMessage payload = 1;</code>
+       */
       public int getPayloadCount() {
         if (payloadBuilder_ == null) {
           return payload_.size();
@@ -3640,19 +3285,21 @@ public final class MessageFormats {
           return payloadBuilder_.getCount();
         }
       }
-      /** <code>repeated .PersistentMessage payload = 1;</code> */
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage getPayload(
-          int index) {
+      /**
+       * <code>repeated .PersistentMessage payload = 1;</code>
+       */
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage getPayload(int index) {
         if (payloadBuilder_ == null) {
           return payload_.get(index);
         } else {
           return payloadBuilder_.getMessage(index);
         }
       }
-      /** <code>repeated .PersistentMessage payload = 1;</code> */
+      /**
+       * <code>repeated .PersistentMessage payload = 1;</code>
+       */
       public Builder setPayload(
-          int index,
-          org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage value) {
+          int index, org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage value) {
         if (payloadBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -3665,11 +3312,11 @@ public final class MessageFormats {
         }
         return this;
       }
-      /** <code>repeated .PersistentMessage payload = 1;</code> */
+      /**
+       * <code>repeated .PersistentMessage payload = 1;</code>
+       */
       public Builder setPayload(
-          int index,
-          org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder
-              builderForValue) {
+          int index, org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder builderForValue) {
         if (payloadBuilder_ == null) {
           ensurePayloadIsMutable();
           payload_.set(index, builderForValue.build());
@@ -3679,9 +3326,10 @@ public final class MessageFormats {
         }
         return this;
       }
-      /** <code>repeated .PersistentMessage payload = 1;</code> */
-      public Builder addPayload(
-          org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage value) {
+      /**
+       * <code>repeated .PersistentMessage payload = 1;</code>
+       */
+      public Builder addPayload(org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage value) {
         if (payloadBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -3694,10 +3342,11 @@ public final class MessageFormats {
         }
         return this;
       }
-      /** <code>repeated .PersistentMessage payload = 1;</code> */
+      /**
+       * <code>repeated .PersistentMessage payload = 1;</code>
+       */
       public Builder addPayload(
-          int index,
-          org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage value) {
+          int index, org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage value) {
         if (payloadBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -3710,10 +3359,11 @@ public final class MessageFormats {
         }
         return this;
       }
-      /** <code>repeated .PersistentMessage payload = 1;</code> */
+      /**
+       * <code>repeated .PersistentMessage payload = 1;</code>
+       */
       public Builder addPayload(
-          org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder
-              builderForValue) {
+          org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder builderForValue) {
         if (payloadBuilder_ == null) {
           ensurePayloadIsMutable();
           payload_.add(builderForValue.build());
@@ -3723,11 +3373,11 @@ public final class MessageFormats {
         }
         return this;
       }
-      /** <code>repeated .PersistentMessage payload = 1;</code> */
+      /**
+       * <code>repeated .PersistentMessage payload = 1;</code>
+       */
       public Builder addPayload(
-          int index,
-          org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder
-              builderForValue) {
+          int index, org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder builderForValue) {
         if (payloadBuilder_ == null) {
           ensurePayloadIsMutable();
           payload_.add(index, builderForValue.build());
@@ -3737,22 +3387,24 @@ public final class MessageFormats {
         }
         return this;
       }
-      /** <code>repeated .PersistentMessage payload = 1;</code> */
+      /**
+       * <code>repeated .PersistentMessage payload = 1;</code>
+       */
       public Builder addAllPayload(
-          java.lang.Iterable<
-                  ? extends
-                      org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage>
-              values) {
+          java.lang.Iterable<? extends org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage> values) {
         if (payloadBuilder_ == null) {
           ensurePayloadIsMutable();
-          org.apache.pekko.protobufv3.internal.AbstractMessageLite.Builder.addAll(values, payload_);
+          org.apache.pekko.protobufv3.internal.AbstractMessageLite.Builder.addAll(
+              values, payload_);
           onChanged();
         } else {
           payloadBuilder_.addAllMessages(values);
         }
         return this;
       }
-      /** <code>repeated .PersistentMessage payload = 1;</code> */
+      /**
+       * <code>repeated .PersistentMessage payload = 1;</code>
+       */
       public Builder clearPayload() {
         if (payloadBuilder_ == null) {
           payload_ = java.util.Collections.emptyList();
@@ -3763,7 +3415,9 @@ public final class MessageFormats {
         }
         return this;
       }
-      /** <code>repeated .PersistentMessage payload = 1;</code> */
+      /**
+       * <code>repeated .PersistentMessage payload = 1;</code>
+       */
       public Builder removePayload(int index) {
         if (payloadBuilder_ == null) {
           ensurePayloadIsMutable();
@@ -3774,75 +3428,70 @@ public final class MessageFormats {
         }
         return this;
       }
-      /** <code>repeated .PersistentMessage payload = 1;</code> */
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder
-          getPayloadBuilder(int index) {
+      /**
+       * <code>repeated .PersistentMessage payload = 1;</code>
+       */
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder getPayloadBuilder(
+          int index) {
         return getPayloadFieldBuilder().getBuilder(index);
       }
-      /** <code>repeated .PersistentMessage payload = 1;</code> */
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessageOrBuilder
-          getPayloadOrBuilder(int index) {
+      /**
+       * <code>repeated .PersistentMessage payload = 1;</code>
+       */
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessageOrBuilder getPayloadOrBuilder(
+          int index) {
         if (payloadBuilder_ == null) {
-          return payload_.get(index);
-        } else {
+          return payload_.get(index);  } else {
           return payloadBuilder_.getMessageOrBuilder(index);
         }
       }
-      /** <code>repeated .PersistentMessage payload = 1;</code> */
-      public java.util.List<
-              ? extends
-                  org.apache.pekko.persistence.serialization.MessageFormats
-                      .PersistentMessageOrBuilder>
-          getPayloadOrBuilderList() {
+      /**
+       * <code>repeated .PersistentMessage payload = 1;</code>
+       */
+      public java.util.List<? extends org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessageOrBuilder> 
+           getPayloadOrBuilderList() {
         if (payloadBuilder_ != null) {
           return payloadBuilder_.getMessageOrBuilderList();
         } else {
           return java.util.Collections.unmodifiableList(payload_);
         }
       }
-      /** <code>repeated .PersistentMessage payload = 1;</code> */
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder
-          addPayloadBuilder() {
-        return getPayloadFieldBuilder()
-            .addBuilder(
-                org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-                    .getDefaultInstance());
+      /**
+       * <code>repeated .PersistentMessage payload = 1;</code>
+       */
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder addPayloadBuilder() {
+        return getPayloadFieldBuilder().addBuilder(
+            org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.getDefaultInstance());
       }
-      /** <code>repeated .PersistentMessage payload = 1;</code> */
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder
-          addPayloadBuilder(int index) {
-        return getPayloadFieldBuilder()
-            .addBuilder(
-                index,
-                org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-                    .getDefaultInstance());
+      /**
+       * <code>repeated .PersistentMessage payload = 1;</code>
+       */
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder addPayloadBuilder(
+          int index) {
+        return getPayloadFieldBuilder().addBuilder(
+            index, org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.getDefaultInstance());
       }
-      /** <code>repeated .PersistentMessage payload = 1;</code> */
-      public java.util.List<
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder>
-          getPayloadBuilderList() {
+      /**
+       * <code>repeated .PersistentMessage payload = 1;</code>
+       */
+      public java.util.List<org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder> 
+           getPayloadBuilderList() {
         return getPayloadFieldBuilder().getBuilderList();
       }
-
       private org.apache.pekko.protobufv3.internal.RepeatedFieldBuilderV3<
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage,
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder,
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessageOrBuilder>
+          org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage, org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder, org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessageOrBuilder> 
           getPayloadFieldBuilder() {
         if (payloadBuilder_ == null) {
-          payloadBuilder_ =
-              new org.apache.pekko.protobufv3.internal.RepeatedFieldBuilderV3<
-                  org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage,
-                  org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage
-                      .Builder,
-                  org.apache.pekko.persistence.serialization.MessageFormats
-                      .PersistentMessageOrBuilder>(
-                  payload_, ((bitField0_ & 0x00000001) != 0), getParentForChildren(), isClean());
+          payloadBuilder_ = new org.apache.pekko.protobufv3.internal.RepeatedFieldBuilderV3<
+              org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage, org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessage.Builder, org.apache.pekko.persistence.serialization.MessageFormats.PersistentMessageOrBuilder>(
+                  payload_,
+                  ((bitField0_ & 0x00000001) != 0),
+                  getParentForChildren(),
+                  isClean());
           payload_ = null;
         }
         return payloadBuilder_;
       }
-
       @java.lang.Override
       public final Builder setUnknownFields(
           final org.apache.pekko.protobufv3.internal.UnknownFieldSet unknownFields) {
@@ -3855,34 +3504,30 @@ public final class MessageFormats {
         return super.mergeUnknownFields(unknownFields);
       }
 
+
       // @@protoc_insertion_point(builder_scope:AtomicWrite)
     }
 
     // @@protoc_insertion_point(class_scope:AtomicWrite)
-    private static final org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite
-        DEFAULT_INSTANCE;
-
+    private static final org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE =
-          new org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite();
+      DEFAULT_INSTANCE = new org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite();
     }
 
-    public static org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite
-        getDefaultInstance() {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
-    @java.lang.Deprecated
-    public static final org.apache.pekko.protobufv3.internal.Parser<AtomicWrite> PARSER =
-        new org.apache.pekko.protobufv3.internal.AbstractParser<AtomicWrite>() {
-          @java.lang.Override
-          public AtomicWrite parsePartialFrom(
-              org.apache.pekko.protobufv3.internal.CodedInputStream input,
-              org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-              throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
-            return new AtomicWrite(input, extensionRegistry);
-          }
-        };
+    @java.lang.Deprecated public static final org.apache.pekko.protobufv3.internal.Parser<AtomicWrite>
+        PARSER = new org.apache.pekko.protobufv3.internal.AbstractParser<AtomicWrite>() {
+      @java.lang.Override
+      public AtomicWrite parsePartialFrom(
+          org.apache.pekko.protobufv3.internal.CodedInputStream input,
+          org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+          throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+        return new AtomicWrite(input, extensionRegistry);
+      }
+    };
 
     public static org.apache.pekko.protobufv3.internal.Parser<AtomicWrite> parser() {
       return PARSER;
@@ -3894,80 +3539,63 @@ public final class MessageFormats {
     }
 
     @java.lang.Override
-    public org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite
-        getDefaultInstanceForType() {
+    public org.apache.pekko.persistence.serialization.MessageFormats.AtomicWrite getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
+
   }
 
-  public interface AtLeastOnceDeliverySnapshotOrBuilder
-      extends
+  public interface AtLeastOnceDeliverySnapshotOrBuilder extends
       // @@protoc_insertion_point(interface_extends:AtLeastOnceDeliverySnapshot)
       org.apache.pekko.protobufv3.internal.MessageOrBuilder {
 
     /**
      * <code>required int64 currentDeliveryId = 1;</code>
-     *
      * @return Whether the currentDeliveryId field is set.
      */
     boolean hasCurrentDeliveryId();
     /**
      * <code>required int64 currentDeliveryId = 1;</code>
-     *
      * @return The currentDeliveryId.
      */
     long getCurrentDeliveryId();
 
     /**
-     * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-     * </code>
+     * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
      */
-    java.util.List<
-            org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                .UnconfirmedDelivery>
+    java.util.List<org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery> 
         getUnconfirmedDeliveriesList();
     /**
-     * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-     * </code>
+     * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
      */
-    org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-            .UnconfirmedDelivery
-        getUnconfirmedDeliveries(int index);
+    org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery getUnconfirmedDeliveries(int index);
     /**
-     * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-     * </code>
+     * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
      */
     int getUnconfirmedDeliveriesCount();
     /**
-     * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-     * </code>
+     * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
      */
-    java.util.List<
-            ? extends
-                org.apache.pekko.persistence.serialization.MessageFormats
-                    .AtLeastOnceDeliverySnapshot.UnconfirmedDeliveryOrBuilder>
+    java.util.List<? extends org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDeliveryOrBuilder> 
         getUnconfirmedDeliveriesOrBuilderList();
     /**
-     * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-     * </code>
+     * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
      */
-    org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-            .UnconfirmedDeliveryOrBuilder
-        getUnconfirmedDeliveriesOrBuilder(int index);
+    org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDeliveryOrBuilder getUnconfirmedDeliveriesOrBuilder(
+        int index);
   }
-  /** Protobuf type {@code AtLeastOnceDeliverySnapshot} */
-  public static final class AtLeastOnceDeliverySnapshot
-      extends org.apache.pekko.protobufv3.internal.GeneratedMessageV3
-      implements
+  /**
+   * Protobuf type {@code AtLeastOnceDeliverySnapshot}
+   */
+  public  static final class AtLeastOnceDeliverySnapshot extends
+      org.apache.pekko.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:AtLeastOnceDeliverySnapshot)
       AtLeastOnceDeliverySnapshotOrBuilder {
-    private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     // Use AtLeastOnceDeliverySnapshot.newBuilder() to construct.
-    private AtLeastOnceDeliverySnapshot(
-        org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
+    private AtLeastOnceDeliverySnapshot(org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
-
     private AtLeastOnceDeliverySnapshot() {
       unconfirmedDeliveries_ = java.util.Collections.emptyList();
     }
@@ -3980,10 +3608,10 @@ public final class MessageFormats {
     }
 
     @java.lang.Override
-    public final org.apache.pekko.protobufv3.internal.UnknownFieldSet getUnknownFields() {
+    public final org.apache.pekko.protobufv3.internal.UnknownFieldSet
+    getUnknownFields() {
       return this.unknownFields;
     }
-
     private AtLeastOnceDeliverySnapshot(
         org.apache.pekko.protobufv3.internal.CodedInputStream input,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -4003,42 +3631,34 @@ public final class MessageFormats {
             case 0:
               done = true;
               break;
-            case 8:
-              {
-                bitField0_ |= 0x00000001;
-                currentDeliveryId_ = input.readInt64();
-                break;
+            case 8: {
+              bitField0_ |= 0x00000001;
+              currentDeliveryId_ = input.readInt64();
+              break;
+            }
+            case 18: {
+              if (!((mutable_bitField0_ & 0x00000002) != 0)) {
+                unconfirmedDeliveries_ = new java.util.ArrayList<org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery>();
+                mutable_bitField0_ |= 0x00000002;
               }
-            case 18:
-              {
-                if (!((mutable_bitField0_ & 0x00000002) != 0)) {
-                  unconfirmedDeliveries_ =
-                      new java.util.ArrayList<
-                          org.apache.pekko.persistence.serialization.MessageFormats
-                              .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery>();
-                  mutable_bitField0_ |= 0x00000002;
-                }
-                unconfirmedDeliveries_.add(
-                    input.readMessage(
-                        org.apache.pekko.persistence.serialization.MessageFormats
-                            .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.PARSER,
-                        extensionRegistry));
-                break;
+              unconfirmedDeliveries_.add(
+                  input.readMessage(org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.PARSER, extensionRegistry));
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
               }
-            default:
-              {
-                if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
-                  done = true;
-                }
-                break;
-              }
+              break;
+            }
           }
         }
       } catch (org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException(e)
-            .setUnfinishedMessage(this);
+        throw new org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
       } finally {
         if (((mutable_bitField0_ & 0x00000002) != 0)) {
           unconfirmedDeliveries_ = java.util.Collections.unmodifiableList(unconfirmedDeliveries_);
@@ -4047,91 +3667,78 @@ public final class MessageFormats {
         makeExtensionsImmutable();
       }
     }
-
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.persistence.serialization.MessageFormats
-          .internal_static_AtLeastOnceDeliverySnapshot_descriptor;
+      return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_AtLeastOnceDeliverySnapshot_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.persistence.serialization.MessageFormats
-          .internal_static_AtLeastOnceDeliverySnapshot_fieldAccessorTable
+      return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_AtLeastOnceDeliverySnapshot_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .class,
-              org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .Builder.class);
+              org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.class, org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.Builder.class);
     }
 
-    public interface UnconfirmedDeliveryOrBuilder
-        extends
+    public interface UnconfirmedDeliveryOrBuilder extends
         // @@protoc_insertion_point(interface_extends:AtLeastOnceDeliverySnapshot.UnconfirmedDelivery)
         org.apache.pekko.protobufv3.internal.MessageOrBuilder {
 
       /**
        * <code>required int64 deliveryId = 1;</code>
-       *
        * @return Whether the deliveryId field is set.
        */
       boolean hasDeliveryId();
       /**
        * <code>required int64 deliveryId = 1;</code>
-       *
        * @return The deliveryId.
        */
       long getDeliveryId();
 
       /**
        * <code>required string destination = 2;</code>
-       *
        * @return Whether the destination field is set.
        */
       boolean hasDestination();
       /**
        * <code>required string destination = 2;</code>
-       *
        * @return The destination.
        */
       java.lang.String getDestination();
       /**
        * <code>required string destination = 2;</code>
-       *
        * @return The bytes for destination.
        */
-      org.apache.pekko.protobufv3.internal.ByteString getDestinationBytes();
+      org.apache.pekko.protobufv3.internal.ByteString
+          getDestinationBytes();
 
       /**
        * <code>required .PersistentPayload payload = 3;</code>
-       *
        * @return Whether the payload field is set.
        */
       boolean hasPayload();
       /**
        * <code>required .PersistentPayload payload = 3;</code>
-       *
        * @return The payload.
        */
       org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload getPayload();
-      /** <code>required .PersistentPayload payload = 3;</code> */
-      org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder
-          getPayloadOrBuilder();
+      /**
+       * <code>required .PersistentPayload payload = 3;</code>
+       */
+      org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder getPayloadOrBuilder();
     }
-    /** Protobuf type {@code AtLeastOnceDeliverySnapshot.UnconfirmedDelivery} */
-    public static final class UnconfirmedDelivery
-        extends org.apache.pekko.protobufv3.internal.GeneratedMessageV3
-        implements
+    /**
+     * Protobuf type {@code AtLeastOnceDeliverySnapshot.UnconfirmedDelivery}
+     */
+    public  static final class UnconfirmedDelivery extends
+        org.apache.pekko.protobufv3.internal.GeneratedMessageV3 implements
         // @@protoc_insertion_point(message_implements:AtLeastOnceDeliverySnapshot.UnconfirmedDelivery)
         UnconfirmedDeliveryOrBuilder {
-      private static final long serialVersionUID = 0L;
+    private static final long serialVersionUID = 0L;
       // Use UnconfirmedDelivery.newBuilder() to construct.
-      private UnconfirmedDelivery(
-          org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
+      private UnconfirmedDelivery(org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
         super(builder);
       }
-
       private UnconfirmedDelivery() {
         destination_ = "";
       }
@@ -4144,10 +3751,10 @@ public final class MessageFormats {
       }
 
       @java.lang.Override
-      public final org.apache.pekko.protobufv3.internal.UnknownFieldSet getUnknownFields() {
+      public final org.apache.pekko.protobufv3.internal.UnknownFieldSet
+      getUnknownFields() {
         return this.unknownFields;
       }
-
       private UnconfirmedDelivery(
           org.apache.pekko.protobufv3.internal.CodedInputStream input,
           org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -4167,75 +3774,60 @@ public final class MessageFormats {
               case 0:
                 done = true;
                 break;
-              case 8:
-                {
-                  bitField0_ |= 0x00000001;
-                  deliveryId_ = input.readInt64();
-                  break;
+              case 8: {
+                bitField0_ |= 0x00000001;
+                deliveryId_ = input.readInt64();
+                break;
+              }
+              case 18: {
+                org.apache.pekko.protobufv3.internal.ByteString bs = input.readBytes();
+                bitField0_ |= 0x00000002;
+                destination_ = bs;
+                break;
+              }
+              case 26: {
+                org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder subBuilder = null;
+                if (((bitField0_ & 0x00000004) != 0)) {
+                  subBuilder = payload_.toBuilder();
                 }
-              case 18:
-                {
-                  org.apache.pekko.protobufv3.internal.ByteString bs = input.readBytes();
-                  bitField0_ |= 0x00000002;
-                  destination_ = bs;
-                  break;
+                payload_ = input.readMessage(org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.PARSER, extensionRegistry);
+                if (subBuilder != null) {
+                  subBuilder.mergeFrom(payload_);
+                  payload_ = subBuilder.buildPartial();
                 }
-              case 26:
-                {
-                  org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                          .Builder
-                      subBuilder = null;
-                  if (((bitField0_ & 0x00000004) != 0)) {
-                    subBuilder = payload_.toBuilder();
-                  }
-                  payload_ =
-                      input.readMessage(
-                          org.apache.pekko.persistence.serialization.MessageFormats
-                              .PersistentPayload.PARSER,
-                          extensionRegistry);
-                  if (subBuilder != null) {
-                    subBuilder.mergeFrom(payload_);
-                    payload_ = subBuilder.buildPartial();
-                  }
-                  bitField0_ |= 0x00000004;
-                  break;
+                bitField0_ |= 0x00000004;
+                break;
+              }
+              default: {
+                if (!parseUnknownField(
+                    input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
                 }
-              default:
-                {
-                  if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
-                    done = true;
-                  }
-                  break;
-                }
+                break;
+              }
             }
           }
         } catch (org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException e) {
           throw e.setUnfinishedMessage(this);
         } catch (java.io.IOException e) {
-          throw new org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException(e)
-              .setUnfinishedMessage(this);
+          throw new org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException(
+              e).setUnfinishedMessage(this);
         } finally {
           this.unknownFields = unknownFields.build();
           makeExtensionsImmutable();
         }
       }
-
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.persistence.serialization.MessageFormats
-            .internal_static_AtLeastOnceDeliverySnapshot_UnconfirmedDelivery_descriptor;
+        return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_AtLeastOnceDeliverySnapshot_UnconfirmedDelivery_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.persistence.serialization.MessageFormats
-            .internal_static_AtLeastOnceDeliverySnapshot_UnconfirmedDelivery_fieldAccessorTable
+        return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_AtLeastOnceDeliverySnapshot_UnconfirmedDelivery_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                org.apache.pekko.persistence.serialization.MessageFormats
-                    .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.class,
-                org.apache.pekko.persistence.serialization.MessageFormats
-                    .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.Builder.class);
+                org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.class, org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.Builder.class);
       }
 
       private int bitField0_;
@@ -4243,7 +3835,6 @@ public final class MessageFormats {
       private long deliveryId_;
       /**
        * <code>required int64 deliveryId = 1;</code>
-       *
        * @return Whether the deliveryId field is set.
        */
       public boolean hasDeliveryId() {
@@ -4251,7 +3842,6 @@ public final class MessageFormats {
       }
       /**
        * <code>required int64 deliveryId = 1;</code>
-       *
        * @return The deliveryId.
        */
       public long getDeliveryId() {
@@ -4262,7 +3852,6 @@ public final class MessageFormats {
       private volatile java.lang.Object destination_;
       /**
        * <code>required string destination = 2;</code>
-       *
        * @return Whether the destination field is set.
        */
       public boolean hasDestination() {
@@ -4270,7 +3859,6 @@ public final class MessageFormats {
       }
       /**
        * <code>required string destination = 2;</code>
-       *
        * @return The destination.
        */
       public java.lang.String getDestination() {
@@ -4278,7 +3866,7 @@ public final class MessageFormats {
         if (ref instanceof java.lang.String) {
           return (java.lang.String) ref;
         } else {
-          org.apache.pekko.protobufv3.internal.ByteString bs =
+          org.apache.pekko.protobufv3.internal.ByteString bs = 
               (org.apache.pekko.protobufv3.internal.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
@@ -4289,14 +3877,15 @@ public final class MessageFormats {
       }
       /**
        * <code>required string destination = 2;</code>
-       *
        * @return The bytes for destination.
        */
-      public org.apache.pekko.protobufv3.internal.ByteString getDestinationBytes() {
+      public org.apache.pekko.protobufv3.internal.ByteString
+          getDestinationBytes() {
         java.lang.Object ref = destination_;
         if (ref instanceof java.lang.String) {
-          org.apache.pekko.protobufv3.internal.ByteString b =
-              org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
+          org.apache.pekko.protobufv3.internal.ByteString b = 
+              org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
           destination_ = b;
           return b;
         } else {
@@ -4308,7 +3897,6 @@ public final class MessageFormats {
       private org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload payload_;
       /**
        * <code>required .PersistentPayload payload = 3;</code>
-       *
        * @return Whether the payload field is set.
        */
       public boolean hasPayload() {
@@ -4316,27 +3904,19 @@ public final class MessageFormats {
       }
       /**
        * <code>required .PersistentPayload payload = 3;</code>
-       *
        * @return The payload.
        */
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-          getPayload() {
-        return payload_ == null
-            ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                .getDefaultInstance()
-            : payload_;
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload getPayload() {
+        return payload_ == null ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance() : payload_;
       }
-      /** <code>required .PersistentPayload payload = 3;</code> */
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder
-          getPayloadOrBuilder() {
-        return payload_ == null
-            ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                .getDefaultInstance()
-            : payload_;
+      /**
+       * <code>required .PersistentPayload payload = 3;</code>
+       */
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder getPayloadOrBuilder() {
+        return payload_ == null ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance() : payload_;
       }
 
       private byte memoizedIsInitialized = -1;
-
       @java.lang.Override
       public final boolean isInitialized() {
         byte isInitialized = memoizedIsInitialized;
@@ -4365,13 +3945,12 @@ public final class MessageFormats {
 
       @java.lang.Override
       public void writeTo(org.apache.pekko.protobufv3.internal.CodedOutputStream output)
-          throws java.io.IOException {
+                          throws java.io.IOException {
         if (((bitField0_ & 0x00000001) != 0)) {
           output.writeInt64(1, deliveryId_);
         }
         if (((bitField0_ & 0x00000002) != 0)) {
-          org.apache.pekko.protobufv3.internal.GeneratedMessageV3.writeString(
-              output, 2, destination_);
+          org.apache.pekko.protobufv3.internal.GeneratedMessageV3.writeString(output, 2, destination_);
         }
         if (((bitField0_ & 0x00000004) != 0)) {
           output.writeMessage(3, getPayload());
@@ -4386,19 +3965,15 @@ public final class MessageFormats {
 
         size = 0;
         if (((bitField0_ & 0x00000001) != 0)) {
-          size +=
-              org.apache.pekko.protobufv3.internal.CodedOutputStream.computeInt64Size(
-                  1, deliveryId_);
+          size += org.apache.pekko.protobufv3.internal.CodedOutputStream
+            .computeInt64Size(1, deliveryId_);
         }
         if (((bitField0_ & 0x00000002) != 0)) {
-          size +=
-              org.apache.pekko.protobufv3.internal.GeneratedMessageV3.computeStringSize(
-                  2, destination_);
+          size += org.apache.pekko.protobufv3.internal.GeneratedMessageV3.computeStringSize(2, destination_);
         }
         if (((bitField0_ & 0x00000004) != 0)) {
-          size +=
-              org.apache.pekko.protobufv3.internal.CodedOutputStream.computeMessageSize(
-                  3, getPayload());
+          size += org.apache.pekko.protobufv3.internal.CodedOutputStream
+            .computeMessageSize(3, getPayload());
         }
         size += unknownFields.getSerializedSize();
         memoizedSize = size;
@@ -4408,32 +3983,27 @@ public final class MessageFormats {
       @java.lang.Override
       public boolean equals(final java.lang.Object obj) {
         if (obj == this) {
-          return true;
+         return true;
         }
-        if (!(obj
-            instanceof
-            org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                .UnconfirmedDelivery)) {
+        if (!(obj instanceof org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery)) {
           return super.equals(obj);
         }
-        org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                .UnconfirmedDelivery
-            other =
-                (org.apache.pekko.persistence.serialization.MessageFormats
-                        .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery)
-                    obj;
+        org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery other = (org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery) obj;
 
         if (hasDeliveryId() != other.hasDeliveryId()) return false;
         if (hasDeliveryId()) {
-          if (getDeliveryId() != other.getDeliveryId()) return false;
+          if (getDeliveryId()
+              != other.getDeliveryId()) return false;
         }
         if (hasDestination() != other.hasDestination()) return false;
         if (hasDestination()) {
-          if (!getDestination().equals(other.getDestination())) return false;
+          if (!getDestination()
+              .equals(other.getDestination())) return false;
         }
         if (hasPayload() != other.hasPayload()) return false;
         if (hasPayload()) {
-          if (!getPayload().equals(other.getPayload())) return false;
+          if (!getPayload()
+              .equals(other.getPayload())) return false;
         }
         if (!unknownFields.equals(other.unknownFields)) return false;
         return true;
@@ -4448,8 +4018,8 @@ public final class MessageFormats {
         hash = (19 * hash) + getDescriptor().hashCode();
         if (hasDeliveryId()) {
           hash = (37 * hash) + DELIVERYID_FIELD_NUMBER;
-          hash =
-              (53 * hash) + org.apache.pekko.protobufv3.internal.Internal.hashLong(getDeliveryId());
+          hash = (53 * hash) + org.apache.pekko.protobufv3.internal.Internal.hashLong(
+              getDeliveryId());
         }
         if (hasDestination()) {
           hash = (37 * hash) + DESTINATION_FIELD_NUMBER;
@@ -4464,125 +4034,88 @@ public final class MessageFormats {
         return hash;
       }
 
-      public static org.apache.pekko.persistence.serialization.MessageFormats
-              .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery
-          parseFrom(java.nio.ByteBuffer data)
-              throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+      public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery parseFrom(
+          java.nio.ByteBuffer data)
+          throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
       }
-
-      public static org.apache.pekko.persistence.serialization.MessageFormats
-              .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery
-          parseFrom(
-              java.nio.ByteBuffer data,
-              org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-              throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+      public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery parseFrom(
+          java.nio.ByteBuffer data,
+          org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+          throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
       }
-
-      public static org.apache.pekko.persistence.serialization.MessageFormats
-              .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery
-          parseFrom(org.apache.pekko.protobufv3.internal.ByteString data)
-              throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+      public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery parseFrom(
+          org.apache.pekko.protobufv3.internal.ByteString data)
+          throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
       }
-
-      public static org.apache.pekko.persistence.serialization.MessageFormats
-              .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery
-          parseFrom(
-              org.apache.pekko.protobufv3.internal.ByteString data,
-              org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-              throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+      public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery parseFrom(
+          org.apache.pekko.protobufv3.internal.ByteString data,
+          org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+          throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
       }
-
-      public static org.apache.pekko.persistence.serialization.MessageFormats
-              .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery
-          parseFrom(byte[] data)
-              throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+      public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery parseFrom(byte[] data)
+          throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
       }
-
-      public static org.apache.pekko.persistence.serialization.MessageFormats
-              .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery
-          parseFrom(
-              byte[] data,
-              org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-              throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+      public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery parseFrom(
+          byte[] data,
+          org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+          throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
       }
-
-      public static org.apache.pekko.persistence.serialization.MessageFormats
-              .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery
-          parseFrom(java.io.InputStream input) throws java.io.IOException {
-        return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-            PARSER, input);
+      public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery parseFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
       }
-
-      public static org.apache.pekko.persistence.serialization.MessageFormats
-              .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery
-          parseFrom(
-              java.io.InputStream input,
-              org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-              throws java.io.IOException {
-        return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-            PARSER, input, extensionRegistry);
+      public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery parseFrom(
+          java.io.InputStream input,
+          org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
       }
-
-      public static org.apache.pekko.persistence.serialization.MessageFormats
-              .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery
-          parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
+      public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery parseDelimitedFrom(java.io.InputStream input)
+          throws java.io.IOException {
         return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
-
-      public static org.apache.pekko.persistence.serialization.MessageFormats
-              .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery
-          parseDelimitedFrom(
-              java.io.InputStream input,
-              org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-              throws java.io.IOException {
+      public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery parseDelimitedFrom(
+          java.io.InputStream input,
+          org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
         return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
       }
-
-      public static org.apache.pekko.persistence.serialization.MessageFormats
-              .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery
-          parseFrom(org.apache.pekko.protobufv3.internal.CodedInputStream input)
-              throws java.io.IOException {
-        return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-            PARSER, input);
+      public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery parseFrom(
+          org.apache.pekko.protobufv3.internal.CodedInputStream input)
+          throws java.io.IOException {
+        return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
       }
-
-      public static org.apache.pekko.persistence.serialization.MessageFormats
-              .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery
-          parseFrom(
-              org.apache.pekko.protobufv3.internal.CodedInputStream input,
-              org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-              throws java.io.IOException {
-        return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-            PARSER, input, extensionRegistry);
+      public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery parseFrom(
+          org.apache.pekko.protobufv3.internal.CodedInputStream input,
+          org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
       }
 
       @java.lang.Override
-      public Builder newBuilderForType() {
-        return newBuilder();
-      }
-
+      public Builder newBuilderForType() { return newBuilder(); }
       public static Builder newBuilder() {
         return DEFAULT_INSTANCE.toBuilder();
       }
-
-      public static Builder newBuilder(
-          org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .UnconfirmedDelivery
-              prototype) {
+      public static Builder newBuilder(org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery prototype) {
         return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
       }
-
       @java.lang.Override
       public Builder toBuilder() {
-        return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+        return this == DEFAULT_INSTANCE
+            ? new Builder() : new Builder().mergeFrom(this);
       }
 
       @java.lang.Override
@@ -4591,33 +4124,27 @@ public final class MessageFormats {
         Builder builder = new Builder(parent);
         return builder;
       }
-      /** Protobuf type {@code AtLeastOnceDeliverySnapshot.UnconfirmedDelivery} */
-      public static final class Builder
-          extends org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<Builder>
-          implements
+      /**
+       * Protobuf type {@code AtLeastOnceDeliverySnapshot.UnconfirmedDelivery}
+       */
+      public static final class Builder extends
+          org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<Builder> implements
           // @@protoc_insertion_point(builder_implements:AtLeastOnceDeliverySnapshot.UnconfirmedDelivery)
-          org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-              .UnconfirmedDeliveryOrBuilder {
+          org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDeliveryOrBuilder {
         public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
             getDescriptor() {
-          return org.apache.pekko.persistence.serialization.MessageFormats
-              .internal_static_AtLeastOnceDeliverySnapshot_UnconfirmedDelivery_descriptor;
+          return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_AtLeastOnceDeliverySnapshot_UnconfirmedDelivery_descriptor;
         }
 
         @java.lang.Override
         protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return org.apache.pekko.persistence.serialization.MessageFormats
-              .internal_static_AtLeastOnceDeliverySnapshot_UnconfirmedDelivery_fieldAccessorTable
+          return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_AtLeastOnceDeliverySnapshot_UnconfirmedDelivery_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
-                  org.apache.pekko.persistence.serialization.MessageFormats
-                      .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.class,
-                  org.apache.pekko.persistence.serialization.MessageFormats
-                      .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.Builder.class);
+                  org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.class, org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.Builder.class);
         }
 
-        // Construct using
-        // org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.newBuilder()
+        // Construct using org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.newBuilder()
         private Builder() {
           maybeForceBuilderInitialization();
         }
@@ -4627,13 +4154,12 @@ public final class MessageFormats {
           super(parent);
           maybeForceBuilderInitialization();
         }
-
         private void maybeForceBuilderInitialization() {
-          if (org.apache.pekko.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders) {
+          if (org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+                  .alwaysUseFieldBuilders) {
             getPayloadFieldBuilder();
           }
         }
-
         @java.lang.Override
         public Builder clear() {
           super.clear();
@@ -4651,26 +4177,19 @@ public final class MessageFormats {
         }
 
         @java.lang.Override
-        public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor getDescriptorForType() {
-          return org.apache.pekko.persistence.serialization.MessageFormats
-              .internal_static_AtLeastOnceDeliverySnapshot_UnconfirmedDelivery_descriptor;
+        public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
+            getDescriptorForType() {
+          return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_AtLeastOnceDeliverySnapshot_UnconfirmedDelivery_descriptor;
         }
 
         @java.lang.Override
-        public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                .UnconfirmedDelivery
-            getDefaultInstanceForType() {
-          return org.apache.pekko.persistence.serialization.MessageFormats
-              .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.getDefaultInstance();
+        public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery getDefaultInstanceForType() {
+          return org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.getDefaultInstance();
         }
 
         @java.lang.Override
-        public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                .UnconfirmedDelivery
-            build() {
-          org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .UnconfirmedDelivery
-              result = buildPartial();
+        public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery build() {
+          org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery result = buildPartial();
           if (!result.isInitialized()) {
             throw newUninitializedMessageException(result);
           }
@@ -4678,14 +4197,8 @@ public final class MessageFormats {
         }
 
         @java.lang.Override
-        public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                .UnconfirmedDelivery
-            buildPartial() {
-          org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .UnconfirmedDelivery
-              result =
-                  new org.apache.pekko.persistence.serialization.MessageFormats
-                      .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery(this);
+        public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery buildPartial() {
+          org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery result = new org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery(this);
           int from_bitField0_ = bitField0_;
           int to_bitField0_ = 0;
           if (((from_bitField0_ & 0x00000001) != 0)) {
@@ -4713,65 +4226,46 @@ public final class MessageFormats {
         public Builder clone() {
           return super.clone();
         }
-
         @java.lang.Override
         public Builder setField(
             org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
           return super.setField(field, value);
         }
-
         @java.lang.Override
         public Builder clearField(
             org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field) {
           return super.clearField(field);
         }
-
         @java.lang.Override
         public Builder clearOneof(
             org.apache.pekko.protobufv3.internal.Descriptors.OneofDescriptor oneof) {
           return super.clearOneof(oneof);
         }
-
         @java.lang.Override
         public Builder setRepeatedField(
             org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field,
-            int index,
-            java.lang.Object value) {
+            int index, java.lang.Object value) {
           return super.setRepeatedField(field, index, value);
         }
-
         @java.lang.Override
         public Builder addRepeatedField(
             org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
           return super.addRepeatedField(field, value);
         }
-
         @java.lang.Override
         public Builder mergeFrom(org.apache.pekko.protobufv3.internal.Message other) {
-          if (other
-              instanceof
-              org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .UnconfirmedDelivery) {
-            return mergeFrom(
-                (org.apache.pekko.persistence.serialization.MessageFormats
-                        .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery)
-                    other);
+          if (other instanceof org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery) {
+            return mergeFrom((org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery)other);
           } else {
             super.mergeFrom(other);
             return this;
           }
         }
 
-        public Builder mergeFrom(
-            org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                    .UnconfirmedDelivery
-                other) {
-          if (other
-              == org.apache.pekko.persistence.serialization.MessageFormats
-                  .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.getDefaultInstance())
-            return this;
+        public Builder mergeFrom(org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery other) {
+          if (other == org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.getDefaultInstance()) return this;
           if (other.hasDeliveryId()) {
             setDeliveryId(other.getDeliveryId());
           }
@@ -4810,16 +4304,11 @@ public final class MessageFormats {
             org.apache.pekko.protobufv3.internal.CodedInputStream input,
             org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-          org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .UnconfirmedDelivery
-              parsedMessage = null;
+          org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery parsedMessage = null;
           try {
             parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
           } catch (org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException e) {
-            parsedMessage =
-                (org.apache.pekko.persistence.serialization.MessageFormats
-                        .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery)
-                    e.getUnfinishedMessage();
+            parsedMessage = (org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery) e.getUnfinishedMessage();
             throw e.unwrapIOException();
           } finally {
             if (parsedMessage != null) {
@@ -4828,13 +4317,11 @@ public final class MessageFormats {
           }
           return this;
         }
-
         private int bitField0_;
 
-        private long deliveryId_;
+        private long deliveryId_ ;
         /**
          * <code>required int64 deliveryId = 1;</code>
-         *
          * @return Whether the deliveryId field is set.
          */
         public boolean hasDeliveryId() {
@@ -4842,7 +4329,6 @@ public final class MessageFormats {
         }
         /**
          * <code>required int64 deliveryId = 1;</code>
-         *
          * @return The deliveryId.
          */
         public long getDeliveryId() {
@@ -4850,7 +4336,6 @@ public final class MessageFormats {
         }
         /**
          * <code>required int64 deliveryId = 1;</code>
-         *
          * @param value The deliveryId to set.
          * @return This builder for chaining.
          */
@@ -4862,7 +4347,6 @@ public final class MessageFormats {
         }
         /**
          * <code>required int64 deliveryId = 1;</code>
-         *
          * @return This builder for chaining.
          */
         public Builder clearDeliveryId() {
@@ -4875,7 +4359,6 @@ public final class MessageFormats {
         private java.lang.Object destination_ = "";
         /**
          * <code>required string destination = 2;</code>
-         *
          * @return Whether the destination field is set.
          */
         public boolean hasDestination() {
@@ -4883,7 +4366,6 @@ public final class MessageFormats {
         }
         /**
          * <code>required string destination = 2;</code>
-         *
          * @return The destination.
          */
         public java.lang.String getDestination() {
@@ -4902,13 +4384,13 @@ public final class MessageFormats {
         }
         /**
          * <code>required string destination = 2;</code>
-         *
          * @return The bytes for destination.
          */
-        public org.apache.pekko.protobufv3.internal.ByteString getDestinationBytes() {
+        public org.apache.pekko.protobufv3.internal.ByteString
+            getDestinationBytes() {
           java.lang.Object ref = destination_;
           if (ref instanceof String) {
-            org.apache.pekko.protobufv3.internal.ByteString b =
+            org.apache.pekko.protobufv3.internal.ByteString b = 
                 org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8(
                     (java.lang.String) ref);
             destination_ = b;
@@ -4919,22 +4401,21 @@ public final class MessageFormats {
         }
         /**
          * <code>required string destination = 2;</code>
-         *
          * @param value The destination to set.
          * @return This builder for chaining.
          */
-        public Builder setDestination(java.lang.String value) {
+        public Builder setDestination(
+            java.lang.String value) {
           if (value == null) {
-            throw new NullPointerException();
-          }
-          bitField0_ |= 0x00000002;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
           destination_ = value;
           onChanged();
           return this;
         }
         /**
          * <code>required string destination = 2;</code>
-         *
          * @return This builder for chaining.
          */
         public Builder clearDestination() {
@@ -4945,31 +4426,25 @@ public final class MessageFormats {
         }
         /**
          * <code>required string destination = 2;</code>
-         *
          * @param value The bytes for destination to set.
          * @return This builder for chaining.
          */
-        public Builder setDestinationBytes(org.apache.pekko.protobufv3.internal.ByteString value) {
+        public Builder setDestinationBytes(
+            org.apache.pekko.protobufv3.internal.ByteString value) {
           if (value == null) {
-            throw new NullPointerException();
-          }
-          bitField0_ |= 0x00000002;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
           destination_ = value;
           onChanged();
           return this;
         }
 
-        private org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-            payload_;
+        private org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload payload_;
         private org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
-                org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload,
-                org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder,
-                org.apache.pekko.persistence.serialization.MessageFormats
-                    .PersistentPayloadOrBuilder>
-            payloadBuilder_;
+            org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder> payloadBuilder_;
         /**
          * <code>required .PersistentPayload payload = 3;</code>
-         *
          * @return Whether the payload field is set.
          */
         public boolean hasPayload() {
@@ -4977,23 +4452,19 @@ public final class MessageFormats {
         }
         /**
          * <code>required .PersistentPayload payload = 3;</code>
-         *
          * @return The payload.
          */
-        public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-            getPayload() {
+        public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload getPayload() {
           if (payloadBuilder_ == null) {
-            return payload_ == null
-                ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                    .getDefaultInstance()
-                : payload_;
+            return payload_ == null ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance() : payload_;
           } else {
             return payloadBuilder_.getMessage();
           }
         }
-        /** <code>required .PersistentPayload payload = 3;</code> */
-        public Builder setPayload(
-            org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload value) {
+        /**
+         * <code>required .PersistentPayload payload = 3;</code>
+         */
+        public Builder setPayload(org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload value) {
           if (payloadBuilder_ == null) {
             if (value == null) {
               throw new NullPointerException();
@@ -5006,10 +4477,11 @@ public final class MessageFormats {
           bitField0_ |= 0x00000004;
           return this;
         }
-        /** <code>required .PersistentPayload payload = 3;</code> */
+        /**
+         * <code>required .PersistentPayload payload = 3;</code>
+         */
         public Builder setPayload(
-            org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder
-                builderForValue) {
+            org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder builderForValue) {
           if (payloadBuilder_ == null) {
             payload_ = builderForValue.build();
             onChanged();
@@ -5019,20 +4491,16 @@ public final class MessageFormats {
           bitField0_ |= 0x00000004;
           return this;
         }
-        /** <code>required .PersistentPayload payload = 3;</code> */
-        public Builder mergePayload(
-            org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload value) {
+        /**
+         * <code>required .PersistentPayload payload = 3;</code>
+         */
+        public Builder mergePayload(org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload value) {
           if (payloadBuilder_ == null) {
-            if (((bitField0_ & 0x00000004) != 0)
-                && payload_ != null
-                && payload_
-                    != org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                        .getDefaultInstance()) {
+            if (((bitField0_ & 0x00000004) != 0) &&
+                payload_ != null &&
+                payload_ != org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance()) {
               payload_ =
-                  org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                      .newBuilder(payload_)
-                      .mergeFrom(value)
-                      .buildPartial();
+                org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.newBuilder(payload_).mergeFrom(value).buildPartial();
             } else {
               payload_ = value;
             }
@@ -5043,7 +4511,9 @@ public final class MessageFormats {
           bitField0_ |= 0x00000004;
           return this;
         }
-        /** <code>required .PersistentPayload payload = 3;</code> */
+        /**
+         * <code>required .PersistentPayload payload = 3;</code>
+         */
         public Builder clearPayload() {
           if (payloadBuilder_ == null) {
             payload_ = null;
@@ -5054,46 +4524,41 @@ public final class MessageFormats {
           bitField0_ = (bitField0_ & ~0x00000004);
           return this;
         }
-        /** <code>required .PersistentPayload payload = 3;</code> */
-        public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder
-            getPayloadBuilder() {
+        /**
+         * <code>required .PersistentPayload payload = 3;</code>
+         */
+        public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder getPayloadBuilder() {
           bitField0_ |= 0x00000004;
           onChanged();
           return getPayloadFieldBuilder().getBuilder();
         }
-        /** <code>required .PersistentPayload payload = 3;</code> */
-        public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder
-            getPayloadOrBuilder() {
+        /**
+         * <code>required .PersistentPayload payload = 3;</code>
+         */
+        public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder getPayloadOrBuilder() {
           if (payloadBuilder_ != null) {
             return payloadBuilder_.getMessageOrBuilder();
           } else {
-            return payload_ == null
-                ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                    .getDefaultInstance()
-                : payload_;
+            return payload_ == null ?
+                org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance() : payload_;
           }
         }
-        /** <code>required .PersistentPayload payload = 3;</code> */
+        /**
+         * <code>required .PersistentPayload payload = 3;</code>
+         */
         private org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
-                org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload,
-                org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder,
-                org.apache.pekko.persistence.serialization.MessageFormats
-                    .PersistentPayloadOrBuilder>
+            org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder> 
             getPayloadFieldBuilder() {
           if (payloadBuilder_ == null) {
-            payloadBuilder_ =
-                new org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
-                    org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload,
-                    org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                        .Builder,
-                    org.apache.pekko.persistence.serialization.MessageFormats
-                        .PersistentPayloadOrBuilder>(
-                    getPayload(), getParentForChildren(), isClean());
+            payloadBuilder_ = new org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
+                org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder>(
+                    getPayload(),
+                    getParentForChildren(),
+                    isClean());
             payload_ = null;
           }
           return payloadBuilder_;
         }
-
         @java.lang.Override
         public final Builder setUnknownFields(
             final org.apache.pekko.protobufv3.internal.UnknownFieldSet unknownFields) {
@@ -5106,37 +4571,30 @@ public final class MessageFormats {
           return super.mergeUnknownFields(unknownFields);
         }
 
+
         // @@protoc_insertion_point(builder_scope:AtLeastOnceDeliverySnapshot.UnconfirmedDelivery)
       }
 
       // @@protoc_insertion_point(class_scope:AtLeastOnceDeliverySnapshot.UnconfirmedDelivery)
-      private static final org.apache.pekko.persistence.serialization.MessageFormats
-              .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery
-          DEFAULT_INSTANCE;
-
+      private static final org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery DEFAULT_INSTANCE;
       static {
-        DEFAULT_INSTANCE =
-            new org.apache.pekko.persistence.serialization.MessageFormats
-                .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery();
+        DEFAULT_INSTANCE = new org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery();
       }
 
-      public static org.apache.pekko.persistence.serialization.MessageFormats
-              .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery
-          getDefaultInstance() {
+      public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery getDefaultInstance() {
         return DEFAULT_INSTANCE;
       }
 
-      @java.lang.Deprecated
-      public static final org.apache.pekko.protobufv3.internal.Parser<UnconfirmedDelivery> PARSER =
-          new org.apache.pekko.protobufv3.internal.AbstractParser<UnconfirmedDelivery>() {
-            @java.lang.Override
-            public UnconfirmedDelivery parsePartialFrom(
-                org.apache.pekko.protobufv3.internal.CodedInputStream input,
-                org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-                throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
-              return new UnconfirmedDelivery(input, extensionRegistry);
-            }
-          };
+      @java.lang.Deprecated public static final org.apache.pekko.protobufv3.internal.Parser<UnconfirmedDelivery>
+          PARSER = new org.apache.pekko.protobufv3.internal.AbstractParser<UnconfirmedDelivery>() {
+        @java.lang.Override
+        public UnconfirmedDelivery parsePartialFrom(
+            org.apache.pekko.protobufv3.internal.CodedInputStream input,
+            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+          return new UnconfirmedDelivery(input, extensionRegistry);
+        }
+      };
 
       public static org.apache.pekko.protobufv3.internal.Parser<UnconfirmedDelivery> parser() {
         return PARSER;
@@ -5148,11 +4606,10 @@ public final class MessageFormats {
       }
 
       @java.lang.Override
-      public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-              .UnconfirmedDelivery
-          getDefaultInstanceForType() {
+      public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery getDefaultInstanceForType() {
         return DEFAULT_INSTANCE;
       }
+
     }
 
     private int bitField0_;
@@ -5160,7 +4617,6 @@ public final class MessageFormats {
     private long currentDeliveryId_;
     /**
      * <code>required int64 currentDeliveryId = 1;</code>
-     *
      * @return Whether the currentDeliveryId field is set.
      */
     public boolean hasCurrentDeliveryId() {
@@ -5168,7 +4624,6 @@ public final class MessageFormats {
     }
     /**
      * <code>required int64 currentDeliveryId = 1;</code>
-     *
      * @return The currentDeliveryId.
      */
     public long getCurrentDeliveryId() {
@@ -5176,59 +4631,41 @@ public final class MessageFormats {
     }
 
     public static final int UNCONFIRMEDDELIVERIES_FIELD_NUMBER = 2;
-    private java.util.List<
-            org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                .UnconfirmedDelivery>
-        unconfirmedDeliveries_;
+    private java.util.List<org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery> unconfirmedDeliveries_;
     /**
-     * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-     * </code>
+     * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
      */
-    public java.util.List<
-            org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                .UnconfirmedDelivery>
-        getUnconfirmedDeliveriesList() {
+    public java.util.List<org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery> getUnconfirmedDeliveriesList() {
       return unconfirmedDeliveries_;
     }
     /**
-     * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-     * </code>
+     * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
      */
-    public java.util.List<
-            ? extends
-                org.apache.pekko.persistence.serialization.MessageFormats
-                    .AtLeastOnceDeliverySnapshot.UnconfirmedDeliveryOrBuilder>
+    public java.util.List<? extends org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDeliveryOrBuilder> 
         getUnconfirmedDeliveriesOrBuilderList() {
       return unconfirmedDeliveries_;
     }
     /**
-     * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-     * </code>
+     * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
      */
     public int getUnconfirmedDeliveriesCount() {
       return unconfirmedDeliveries_.size();
     }
     /**
-     * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-     * </code>
+     * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
      */
-    public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-            .UnconfirmedDelivery
-        getUnconfirmedDeliveries(int index) {
+    public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery getUnconfirmedDeliveries(int index) {
       return unconfirmedDeliveries_.get(index);
     }
     /**
-     * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-     * </code>
+     * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
      */
-    public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-            .UnconfirmedDeliveryOrBuilder
-        getUnconfirmedDeliveriesOrBuilder(int index) {
+    public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDeliveryOrBuilder getUnconfirmedDeliveriesOrBuilder(
+        int index) {
       return unconfirmedDeliveries_.get(index);
     }
 
     private byte memoizedIsInitialized = -1;
-
     @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -5251,7 +4688,7 @@ public final class MessageFormats {
 
     @java.lang.Override
     public void writeTo(org.apache.pekko.protobufv3.internal.CodedOutputStream output)
-        throws java.io.IOException {
+                        throws java.io.IOException {
       if (((bitField0_ & 0x00000001) != 0)) {
         output.writeInt64(1, currentDeliveryId_);
       }
@@ -5268,14 +4705,12 @@ public final class MessageFormats {
 
       size = 0;
       if (((bitField0_ & 0x00000001) != 0)) {
-        size +=
-            org.apache.pekko.protobufv3.internal.CodedOutputStream.computeInt64Size(
-                1, currentDeliveryId_);
+        size += org.apache.pekko.protobufv3.internal.CodedOutputStream
+          .computeInt64Size(1, currentDeliveryId_);
       }
       for (int i = 0; i < unconfirmedDeliveries_.size(); i++) {
-        size +=
-            org.apache.pekko.protobufv3.internal.CodedOutputStream.computeMessageSize(
-                2, unconfirmedDeliveries_.get(i));
+        size += org.apache.pekko.protobufv3.internal.CodedOutputStream
+          .computeMessageSize(2, unconfirmedDeliveries_.get(i));
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -5285,23 +4720,20 @@ public final class MessageFormats {
     @java.lang.Override
     public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
-        return true;
+       return true;
       }
-      if (!(obj
-          instanceof
-          org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot)) {
+      if (!(obj instanceof org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot)) {
         return super.equals(obj);
       }
-      org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot other =
-          (org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot)
-              obj;
+      org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot other = (org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot) obj;
 
       if (hasCurrentDeliveryId() != other.hasCurrentDeliveryId()) return false;
       if (hasCurrentDeliveryId()) {
-        if (getCurrentDeliveryId() != other.getCurrentDeliveryId()) return false;
+        if (getCurrentDeliveryId()
+            != other.getCurrentDeliveryId()) return false;
       }
-      if (!getUnconfirmedDeliveriesList().equals(other.getUnconfirmedDeliveriesList()))
-        return false;
+      if (!getUnconfirmedDeliveriesList()
+          .equals(other.getUnconfirmedDeliveriesList())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -5315,9 +4747,8 @@ public final class MessageFormats {
       hash = (19 * hash) + getDescriptor().hashCode();
       if (hasCurrentDeliveryId()) {
         hash = (37 * hash) + CURRENTDELIVERYID_FIELD_NUMBER;
-        hash =
-            (53 * hash)
-                + org.apache.pekko.protobufv3.internal.Internal.hashLong(getCurrentDeliveryId());
+        hash = (53 * hash) + org.apache.pekko.protobufv3.internal.Internal.hashLong(
+            getCurrentDeliveryId());
       }
       if (getUnconfirmedDeliveriesCount() > 0) {
         hash = (37 * hash) + UNCONFIRMEDDELIVERIES_FIELD_NUMBER;
@@ -5328,124 +4759,88 @@ public final class MessageFormats {
       return hash;
     }
 
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .AtLeastOnceDeliverySnapshot
-        parseFrom(java.nio.ByteBuffer data)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot parseFrom(
+        java.nio.ByteBuffer data)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .AtLeastOnceDeliverySnapshot
-        parseFrom(
-            java.nio.ByteBuffer data,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot parseFrom(
+        java.nio.ByteBuffer data,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .AtLeastOnceDeliverySnapshot
-        parseFrom(org.apache.pekko.protobufv3.internal.ByteString data)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot parseFrom(
+        org.apache.pekko.protobufv3.internal.ByteString data)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .AtLeastOnceDeliverySnapshot
-        parseFrom(
-            org.apache.pekko.protobufv3.internal.ByteString data,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot parseFrom(
+        org.apache.pekko.protobufv3.internal.ByteString data,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .AtLeastOnceDeliverySnapshot
-        parseFrom(byte[] data)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot parseFrom(byte[] data)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .AtLeastOnceDeliverySnapshot
-        parseFrom(
-            byte[] data,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot parseFrom(
+        byte[] data,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .AtLeastOnceDeliverySnapshot
-        parseFrom(java.io.InputStream input) throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .AtLeastOnceDeliverySnapshot
-        parseFrom(
-            java.io.InputStream input,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input, extensionRegistry);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot parseFrom(
+        java.io.InputStream input,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .AtLeastOnceDeliverySnapshot
-        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
-          PARSER, input);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .AtLeastOnceDeliverySnapshot
-        parseDelimitedFrom(
-            java.io.InputStream input,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
-          PARSER, input, extensionRegistry);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot parseDelimitedFrom(
+        java.io.InputStream input,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .AtLeastOnceDeliverySnapshot
-        parseFrom(org.apache.pekko.protobufv3.internal.CodedInputStream input)
-            throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot parseFrom(
+        org.apache.pekko.protobufv3.internal.CodedInputStream input)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .AtLeastOnceDeliverySnapshot
-        parseFrom(
-            org.apache.pekko.protobufv3.internal.CodedInputStream input,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input, extensionRegistry);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot parseFrom(
+        org.apache.pekko.protobufv3.internal.CodedInputStream input,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
     @java.lang.Override
-    public Builder newBuilderForType() {
-      return newBuilder();
-    }
-
+    public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-
-    public static Builder newBuilder(
-        org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-            prototype) {
+    public static Builder newBuilder(org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-
     @java.lang.Override
     public Builder toBuilder() {
-      return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
     }
 
     @java.lang.Override
@@ -5454,33 +4849,27 @@ public final class MessageFormats {
       Builder builder = new Builder(parent);
       return builder;
     }
-    /** Protobuf type {@code AtLeastOnceDeliverySnapshot} */
-    public static final class Builder
-        extends org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<Builder>
-        implements
+    /**
+     * Protobuf type {@code AtLeastOnceDeliverySnapshot}
+     */
+    public static final class Builder extends
+        org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:AtLeastOnceDeliverySnapshot)
-        org.apache.pekko.persistence.serialization.MessageFormats
-            .AtLeastOnceDeliverySnapshotOrBuilder {
+        org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshotOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.persistence.serialization.MessageFormats
-            .internal_static_AtLeastOnceDeliverySnapshot_descriptor;
+        return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_AtLeastOnceDeliverySnapshot_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.persistence.serialization.MessageFormats
-            .internal_static_AtLeastOnceDeliverySnapshot_fieldAccessorTable
+        return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_AtLeastOnceDeliverySnapshot_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                org.apache.pekko.persistence.serialization.MessageFormats
-                    .AtLeastOnceDeliverySnapshot.class,
-                org.apache.pekko.persistence.serialization.MessageFormats
-                    .AtLeastOnceDeliverySnapshot.Builder.class);
+                org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.class, org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.Builder.class);
       }
 
-      // Construct using
-      // org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.newBuilder()
+      // Construct using org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
@@ -5490,13 +4879,12 @@ public final class MessageFormats {
         super(parent);
         maybeForceBuilderInitialization();
       }
-
       private void maybeForceBuilderInitialization() {
-        if (org.apache.pekko.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders) {
+        if (org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
           getUnconfirmedDeliveriesFieldBuilder();
         }
       }
-
       @java.lang.Override
       public Builder clear() {
         super.clear();
@@ -5512,23 +4900,19 @@ public final class MessageFormats {
       }
 
       @java.lang.Override
-      public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor getDescriptorForType() {
-        return org.apache.pekko.persistence.serialization.MessageFormats
-            .internal_static_AtLeastOnceDeliverySnapshot_descriptor;
+      public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_AtLeastOnceDeliverySnapshot_descriptor;
       }
 
       @java.lang.Override
-      public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-          getDefaultInstanceForType() {
-        return org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-            .getDefaultInstance();
+      public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot getDefaultInstanceForType() {
+        return org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.getDefaultInstance();
       }
 
       @java.lang.Override
-      public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-          build() {
-        org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-            result = buildPartial();
+      public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot build() {
+        org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
@@ -5536,12 +4920,8 @@ public final class MessageFormats {
       }
 
       @java.lang.Override
-      public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-          buildPartial() {
-        org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-            result =
-                new org.apache.pekko.persistence.serialization.MessageFormats
-                    .AtLeastOnceDeliverySnapshot(this);
+      public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot buildPartial() {
+        org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot result = new org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
@@ -5566,62 +4946,46 @@ public final class MessageFormats {
       public Builder clone() {
         return super.clone();
       }
-
       @java.lang.Override
       public Builder setField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return super.setField(field, value);
       }
-
       @java.lang.Override
       public Builder clearField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-
       @java.lang.Override
       public Builder clearOneof(
           org.apache.pekko.protobufv3.internal.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-
       @java.lang.Override
       public Builder setRepeatedField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field,
-          int index,
-          java.lang.Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-
       @java.lang.Override
       public Builder addRepeatedField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-
       @java.lang.Override
       public Builder mergeFrom(org.apache.pekko.protobufv3.internal.Message other) {
-        if (other
-            instanceof
-            org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot) {
-          return mergeFrom(
-              (org.apache.pekko.persistence.serialization.MessageFormats
-                      .AtLeastOnceDeliverySnapshot)
-                  other);
+        if (other instanceof org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot) {
+          return mergeFrom((org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(
-          org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-              other) {
-        if (other
-            == org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                .getDefaultInstance()) return this;
+      public Builder mergeFrom(org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot other) {
+        if (other == org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.getDefaultInstance()) return this;
         if (other.hasCurrentDeliveryId()) {
           setCurrentDeliveryId(other.getCurrentDeliveryId());
         }
@@ -5643,10 +5007,9 @@ public final class MessageFormats {
               unconfirmedDeliveriesBuilder_ = null;
               unconfirmedDeliveries_ = other.unconfirmedDeliveries_;
               bitField0_ = (bitField0_ & ~0x00000002);
-              unconfirmedDeliveriesBuilder_ =
-                  org.apache.pekko.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders
-                      ? getUnconfirmedDeliveriesFieldBuilder()
-                      : null;
+              unconfirmedDeliveriesBuilder_ = 
+                org.apache.pekko.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders ?
+                   getUnconfirmedDeliveriesFieldBuilder() : null;
             } else {
               unconfirmedDeliveriesBuilder_.addAllMessages(other.unconfirmedDeliveries_);
             }
@@ -5675,15 +5038,11 @@ public final class MessageFormats {
           org.apache.pekko.protobufv3.internal.CodedInputStream input,
           org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-            parsedMessage = null;
+        org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException e) {
-          parsedMessage =
-              (org.apache.pekko.persistence.serialization.MessageFormats
-                      .AtLeastOnceDeliverySnapshot)
-                  e.getUnfinishedMessage();
+          parsedMessage = (org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -5692,13 +5051,11 @@ public final class MessageFormats {
         }
         return this;
       }
-
       private int bitField0_;
 
-      private long currentDeliveryId_;
+      private long currentDeliveryId_ ;
       /**
        * <code>required int64 currentDeliveryId = 1;</code>
-       *
        * @return Whether the currentDeliveryId field is set.
        */
       public boolean hasCurrentDeliveryId() {
@@ -5706,7 +5063,6 @@ public final class MessageFormats {
       }
       /**
        * <code>required int64 currentDeliveryId = 1;</code>
-       *
        * @return The currentDeliveryId.
        */
       public long getCurrentDeliveryId() {
@@ -5714,7 +5070,6 @@ public final class MessageFormats {
       }
       /**
        * <code>required int64 currentDeliveryId = 1;</code>
-       *
        * @param value The currentDeliveryId to set.
        * @return This builder for chaining.
        */
@@ -5726,7 +5081,6 @@ public final class MessageFormats {
       }
       /**
        * <code>required int64 currentDeliveryId = 1;</code>
-       *
        * @return This builder for chaining.
        */
       public Builder clearCurrentDeliveryId() {
@@ -5736,38 +5090,22 @@ public final class MessageFormats {
         return this;
       }
 
-      private java.util.List<
-              org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .UnconfirmedDelivery>
-          unconfirmedDeliveries_ = java.util.Collections.emptyList();
-
+      private java.util.List<org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery> unconfirmedDeliveries_ =
+        java.util.Collections.emptyList();
       private void ensureUnconfirmedDeliveriesIsMutable() {
         if (!((bitField0_ & 0x00000002) != 0)) {
-          unconfirmedDeliveries_ =
-              new java.util.ArrayList<
-                  org.apache.pekko.persistence.serialization.MessageFormats
-                      .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery>(unconfirmedDeliveries_);
+          unconfirmedDeliveries_ = new java.util.ArrayList<org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery>(unconfirmedDeliveries_);
           bitField0_ |= 0x00000002;
-        }
+         }
       }
 
       private org.apache.pekko.protobufv3.internal.RepeatedFieldBuilderV3<
-              org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .UnconfirmedDelivery,
-              org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .UnconfirmedDelivery.Builder,
-              org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .UnconfirmedDeliveryOrBuilder>
-          unconfirmedDeliveriesBuilder_;
+          org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery, org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.Builder, org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDeliveryOrBuilder> unconfirmedDeliveriesBuilder_;
 
       /**
-       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-       * </code>
+       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
        */
-      public java.util.List<
-              org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .UnconfirmedDelivery>
-          getUnconfirmedDeliveriesList() {
+      public java.util.List<org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery> getUnconfirmedDeliveriesList() {
         if (unconfirmedDeliveriesBuilder_ == null) {
           return java.util.Collections.unmodifiableList(unconfirmedDeliveries_);
         } else {
@@ -5775,8 +5113,7 @@ public final class MessageFormats {
         }
       }
       /**
-       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-       * </code>
+       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
        */
       public int getUnconfirmedDeliveriesCount() {
         if (unconfirmedDeliveriesBuilder_ == null) {
@@ -5786,12 +5123,9 @@ public final class MessageFormats {
         }
       }
       /**
-       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-       * </code>
+       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
        */
-      public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-              .UnconfirmedDelivery
-          getUnconfirmedDeliveries(int index) {
+      public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery getUnconfirmedDeliveries(int index) {
         if (unconfirmedDeliveriesBuilder_ == null) {
           return unconfirmedDeliveries_.get(index);
         } else {
@@ -5799,14 +5133,10 @@ public final class MessageFormats {
         }
       }
       /**
-       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-       * </code>
+       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
        */
       public Builder setUnconfirmedDeliveries(
-          int index,
-          org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .UnconfirmedDelivery
-              value) {
+          int index, org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery value) {
         if (unconfirmedDeliveriesBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -5820,14 +5150,10 @@ public final class MessageFormats {
         return this;
       }
       /**
-       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-       * </code>
+       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
        */
       public Builder setUnconfirmedDeliveries(
-          int index,
-          org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .UnconfirmedDelivery.Builder
-              builderForValue) {
+          int index, org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.Builder builderForValue) {
         if (unconfirmedDeliveriesBuilder_ == null) {
           ensureUnconfirmedDeliveriesIsMutable();
           unconfirmedDeliveries_.set(index, builderForValue.build());
@@ -5838,13 +5164,9 @@ public final class MessageFormats {
         return this;
       }
       /**
-       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-       * </code>
+       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
        */
-      public Builder addUnconfirmedDeliveries(
-          org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .UnconfirmedDelivery
-              value) {
+      public Builder addUnconfirmedDeliveries(org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery value) {
         if (unconfirmedDeliveriesBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -5858,14 +5180,10 @@ public final class MessageFormats {
         return this;
       }
       /**
-       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-       * </code>
+       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
        */
       public Builder addUnconfirmedDeliveries(
-          int index,
-          org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .UnconfirmedDelivery
-              value) {
+          int index, org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery value) {
         if (unconfirmedDeliveriesBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -5879,13 +5197,10 @@ public final class MessageFormats {
         return this;
       }
       /**
-       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-       * </code>
+       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
        */
       public Builder addUnconfirmedDeliveries(
-          org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .UnconfirmedDelivery.Builder
-              builderForValue) {
+          org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.Builder builderForValue) {
         if (unconfirmedDeliveriesBuilder_ == null) {
           ensureUnconfirmedDeliveriesIsMutable();
           unconfirmedDeliveries_.add(builderForValue.build());
@@ -5896,14 +5211,10 @@ public final class MessageFormats {
         return this;
       }
       /**
-       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-       * </code>
+       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
        */
       public Builder addUnconfirmedDeliveries(
-          int index,
-          org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .UnconfirmedDelivery.Builder
-              builderForValue) {
+          int index, org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.Builder builderForValue) {
         if (unconfirmedDeliveriesBuilder_ == null) {
           ensureUnconfirmedDeliveriesIsMutable();
           unconfirmedDeliveries_.add(index, builderForValue.build());
@@ -5914,15 +5225,10 @@ public final class MessageFormats {
         return this;
       }
       /**
-       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-       * </code>
+       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
        */
       public Builder addAllUnconfirmedDeliveries(
-          java.lang.Iterable<
-                  ? extends
-                      org.apache.pekko.persistence.serialization.MessageFormats
-                          .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery>
-              values) {
+          java.lang.Iterable<? extends org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery> values) {
         if (unconfirmedDeliveriesBuilder_ == null) {
           ensureUnconfirmedDeliveriesIsMutable();
           org.apache.pekko.protobufv3.internal.AbstractMessageLite.Builder.addAll(
@@ -5934,8 +5240,7 @@ public final class MessageFormats {
         return this;
       }
       /**
-       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-       * </code>
+       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
        */
       public Builder clearUnconfirmedDeliveries() {
         if (unconfirmedDeliveriesBuilder_ == null) {
@@ -5948,8 +5253,7 @@ public final class MessageFormats {
         return this;
       }
       /**
-       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-       * </code>
+       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
        */
       public Builder removeUnconfirmedDeliveries(int index) {
         if (unconfirmedDeliveriesBuilder_ == null) {
@@ -5962,36 +5266,27 @@ public final class MessageFormats {
         return this;
       }
       /**
-       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-       * </code>
+       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
        */
-      public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-              .UnconfirmedDelivery.Builder
-          getUnconfirmedDeliveriesBuilder(int index) {
+      public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.Builder getUnconfirmedDeliveriesBuilder(
+          int index) {
         return getUnconfirmedDeliveriesFieldBuilder().getBuilder(index);
       }
       /**
-       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-       * </code>
+       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
        */
-      public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-              .UnconfirmedDeliveryOrBuilder
-          getUnconfirmedDeliveriesOrBuilder(int index) {
+      public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDeliveryOrBuilder getUnconfirmedDeliveriesOrBuilder(
+          int index) {
         if (unconfirmedDeliveriesBuilder_ == null) {
-          return unconfirmedDeliveries_.get(index);
-        } else {
+          return unconfirmedDeliveries_.get(index);  } else {
           return unconfirmedDeliveriesBuilder_.getMessageOrBuilder(index);
         }
       }
       /**
-       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-       * </code>
+       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
        */
-      public java.util.List<
-              ? extends
-                  org.apache.pekko.persistence.serialization.MessageFormats
-                      .AtLeastOnceDeliverySnapshot.UnconfirmedDeliveryOrBuilder>
-          getUnconfirmedDeliveriesOrBuilderList() {
+      public java.util.List<? extends org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDeliveryOrBuilder> 
+           getUnconfirmedDeliveriesOrBuilderList() {
         if (unconfirmedDeliveriesBuilder_ != null) {
           return unconfirmedDeliveriesBuilder_.getMessageOrBuilderList();
         } else {
@@ -5999,58 +5294,33 @@ public final class MessageFormats {
         }
       }
       /**
-       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-       * </code>
+       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
        */
-      public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-              .UnconfirmedDelivery.Builder
-          addUnconfirmedDeliveriesBuilder() {
-        return getUnconfirmedDeliveriesFieldBuilder()
-            .addBuilder(
-                org.apache.pekko.persistence.serialization.MessageFormats
-                    .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.getDefaultInstance());
+      public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.Builder addUnconfirmedDeliveriesBuilder() {
+        return getUnconfirmedDeliveriesFieldBuilder().addBuilder(
+            org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.getDefaultInstance());
       }
       /**
-       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-       * </code>
+       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
        */
-      public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-              .UnconfirmedDelivery.Builder
-          addUnconfirmedDeliveriesBuilder(int index) {
-        return getUnconfirmedDeliveriesFieldBuilder()
-            .addBuilder(
-                index,
-                org.apache.pekko.persistence.serialization.MessageFormats
-                    .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.getDefaultInstance());
+      public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.Builder addUnconfirmedDeliveriesBuilder(
+          int index) {
+        return getUnconfirmedDeliveriesFieldBuilder().addBuilder(
+            index, org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.getDefaultInstance());
       }
       /**
-       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;
-       * </code>
+       * <code>repeated .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery unconfirmedDeliveries = 2;</code>
        */
-      public java.util.List<
-              org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .UnconfirmedDelivery.Builder>
-          getUnconfirmedDeliveriesBuilderList() {
+      public java.util.List<org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.Builder> 
+           getUnconfirmedDeliveriesBuilderList() {
         return getUnconfirmedDeliveriesFieldBuilder().getBuilderList();
       }
-
       private org.apache.pekko.protobufv3.internal.RepeatedFieldBuilderV3<
-              org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .UnconfirmedDelivery,
-              org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .UnconfirmedDelivery.Builder,
-              org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-                  .UnconfirmedDeliveryOrBuilder>
+          org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery, org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.Builder, org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDeliveryOrBuilder> 
           getUnconfirmedDeliveriesFieldBuilder() {
         if (unconfirmedDeliveriesBuilder_ == null) {
-          unconfirmedDeliveriesBuilder_ =
-              new org.apache.pekko.protobufv3.internal.RepeatedFieldBuilderV3<
-                  org.apache.pekko.persistence.serialization.MessageFormats
-                      .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery,
-                  org.apache.pekko.persistence.serialization.MessageFormats
-                      .AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.Builder,
-                  org.apache.pekko.persistence.serialization.MessageFormats
-                      .AtLeastOnceDeliverySnapshot.UnconfirmedDeliveryOrBuilder>(
+          unconfirmedDeliveriesBuilder_ = new org.apache.pekko.protobufv3.internal.RepeatedFieldBuilderV3<
+              org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery, org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery.Builder, org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDeliveryOrBuilder>(
                   unconfirmedDeliveries_,
                   ((bitField0_ & 0x00000002) != 0),
                   getParentForChildren(),
@@ -6059,7 +5329,6 @@ public final class MessageFormats {
         }
         return unconfirmedDeliveriesBuilder_;
       }
-
       @java.lang.Override
       public final Builder setUnknownFields(
           final org.apache.pekko.protobufv3.internal.UnknownFieldSet unknownFields) {
@@ -6072,144 +5341,120 @@ public final class MessageFormats {
         return super.mergeUnknownFields(unknownFields);
       }
 
+
       // @@protoc_insertion_point(builder_scope:AtLeastOnceDeliverySnapshot)
     }
 
     // @@protoc_insertion_point(class_scope:AtLeastOnceDeliverySnapshot)
-    private static final org.apache.pekko.persistence.serialization.MessageFormats
-            .AtLeastOnceDeliverySnapshot
-        DEFAULT_INSTANCE;
-
+    private static final org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE =
-          new org.apache.pekko.persistence.serialization.MessageFormats
-              .AtLeastOnceDeliverySnapshot();
+      DEFAULT_INSTANCE = new org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot();
     }
 
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .AtLeastOnceDeliverySnapshot
-        getDefaultInstance() {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
-    @java.lang.Deprecated
-    public static final org.apache.pekko.protobufv3.internal.Parser<AtLeastOnceDeliverySnapshot>
-        PARSER =
-            new org.apache.pekko.protobufv3.internal.AbstractParser<AtLeastOnceDeliverySnapshot>() {
-              @java.lang.Override
-              public AtLeastOnceDeliverySnapshot parsePartialFrom(
-                  org.apache.pekko.protobufv3.internal.CodedInputStream input,
-                  org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-                  throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
-                return new AtLeastOnceDeliverySnapshot(input, extensionRegistry);
-              }
-            };
+    @java.lang.Deprecated public static final org.apache.pekko.protobufv3.internal.Parser<AtLeastOnceDeliverySnapshot>
+        PARSER = new org.apache.pekko.protobufv3.internal.AbstractParser<AtLeastOnceDeliverySnapshot>() {
+      @java.lang.Override
+      public AtLeastOnceDeliverySnapshot parsePartialFrom(
+          org.apache.pekko.protobufv3.internal.CodedInputStream input,
+          org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+          throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+        return new AtLeastOnceDeliverySnapshot(input, extensionRegistry);
+      }
+    };
 
-    public static org.apache.pekko.protobufv3.internal.Parser<AtLeastOnceDeliverySnapshot>
-        parser() {
+    public static org.apache.pekko.protobufv3.internal.Parser<AtLeastOnceDeliverySnapshot> parser() {
       return PARSER;
     }
 
     @java.lang.Override
-    public org.apache.pekko.protobufv3.internal.Parser<AtLeastOnceDeliverySnapshot>
-        getParserForType() {
+    public org.apache.pekko.protobufv3.internal.Parser<AtLeastOnceDeliverySnapshot> getParserForType() {
       return PARSER;
     }
 
     @java.lang.Override
-    public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot
-        getDefaultInstanceForType() {
+    public org.apache.pekko.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
+
   }
 
-  public interface PersistentStateChangeEventOrBuilder
-      extends
+  public interface PersistentStateChangeEventOrBuilder extends
       // @@protoc_insertion_point(interface_extends:PersistentStateChangeEvent)
       org.apache.pekko.protobufv3.internal.MessageOrBuilder {
 
     /**
      * <code>required string stateIdentifier = 1;</code>
-     *
      * @return Whether the stateIdentifier field is set.
      */
     boolean hasStateIdentifier();
     /**
      * <code>required string stateIdentifier = 1;</code>
-     *
      * @return The stateIdentifier.
      */
     java.lang.String getStateIdentifier();
     /**
      * <code>required string stateIdentifier = 1;</code>
-     *
      * @return The bytes for stateIdentifier.
      */
-    org.apache.pekko.protobufv3.internal.ByteString getStateIdentifierBytes();
+    org.apache.pekko.protobufv3.internal.ByteString
+        getStateIdentifierBytes();
 
     /**
-     *
-     *
      * <pre>
-     * not used in new records from 2.4.5
+     *not used in new records from 2.4.5
      * </pre>
      *
      * <code>optional string timeout = 2;</code>
-     *
      * @return Whether the timeout field is set.
      */
     boolean hasTimeout();
     /**
-     *
-     *
      * <pre>
-     * not used in new records from 2.4.5
+     *not used in new records from 2.4.5
      * </pre>
      *
      * <code>optional string timeout = 2;</code>
-     *
      * @return The timeout.
      */
     java.lang.String getTimeout();
     /**
-     *
-     *
      * <pre>
-     * not used in new records from 2.4.5
+     *not used in new records from 2.4.5
      * </pre>
      *
      * <code>optional string timeout = 2;</code>
-     *
      * @return The bytes for timeout.
      */
-    org.apache.pekko.protobufv3.internal.ByteString getTimeoutBytes();
+    org.apache.pekko.protobufv3.internal.ByteString
+        getTimeoutBytes();
 
     /**
      * <code>optional int64 timeoutNanos = 3;</code>
-     *
      * @return Whether the timeoutNanos field is set.
      */
     boolean hasTimeoutNanos();
     /**
      * <code>optional int64 timeoutNanos = 3;</code>
-     *
      * @return The timeoutNanos.
      */
     long getTimeoutNanos();
   }
-  /** Protobuf type {@code PersistentStateChangeEvent} */
-  public static final class PersistentStateChangeEvent
-      extends org.apache.pekko.protobufv3.internal.GeneratedMessageV3
-      implements
+  /**
+   * Protobuf type {@code PersistentStateChangeEvent}
+   */
+  public  static final class PersistentStateChangeEvent extends
+      org.apache.pekko.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:PersistentStateChangeEvent)
       PersistentStateChangeEventOrBuilder {
-    private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     // Use PersistentStateChangeEvent.newBuilder() to construct.
-    private PersistentStateChangeEvent(
-        org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
+    private PersistentStateChangeEvent(org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
-
     private PersistentStateChangeEvent() {
       stateIdentifier_ = "";
       timeout_ = "";
@@ -6223,10 +5468,10 @@ public final class MessageFormats {
     }
 
     @java.lang.Override
-    public final org.apache.pekko.protobufv3.internal.UnknownFieldSet getUnknownFields() {
+    public final org.apache.pekko.protobufv3.internal.UnknownFieldSet
+    getUnknownFields() {
       return this.unknownFields;
     }
-
     private PersistentStateChangeEvent(
         org.apache.pekko.protobufv3.internal.CodedInputStream input,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -6246,62 +5491,53 @@ public final class MessageFormats {
             case 0:
               done = true;
               break;
-            case 10:
-              {
-                org.apache.pekko.protobufv3.internal.ByteString bs = input.readBytes();
-                bitField0_ |= 0x00000001;
-                stateIdentifier_ = bs;
-                break;
+            case 10: {
+              org.apache.pekko.protobufv3.internal.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              stateIdentifier_ = bs;
+              break;
+            }
+            case 18: {
+              org.apache.pekko.protobufv3.internal.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              timeout_ = bs;
+              break;
+            }
+            case 24: {
+              bitField0_ |= 0x00000004;
+              timeoutNanos_ = input.readInt64();
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
               }
-            case 18:
-              {
-                org.apache.pekko.protobufv3.internal.ByteString bs = input.readBytes();
-                bitField0_ |= 0x00000002;
-                timeout_ = bs;
-                break;
-              }
-            case 24:
-              {
-                bitField0_ |= 0x00000004;
-                timeoutNanos_ = input.readInt64();
-                break;
-              }
-            default:
-              {
-                if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
-                  done = true;
-                }
-                break;
-              }
+              break;
+            }
           }
         }
       } catch (org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException(e)
-            .setUnfinishedMessage(this);
+        throw new org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
     }
-
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.persistence.serialization.MessageFormats
-          .internal_static_PersistentStateChangeEvent_descriptor;
+      return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_PersistentStateChangeEvent_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.persistence.serialization.MessageFormats
-          .internal_static_PersistentStateChangeEvent_fieldAccessorTable
+      return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_PersistentStateChangeEvent_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent
-                  .class,
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent
-                  .Builder.class);
+              org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent.class, org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent.Builder.class);
     }
 
     private int bitField0_;
@@ -6309,7 +5545,6 @@ public final class MessageFormats {
     private volatile java.lang.Object stateIdentifier_;
     /**
      * <code>required string stateIdentifier = 1;</code>
-     *
      * @return Whether the stateIdentifier field is set.
      */
     public boolean hasStateIdentifier() {
@@ -6317,7 +5552,6 @@ public final class MessageFormats {
     }
     /**
      * <code>required string stateIdentifier = 1;</code>
-     *
      * @return The stateIdentifier.
      */
     public java.lang.String getStateIdentifier() {
@@ -6325,7 +5559,7 @@ public final class MessageFormats {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        org.apache.pekko.protobufv3.internal.ByteString bs =
+        org.apache.pekko.protobufv3.internal.ByteString bs = 
             (org.apache.pekko.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -6336,14 +5570,15 @@ public final class MessageFormats {
     }
     /**
      * <code>required string stateIdentifier = 1;</code>
-     *
      * @return The bytes for stateIdentifier.
      */
-    public org.apache.pekko.protobufv3.internal.ByteString getStateIdentifierBytes() {
+    public org.apache.pekko.protobufv3.internal.ByteString
+        getStateIdentifierBytes() {
       java.lang.Object ref = stateIdentifier_;
       if (ref instanceof java.lang.String) {
-        org.apache.pekko.protobufv3.internal.ByteString b =
-            org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
+        org.apache.pekko.protobufv3.internal.ByteString b = 
+            org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
         stateIdentifier_ = b;
         return b;
       } else {
@@ -6354,28 +5589,22 @@ public final class MessageFormats {
     public static final int TIMEOUT_FIELD_NUMBER = 2;
     private volatile java.lang.Object timeout_;
     /**
-     *
-     *
      * <pre>
-     * not used in new records from 2.4.5
+     *not used in new records from 2.4.5
      * </pre>
      *
      * <code>optional string timeout = 2;</code>
-     *
      * @return Whether the timeout field is set.
      */
     public boolean hasTimeout() {
       return ((bitField0_ & 0x00000002) != 0);
     }
     /**
-     *
-     *
      * <pre>
-     * not used in new records from 2.4.5
+     *not used in new records from 2.4.5
      * </pre>
      *
      * <code>optional string timeout = 2;</code>
-     *
      * @return The timeout.
      */
     public java.lang.String getTimeout() {
@@ -6383,7 +5612,7 @@ public final class MessageFormats {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        org.apache.pekko.protobufv3.internal.ByteString bs =
+        org.apache.pekko.protobufv3.internal.ByteString bs = 
             (org.apache.pekko.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -6393,21 +5622,20 @@ public final class MessageFormats {
       }
     }
     /**
-     *
-     *
      * <pre>
-     * not used in new records from 2.4.5
+     *not used in new records from 2.4.5
      * </pre>
      *
      * <code>optional string timeout = 2;</code>
-     *
      * @return The bytes for timeout.
      */
-    public org.apache.pekko.protobufv3.internal.ByteString getTimeoutBytes() {
+    public org.apache.pekko.protobufv3.internal.ByteString
+        getTimeoutBytes() {
       java.lang.Object ref = timeout_;
       if (ref instanceof java.lang.String) {
-        org.apache.pekko.protobufv3.internal.ByteString b =
-            org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
+        org.apache.pekko.protobufv3.internal.ByteString b = 
+            org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
         timeout_ = b;
         return b;
       } else {
@@ -6419,7 +5647,6 @@ public final class MessageFormats {
     private long timeoutNanos_;
     /**
      * <code>optional int64 timeoutNanos = 3;</code>
-     *
      * @return Whether the timeoutNanos field is set.
      */
     public boolean hasTimeoutNanos() {
@@ -6427,7 +5654,6 @@ public final class MessageFormats {
     }
     /**
      * <code>optional int64 timeoutNanos = 3;</code>
-     *
      * @return The timeoutNanos.
      */
     public long getTimeoutNanos() {
@@ -6435,7 +5661,6 @@ public final class MessageFormats {
     }
 
     private byte memoizedIsInitialized = -1;
-
     @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -6452,10 +5677,9 @@ public final class MessageFormats {
 
     @java.lang.Override
     public void writeTo(org.apache.pekko.protobufv3.internal.CodedOutputStream output)
-        throws java.io.IOException {
+                        throws java.io.IOException {
       if (((bitField0_ & 0x00000001) != 0)) {
-        org.apache.pekko.protobufv3.internal.GeneratedMessageV3.writeString(
-            output, 1, stateIdentifier_);
+        org.apache.pekko.protobufv3.internal.GeneratedMessageV3.writeString(output, 1, stateIdentifier_);
       }
       if (((bitField0_ & 0x00000002) != 0)) {
         org.apache.pekko.protobufv3.internal.GeneratedMessageV3.writeString(output, 2, timeout_);
@@ -6473,18 +5697,14 @@ public final class MessageFormats {
 
       size = 0;
       if (((bitField0_ & 0x00000001) != 0)) {
-        size +=
-            org.apache.pekko.protobufv3.internal.GeneratedMessageV3.computeStringSize(
-                1, stateIdentifier_);
+        size += org.apache.pekko.protobufv3.internal.GeneratedMessageV3.computeStringSize(1, stateIdentifier_);
       }
       if (((bitField0_ & 0x00000002) != 0)) {
-        size +=
-            org.apache.pekko.protobufv3.internal.GeneratedMessageV3.computeStringSize(2, timeout_);
+        size += org.apache.pekko.protobufv3.internal.GeneratedMessageV3.computeStringSize(2, timeout_);
       }
       if (((bitField0_ & 0x00000004) != 0)) {
-        size +=
-            org.apache.pekko.protobufv3.internal.CodedOutputStream.computeInt64Size(
-                3, timeoutNanos_);
+        size += org.apache.pekko.protobufv3.internal.CodedOutputStream
+          .computeInt64Size(3, timeoutNanos_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -6494,28 +5714,27 @@ public final class MessageFormats {
     @java.lang.Override
     public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
-        return true;
+       return true;
       }
-      if (!(obj
-          instanceof
-          org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent)) {
+      if (!(obj instanceof org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent)) {
         return super.equals(obj);
       }
-      org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent other =
-          (org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent)
-              obj;
+      org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent other = (org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent) obj;
 
       if (hasStateIdentifier() != other.hasStateIdentifier()) return false;
       if (hasStateIdentifier()) {
-        if (!getStateIdentifier().equals(other.getStateIdentifier())) return false;
+        if (!getStateIdentifier()
+            .equals(other.getStateIdentifier())) return false;
       }
       if (hasTimeout() != other.hasTimeout()) return false;
       if (hasTimeout()) {
-        if (!getTimeout().equals(other.getTimeout())) return false;
+        if (!getTimeout()
+            .equals(other.getTimeout())) return false;
       }
       if (hasTimeoutNanos() != other.hasTimeoutNanos()) return false;
       if (hasTimeoutNanos()) {
-        if (getTimeoutNanos() != other.getTimeoutNanos()) return false;
+        if (getTimeoutNanos()
+            != other.getTimeoutNanos()) return false;
       }
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
@@ -6538,132 +5757,96 @@ public final class MessageFormats {
       }
       if (hasTimeoutNanos()) {
         hash = (37 * hash) + TIMEOUTNANOS_FIELD_NUMBER;
-        hash =
-            (53 * hash) + org.apache.pekko.protobufv3.internal.Internal.hashLong(getTimeoutNanos());
+        hash = (53 * hash) + org.apache.pekko.protobufv3.internal.Internal.hashLong(
+            getTimeoutNanos());
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
     }
 
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .PersistentStateChangeEvent
-        parseFrom(java.nio.ByteBuffer data)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent parseFrom(
+        java.nio.ByteBuffer data)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .PersistentStateChangeEvent
-        parseFrom(
-            java.nio.ByteBuffer data,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent parseFrom(
+        java.nio.ByteBuffer data,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .PersistentStateChangeEvent
-        parseFrom(org.apache.pekko.protobufv3.internal.ByteString data)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent parseFrom(
+        org.apache.pekko.protobufv3.internal.ByteString data)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .PersistentStateChangeEvent
-        parseFrom(
-            org.apache.pekko.protobufv3.internal.ByteString data,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent parseFrom(
+        org.apache.pekko.protobufv3.internal.ByteString data,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .PersistentStateChangeEvent
-        parseFrom(byte[] data)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent parseFrom(byte[] data)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .PersistentStateChangeEvent
-        parseFrom(
-            byte[] data,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent parseFrom(
+        byte[] data,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .PersistentStateChangeEvent
-        parseFrom(java.io.InputStream input) throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .PersistentStateChangeEvent
-        parseFrom(
-            java.io.InputStream input,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input, extensionRegistry);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent parseFrom(
+        java.io.InputStream input,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .PersistentStateChangeEvent
-        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
-          PARSER, input);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .PersistentStateChangeEvent
-        parseDelimitedFrom(
-            java.io.InputStream input,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
-          PARSER, input, extensionRegistry);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent parseDelimitedFrom(
+        java.io.InputStream input,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .PersistentStateChangeEvent
-        parseFrom(org.apache.pekko.protobufv3.internal.CodedInputStream input)
-            throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent parseFrom(
+        org.apache.pekko.protobufv3.internal.CodedInputStream input)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .PersistentStateChangeEvent
-        parseFrom(
-            org.apache.pekko.protobufv3.internal.CodedInputStream input,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input, extensionRegistry);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent parseFrom(
+        org.apache.pekko.protobufv3.internal.CodedInputStream input,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
     @java.lang.Override
-    public Builder newBuilderForType() {
-      return newBuilder();
-    }
-
+    public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-
-    public static Builder newBuilder(
-        org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent
-            prototype) {
+    public static Builder newBuilder(org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-
     @java.lang.Override
     public Builder toBuilder() {
-      return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
     }
 
     @java.lang.Override
@@ -6672,33 +5855,27 @@ public final class MessageFormats {
       Builder builder = new Builder(parent);
       return builder;
     }
-    /** Protobuf type {@code PersistentStateChangeEvent} */
-    public static final class Builder
-        extends org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<Builder>
-        implements
+    /**
+     * Protobuf type {@code PersistentStateChangeEvent}
+     */
+    public static final class Builder extends
+        org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:PersistentStateChangeEvent)
-        org.apache.pekko.persistence.serialization.MessageFormats
-            .PersistentStateChangeEventOrBuilder {
+        org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEventOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.persistence.serialization.MessageFormats
-            .internal_static_PersistentStateChangeEvent_descriptor;
+        return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_PersistentStateChangeEvent_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.persistence.serialization.MessageFormats
-            .internal_static_PersistentStateChangeEvent_fieldAccessorTable
+        return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_PersistentStateChangeEvent_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent
-                    .class,
-                org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent
-                    .Builder.class);
+                org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent.class, org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent.Builder.class);
       }
 
-      // Construct using
-      // org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent.newBuilder()
+      // Construct using org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
@@ -6708,11 +5885,11 @@ public final class MessageFormats {
         super(parent);
         maybeForceBuilderInitialization();
       }
-
       private void maybeForceBuilderInitialization() {
-        if (org.apache.pekko.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders) {}
+        if (org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
       }
-
       @java.lang.Override
       public Builder clear() {
         super.clear();
@@ -6726,23 +5903,19 @@ public final class MessageFormats {
       }
 
       @java.lang.Override
-      public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor getDescriptorForType() {
-        return org.apache.pekko.persistence.serialization.MessageFormats
-            .internal_static_PersistentStateChangeEvent_descriptor;
+      public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_PersistentStateChangeEvent_descriptor;
       }
 
       @java.lang.Override
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent
-          getDefaultInstanceForType() {
-        return org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent
-            .getDefaultInstance();
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent getDefaultInstanceForType() {
+        return org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent.getDefaultInstance();
       }
 
       @java.lang.Override
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent
-          build() {
-        org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent
-            result = buildPartial();
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent build() {
+        org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
@@ -6750,12 +5923,8 @@ public final class MessageFormats {
       }
 
       @java.lang.Override
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent
-          buildPartial() {
-        org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent
-            result =
-                new org.apache.pekko.persistence.serialization.MessageFormats
-                    .PersistentStateChangeEvent(this);
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent buildPartial() {
+        org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent result = new org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
@@ -6779,61 +5948,46 @@ public final class MessageFormats {
       public Builder clone() {
         return super.clone();
       }
-
       @java.lang.Override
       public Builder setField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return super.setField(field, value);
       }
-
       @java.lang.Override
       public Builder clearField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-
       @java.lang.Override
       public Builder clearOneof(
           org.apache.pekko.protobufv3.internal.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-
       @java.lang.Override
       public Builder setRepeatedField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field,
-          int index,
-          java.lang.Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-
       @java.lang.Override
       public Builder addRepeatedField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-
       @java.lang.Override
       public Builder mergeFrom(org.apache.pekko.protobufv3.internal.Message other) {
-        if (other
-            instanceof
-            org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent) {
-          return mergeFrom(
-              (org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent)
-                  other);
+        if (other instanceof org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent) {
+          return mergeFrom((org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(
-          org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent
-              other) {
-        if (other
-            == org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent
-                .getDefaultInstance()) return this;
+      public Builder mergeFrom(org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent other) {
+        if (other == org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent.getDefaultInstance()) return this;
         if (other.hasStateIdentifier()) {
           bitField0_ |= 0x00000001;
           stateIdentifier_ = other.stateIdentifier_;
@@ -6865,14 +6019,11 @@ public final class MessageFormats {
           org.apache.pekko.protobufv3.internal.CodedInputStream input,
           org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent
-            parsedMessage = null;
+        org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException e) {
-          parsedMessage =
-              (org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent)
-                  e.getUnfinishedMessage();
+          parsedMessage = (org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -6881,13 +6032,11 @@ public final class MessageFormats {
         }
         return this;
       }
-
       private int bitField0_;
 
       private java.lang.Object stateIdentifier_ = "";
       /**
        * <code>required string stateIdentifier = 1;</code>
-       *
        * @return Whether the stateIdentifier field is set.
        */
       public boolean hasStateIdentifier() {
@@ -6895,7 +6044,6 @@ public final class MessageFormats {
       }
       /**
        * <code>required string stateIdentifier = 1;</code>
-       *
        * @return The stateIdentifier.
        */
       public java.lang.String getStateIdentifier() {
@@ -6914,14 +6062,15 @@ public final class MessageFormats {
       }
       /**
        * <code>required string stateIdentifier = 1;</code>
-       *
        * @return The bytes for stateIdentifier.
        */
-      public org.apache.pekko.protobufv3.internal.ByteString getStateIdentifierBytes() {
+      public org.apache.pekko.protobufv3.internal.ByteString
+          getStateIdentifierBytes() {
         java.lang.Object ref = stateIdentifier_;
         if (ref instanceof String) {
-          org.apache.pekko.protobufv3.internal.ByteString b =
-              org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
+          org.apache.pekko.protobufv3.internal.ByteString b = 
+              org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
           stateIdentifier_ = b;
           return b;
         } else {
@@ -6930,22 +6079,21 @@ public final class MessageFormats {
       }
       /**
        * <code>required string stateIdentifier = 1;</code>
-       *
        * @param value The stateIdentifier to set.
        * @return This builder for chaining.
        */
-      public Builder setStateIdentifier(java.lang.String value) {
+      public Builder setStateIdentifier(
+          java.lang.String value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000001;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
         stateIdentifier_ = value;
         onChanged();
         return this;
       }
       /**
        * <code>required string stateIdentifier = 1;</code>
-       *
        * @return This builder for chaining.
        */
       public Builder clearStateIdentifier() {
@@ -6956,16 +6104,15 @@ public final class MessageFormats {
       }
       /**
        * <code>required string stateIdentifier = 1;</code>
-       *
        * @param value The bytes for stateIdentifier to set.
        * @return This builder for chaining.
        */
       public Builder setStateIdentifierBytes(
           org.apache.pekko.protobufv3.internal.ByteString value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000001;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
         stateIdentifier_ = value;
         onChanged();
         return this;
@@ -6973,28 +6120,22 @@ public final class MessageFormats {
 
       private java.lang.Object timeout_ = "";
       /**
-       *
-       *
        * <pre>
-       * not used in new records from 2.4.5
+       *not used in new records from 2.4.5
        * </pre>
        *
        * <code>optional string timeout = 2;</code>
-       *
        * @return Whether the timeout field is set.
        */
       public boolean hasTimeout() {
         return ((bitField0_ & 0x00000002) != 0);
       }
       /**
-       *
-       *
        * <pre>
-       * not used in new records from 2.4.5
+       *not used in new records from 2.4.5
        * </pre>
        *
        * <code>optional string timeout = 2;</code>
-       *
        * @return The timeout.
        */
       public java.lang.String getTimeout() {
@@ -7012,21 +6153,20 @@ public final class MessageFormats {
         }
       }
       /**
-       *
-       *
        * <pre>
-       * not used in new records from 2.4.5
+       *not used in new records from 2.4.5
        * </pre>
        *
        * <code>optional string timeout = 2;</code>
-       *
        * @return The bytes for timeout.
        */
-      public org.apache.pekko.protobufv3.internal.ByteString getTimeoutBytes() {
+      public org.apache.pekko.protobufv3.internal.ByteString
+          getTimeoutBytes() {
         java.lang.Object ref = timeout_;
         if (ref instanceof String) {
-          org.apache.pekko.protobufv3.internal.ByteString b =
-              org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
+          org.apache.pekko.protobufv3.internal.ByteString b = 
+              org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
           timeout_ = b;
           return b;
         } else {
@@ -7034,35 +6174,30 @@ public final class MessageFormats {
         }
       }
       /**
-       *
-       *
        * <pre>
-       * not used in new records from 2.4.5
+       *not used in new records from 2.4.5
        * </pre>
        *
        * <code>optional string timeout = 2;</code>
-       *
        * @param value The timeout to set.
        * @return This builder for chaining.
        */
-      public Builder setTimeout(java.lang.String value) {
+      public Builder setTimeout(
+          java.lang.String value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000002;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
         timeout_ = value;
         onChanged();
         return this;
       }
       /**
-       *
-       *
        * <pre>
-       * not used in new records from 2.4.5
+       *not used in new records from 2.4.5
        * </pre>
        *
        * <code>optional string timeout = 2;</code>
-       *
        * @return This builder for chaining.
        */
       public Builder clearTimeout() {
@@ -7072,31 +6207,28 @@ public final class MessageFormats {
         return this;
       }
       /**
-       *
-       *
        * <pre>
-       * not used in new records from 2.4.5
+       *not used in new records from 2.4.5
        * </pre>
        *
        * <code>optional string timeout = 2;</code>
-       *
        * @param value The bytes for timeout to set.
        * @return This builder for chaining.
        */
-      public Builder setTimeoutBytes(org.apache.pekko.protobufv3.internal.ByteString value) {
+      public Builder setTimeoutBytes(
+          org.apache.pekko.protobufv3.internal.ByteString value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000002;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
         timeout_ = value;
         onChanged();
         return this;
       }
 
-      private long timeoutNanos_;
+      private long timeoutNanos_ ;
       /**
        * <code>optional int64 timeoutNanos = 3;</code>
-       *
        * @return Whether the timeoutNanos field is set.
        */
       public boolean hasTimeoutNanos() {
@@ -7104,7 +6236,6 @@ public final class MessageFormats {
       }
       /**
        * <code>optional int64 timeoutNanos = 3;</code>
-       *
        * @return The timeoutNanos.
        */
       public long getTimeoutNanos() {
@@ -7112,7 +6243,6 @@ public final class MessageFormats {
       }
       /**
        * <code>optional int64 timeoutNanos = 3;</code>
-       *
        * @param value The timeoutNanos to set.
        * @return This builder for chaining.
        */
@@ -7124,7 +6254,6 @@ public final class MessageFormats {
       }
       /**
        * <code>optional int64 timeoutNanos = 3;</code>
-       *
        * @return This builder for chaining.
        */
       public Builder clearTimeoutNanos() {
@@ -7133,7 +6262,6 @@ public final class MessageFormats {
         onChanged();
         return this;
       }
-
       @java.lang.Override
       public final Builder setUnknownFields(
           final org.apache.pekko.protobufv3.internal.UnknownFieldSet unknownFields) {
@@ -7146,122 +6274,106 @@ public final class MessageFormats {
         return super.mergeUnknownFields(unknownFields);
       }
 
+
       // @@protoc_insertion_point(builder_scope:PersistentStateChangeEvent)
     }
 
     // @@protoc_insertion_point(class_scope:PersistentStateChangeEvent)
-    private static final org.apache.pekko.persistence.serialization.MessageFormats
-            .PersistentStateChangeEvent
-        DEFAULT_INSTANCE;
-
+    private static final org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE =
-          new org.apache.pekko.persistence.serialization.MessageFormats
-              .PersistentStateChangeEvent();
+      DEFAULT_INSTANCE = new org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent();
     }
 
-    public static org.apache.pekko.persistence.serialization.MessageFormats
-            .PersistentStateChangeEvent
-        getDefaultInstance() {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
-    @java.lang.Deprecated
-    public static final org.apache.pekko.protobufv3.internal.Parser<PersistentStateChangeEvent>
-        PARSER =
-            new org.apache.pekko.protobufv3.internal.AbstractParser<PersistentStateChangeEvent>() {
-              @java.lang.Override
-              public PersistentStateChangeEvent parsePartialFrom(
-                  org.apache.pekko.protobufv3.internal.CodedInputStream input,
-                  org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-                  throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
-                return new PersistentStateChangeEvent(input, extensionRegistry);
-              }
-            };
+    @java.lang.Deprecated public static final org.apache.pekko.protobufv3.internal.Parser<PersistentStateChangeEvent>
+        PARSER = new org.apache.pekko.protobufv3.internal.AbstractParser<PersistentStateChangeEvent>() {
+      @java.lang.Override
+      public PersistentStateChangeEvent parsePartialFrom(
+          org.apache.pekko.protobufv3.internal.CodedInputStream input,
+          org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+          throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+        return new PersistentStateChangeEvent(input, extensionRegistry);
+      }
+    };
 
     public static org.apache.pekko.protobufv3.internal.Parser<PersistentStateChangeEvent> parser() {
       return PARSER;
     }
 
     @java.lang.Override
-    public org.apache.pekko.protobufv3.internal.Parser<PersistentStateChangeEvent>
-        getParserForType() {
+    public org.apache.pekko.protobufv3.internal.Parser<PersistentStateChangeEvent> getParserForType() {
       return PARSER;
     }
 
     @java.lang.Override
-    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent
-        getDefaultInstanceForType() {
+    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentStateChangeEvent getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
+
   }
 
-  public interface PersistentFSMSnapshotOrBuilder
-      extends
+  public interface PersistentFSMSnapshotOrBuilder extends
       // @@protoc_insertion_point(interface_extends:PersistentFSMSnapshot)
       org.apache.pekko.protobufv3.internal.MessageOrBuilder {
 
     /**
      * <code>required string stateIdentifier = 1;</code>
-     *
      * @return Whether the stateIdentifier field is set.
      */
     boolean hasStateIdentifier();
     /**
      * <code>required string stateIdentifier = 1;</code>
-     *
      * @return The stateIdentifier.
      */
     java.lang.String getStateIdentifier();
     /**
      * <code>required string stateIdentifier = 1;</code>
-     *
      * @return The bytes for stateIdentifier.
      */
-    org.apache.pekko.protobufv3.internal.ByteString getStateIdentifierBytes();
+    org.apache.pekko.protobufv3.internal.ByteString
+        getStateIdentifierBytes();
 
     /**
      * <code>required .PersistentPayload data = 2;</code>
-     *
      * @return Whether the data field is set.
      */
     boolean hasData();
     /**
      * <code>required .PersistentPayload data = 2;</code>
-     *
      * @return The data.
      */
     org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload getData();
-    /** <code>required .PersistentPayload data = 2;</code> */
-    org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder
-        getDataOrBuilder();
+    /**
+     * <code>required .PersistentPayload data = 2;</code>
+     */
+    org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder getDataOrBuilder();
 
     /**
      * <code>optional int64 timeoutNanos = 3;</code>
-     *
      * @return Whether the timeoutNanos field is set.
      */
     boolean hasTimeoutNanos();
     /**
      * <code>optional int64 timeoutNanos = 3;</code>
-     *
      * @return The timeoutNanos.
      */
     long getTimeoutNanos();
   }
-  /** Protobuf type {@code PersistentFSMSnapshot} */
-  public static final class PersistentFSMSnapshot
-      extends org.apache.pekko.protobufv3.internal.GeneratedMessageV3
-      implements
+  /**
+   * Protobuf type {@code PersistentFSMSnapshot}
+   */
+  public  static final class PersistentFSMSnapshot extends
+      org.apache.pekko.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:PersistentFSMSnapshot)
       PersistentFSMSnapshotOrBuilder {
-    private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     // Use PersistentFSMSnapshot.newBuilder() to construct.
-    private PersistentFSMSnapshot(
-        org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
+    private PersistentFSMSnapshot(org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
-
     private PersistentFSMSnapshot() {
       stateIdentifier_ = "";
     }
@@ -7274,10 +6386,10 @@ public final class MessageFormats {
     }
 
     @java.lang.Override
-    public final org.apache.pekko.protobufv3.internal.UnknownFieldSet getUnknownFields() {
+    public final org.apache.pekko.protobufv3.internal.UnknownFieldSet
+    getUnknownFields() {
       return this.unknownFields;
     }
-
     private PersistentFSMSnapshot(
         org.apache.pekko.protobufv3.internal.CodedInputStream input,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -7297,73 +6409,60 @@ public final class MessageFormats {
             case 0:
               done = true;
               break;
-            case 10:
-              {
-                org.apache.pekko.protobufv3.internal.ByteString bs = input.readBytes();
-                bitField0_ |= 0x00000001;
-                stateIdentifier_ = bs;
-                break;
+            case 10: {
+              org.apache.pekko.protobufv3.internal.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              stateIdentifier_ = bs;
+              break;
+            }
+            case 18: {
+              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000002) != 0)) {
+                subBuilder = data_.toBuilder();
               }
-            case 18:
-              {
-                org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder
-                    subBuilder = null;
-                if (((bitField0_ & 0x00000002) != 0)) {
-                  subBuilder = data_.toBuilder();
-                }
-                data_ =
-                    input.readMessage(
-                        org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                            .PARSER,
-                        extensionRegistry);
-                if (subBuilder != null) {
-                  subBuilder.mergeFrom(data_);
-                  data_ = subBuilder.buildPartial();
-                }
-                bitField0_ |= 0x00000002;
-                break;
+              data_ = input.readMessage(org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(data_);
+                data_ = subBuilder.buildPartial();
               }
-            case 24:
-              {
-                bitField0_ |= 0x00000004;
-                timeoutNanos_ = input.readInt64();
-                break;
+              bitField0_ |= 0x00000002;
+              break;
+            }
+            case 24: {
+              bitField0_ |= 0x00000004;
+              timeoutNanos_ = input.readInt64();
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
               }
-            default:
-              {
-                if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
-                  done = true;
-                }
-                break;
-              }
+              break;
+            }
           }
         }
       } catch (org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException(e)
-            .setUnfinishedMessage(this);
+        throw new org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
     }
-
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.persistence.serialization.MessageFormats
-          .internal_static_PersistentFSMSnapshot_descriptor;
+      return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_PersistentFSMSnapshot_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.persistence.serialization.MessageFormats
-          .internal_static_PersistentFSMSnapshot_fieldAccessorTable
+      return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_PersistentFSMSnapshot_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot.class,
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-                  .Builder.class);
+              org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot.class, org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot.Builder.class);
     }
 
     private int bitField0_;
@@ -7371,7 +6470,6 @@ public final class MessageFormats {
     private volatile java.lang.Object stateIdentifier_;
     /**
      * <code>required string stateIdentifier = 1;</code>
-     *
      * @return Whether the stateIdentifier field is set.
      */
     public boolean hasStateIdentifier() {
@@ -7379,7 +6477,6 @@ public final class MessageFormats {
     }
     /**
      * <code>required string stateIdentifier = 1;</code>
-     *
      * @return The stateIdentifier.
      */
     public java.lang.String getStateIdentifier() {
@@ -7387,7 +6484,7 @@ public final class MessageFormats {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        org.apache.pekko.protobufv3.internal.ByteString bs =
+        org.apache.pekko.protobufv3.internal.ByteString bs = 
             (org.apache.pekko.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -7398,14 +6495,15 @@ public final class MessageFormats {
     }
     /**
      * <code>required string stateIdentifier = 1;</code>
-     *
      * @return The bytes for stateIdentifier.
      */
-    public org.apache.pekko.protobufv3.internal.ByteString getStateIdentifierBytes() {
+    public org.apache.pekko.protobufv3.internal.ByteString
+        getStateIdentifierBytes() {
       java.lang.Object ref = stateIdentifier_;
       if (ref instanceof java.lang.String) {
-        org.apache.pekko.protobufv3.internal.ByteString b =
-            org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
+        org.apache.pekko.protobufv3.internal.ByteString b = 
+            org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
         stateIdentifier_ = b;
         return b;
       } else {
@@ -7417,7 +6515,6 @@ public final class MessageFormats {
     private org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload data_;
     /**
      * <code>required .PersistentPayload data = 2;</code>
-     *
      * @return Whether the data field is set.
      */
     public boolean hasData() {
@@ -7425,29 +6522,22 @@ public final class MessageFormats {
     }
     /**
      * <code>required .PersistentPayload data = 2;</code>
-     *
      * @return The data.
      */
     public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload getData() {
-      return data_ == null
-          ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-              .getDefaultInstance()
-          : data_;
+      return data_ == null ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance() : data_;
     }
-    /** <code>required .PersistentPayload data = 2;</code> */
-    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder
-        getDataOrBuilder() {
-      return data_ == null
-          ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-              .getDefaultInstance()
-          : data_;
+    /**
+     * <code>required .PersistentPayload data = 2;</code>
+     */
+    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder getDataOrBuilder() {
+      return data_ == null ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance() : data_;
     }
 
     public static final int TIMEOUTNANOS_FIELD_NUMBER = 3;
     private long timeoutNanos_;
     /**
      * <code>optional int64 timeoutNanos = 3;</code>
-     *
      * @return Whether the timeoutNanos field is set.
      */
     public boolean hasTimeoutNanos() {
@@ -7455,7 +6545,6 @@ public final class MessageFormats {
     }
     /**
      * <code>optional int64 timeoutNanos = 3;</code>
-     *
      * @return The timeoutNanos.
      */
     public long getTimeoutNanos() {
@@ -7463,7 +6552,6 @@ public final class MessageFormats {
     }
 
     private byte memoizedIsInitialized = -1;
-
     @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -7488,10 +6576,9 @@ public final class MessageFormats {
 
     @java.lang.Override
     public void writeTo(org.apache.pekko.protobufv3.internal.CodedOutputStream output)
-        throws java.io.IOException {
+                        throws java.io.IOException {
       if (((bitField0_ & 0x00000001) != 0)) {
-        org.apache.pekko.protobufv3.internal.GeneratedMessageV3.writeString(
-            output, 1, stateIdentifier_);
+        org.apache.pekko.protobufv3.internal.GeneratedMessageV3.writeString(output, 1, stateIdentifier_);
       }
       if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(2, getData());
@@ -7509,18 +6596,15 @@ public final class MessageFormats {
 
       size = 0;
       if (((bitField0_ & 0x00000001) != 0)) {
-        size +=
-            org.apache.pekko.protobufv3.internal.GeneratedMessageV3.computeStringSize(
-                1, stateIdentifier_);
+        size += org.apache.pekko.protobufv3.internal.GeneratedMessageV3.computeStringSize(1, stateIdentifier_);
       }
       if (((bitField0_ & 0x00000002) != 0)) {
-        size +=
-            org.apache.pekko.protobufv3.internal.CodedOutputStream.computeMessageSize(2, getData());
+        size += org.apache.pekko.protobufv3.internal.CodedOutputStream
+          .computeMessageSize(2, getData());
       }
       if (((bitField0_ & 0x00000004) != 0)) {
-        size +=
-            org.apache.pekko.protobufv3.internal.CodedOutputStream.computeInt64Size(
-                3, timeoutNanos_);
+        size += org.apache.pekko.protobufv3.internal.CodedOutputStream
+          .computeInt64Size(3, timeoutNanos_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -7530,27 +6614,27 @@ public final class MessageFormats {
     @java.lang.Override
     public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
-        return true;
+       return true;
       }
-      if (!(obj
-          instanceof
-          org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot)) {
+      if (!(obj instanceof org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot)) {
         return super.equals(obj);
       }
-      org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot other =
-          (org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot) obj;
+      org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot other = (org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot) obj;
 
       if (hasStateIdentifier() != other.hasStateIdentifier()) return false;
       if (hasStateIdentifier()) {
-        if (!getStateIdentifier().equals(other.getStateIdentifier())) return false;
+        if (!getStateIdentifier()
+            .equals(other.getStateIdentifier())) return false;
       }
       if (hasData() != other.hasData()) return false;
       if (hasData()) {
-        if (!getData().equals(other.getData())) return false;
+        if (!getData()
+            .equals(other.getData())) return false;
       }
       if (hasTimeoutNanos() != other.hasTimeoutNanos()) return false;
       if (hasTimeoutNanos()) {
-        if (getTimeoutNanos() != other.getTimeoutNanos()) return false;
+        if (getTimeoutNanos()
+            != other.getTimeoutNanos()) return false;
       }
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
@@ -7573,119 +6657,96 @@ public final class MessageFormats {
       }
       if (hasTimeoutNanos()) {
         hash = (37 * hash) + TIMEOUTNANOS_FIELD_NUMBER;
-        hash =
-            (53 * hash) + org.apache.pekko.protobufv3.internal.Internal.hashLong(getTimeoutNanos());
+        hash = (53 * hash) + org.apache.pekko.protobufv3.internal.Internal.hashLong(
+            getTimeoutNanos());
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
     }
 
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-        parseFrom(java.nio.ByteBuffer data)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot parseFrom(
+        java.nio.ByteBuffer data)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-        parseFrom(
-            java.nio.ByteBuffer data,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot parseFrom(
+        java.nio.ByteBuffer data,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-        parseFrom(org.apache.pekko.protobufv3.internal.ByteString data)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot parseFrom(
+        org.apache.pekko.protobufv3.internal.ByteString data)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-        parseFrom(
-            org.apache.pekko.protobufv3.internal.ByteString data,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot parseFrom(
+        org.apache.pekko.protobufv3.internal.ByteString data,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-        parseFrom(byte[] data)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot parseFrom(byte[] data)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-        parseFrom(
-            byte[] data,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot parseFrom(
+        byte[] data,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-        parseFrom(java.io.InputStream input) throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-        parseFrom(
-            java.io.InputStream input,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input, extensionRegistry);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot parseFrom(
+        java.io.InputStream input,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
-          PARSER, input);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-        parseDelimitedFrom(
-            java.io.InputStream input,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
-          PARSER, input, extensionRegistry);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot parseDelimitedFrom(
+        java.io.InputStream input,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-        parseFrom(org.apache.pekko.protobufv3.internal.CodedInputStream input)
-            throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot parseFrom(
+        org.apache.pekko.protobufv3.internal.CodedInputStream input)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
-
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-        parseFrom(
-            org.apache.pekko.protobufv3.internal.CodedInputStream input,
-            org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
-          PARSER, input, extensionRegistry);
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot parseFrom(
+        org.apache.pekko.protobufv3.internal.CodedInputStream input,
+        org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
     @java.lang.Override
-    public Builder newBuilderForType() {
-      return newBuilder();
-    }
-
+    public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-
-    public static Builder newBuilder(
-        org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot prototype) {
+    public static Builder newBuilder(org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-
     @java.lang.Override
     public Builder toBuilder() {
-      return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
     }
 
     @java.lang.Override
@@ -7694,32 +6755,27 @@ public final class MessageFormats {
       Builder builder = new Builder(parent);
       return builder;
     }
-    /** Protobuf type {@code PersistentFSMSnapshot} */
-    public static final class Builder
-        extends org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<Builder>
-        implements
+    /**
+     * Protobuf type {@code PersistentFSMSnapshot}
+     */
+    public static final class Builder extends
+        org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:PersistentFSMSnapshot)
         org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshotOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.persistence.serialization.MessageFormats
-            .internal_static_PersistentFSMSnapshot_descriptor;
+        return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_PersistentFSMSnapshot_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.persistence.serialization.MessageFormats
-            .internal_static_PersistentFSMSnapshot_fieldAccessorTable
+        return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_PersistentFSMSnapshot_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-                    .class,
-                org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-                    .Builder.class);
+                org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot.class, org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot.Builder.class);
       }
 
-      // Construct using
-      // org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot.newBuilder()
+      // Construct using org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
@@ -7729,13 +6785,12 @@ public final class MessageFormats {
         super(parent);
         maybeForceBuilderInitialization();
       }
-
       private void maybeForceBuilderInitialization() {
-        if (org.apache.pekko.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders) {
+        if (org.apache.pekko.protobufv3.internal.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
           getDataFieldBuilder();
         }
       }
-
       @java.lang.Override
       public Builder clear() {
         super.clear();
@@ -7753,23 +6808,19 @@ public final class MessageFormats {
       }
 
       @java.lang.Override
-      public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor getDescriptorForType() {
-        return org.apache.pekko.persistence.serialization.MessageFormats
-            .internal_static_PersistentFSMSnapshot_descriptor;
+      public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.pekko.persistence.serialization.MessageFormats.internal_static_PersistentFSMSnapshot_descriptor;
       }
 
       @java.lang.Override
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-          getDefaultInstanceForType() {
-        return org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-            .getDefaultInstance();
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot getDefaultInstanceForType() {
+        return org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot.getDefaultInstance();
       }
 
       @java.lang.Override
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-          build() {
-        org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot result =
-            buildPartial();
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot build() {
+        org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
@@ -7777,11 +6828,8 @@ public final class MessageFormats {
       }
 
       @java.lang.Override
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-          buildPartial() {
-        org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot result =
-            new org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot(
-                this);
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot buildPartial() {
+        org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot result = new org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
@@ -7809,60 +6857,46 @@ public final class MessageFormats {
       public Builder clone() {
         return super.clone();
       }
-
       @java.lang.Override
       public Builder setField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return super.setField(field, value);
       }
-
       @java.lang.Override
       public Builder clearField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-
       @java.lang.Override
       public Builder clearOneof(
           org.apache.pekko.protobufv3.internal.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-
       @java.lang.Override
       public Builder setRepeatedField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field,
-          int index,
-          java.lang.Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-
       @java.lang.Override
       public Builder addRepeatedField(
           org.apache.pekko.protobufv3.internal.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-
       @java.lang.Override
       public Builder mergeFrom(org.apache.pekko.protobufv3.internal.Message other) {
-        if (other
-            instanceof
-            org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot) {
-          return mergeFrom(
-              (org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot)
-                  other);
+        if (other instanceof org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot) {
+          return mergeFrom((org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(
-          org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot other) {
-        if (other
-            == org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-                .getDefaultInstance()) return this;
+      public Builder mergeFrom(org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot other) {
+        if (other == org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot.getDefaultInstance()) return this;
         if (other.hasStateIdentifier()) {
           bitField0_ |= 0x00000001;
           stateIdentifier_ = other.stateIdentifier_;
@@ -7898,14 +6932,11 @@ public final class MessageFormats {
           org.apache.pekko.protobufv3.internal.CodedInputStream input,
           org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-            parsedMessage = null;
+        org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException e) {
-          parsedMessage =
-              (org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot)
-                  e.getUnfinishedMessage();
+          parsedMessage = (org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -7914,13 +6945,11 @@ public final class MessageFormats {
         }
         return this;
       }
-
       private int bitField0_;
 
       private java.lang.Object stateIdentifier_ = "";
       /**
        * <code>required string stateIdentifier = 1;</code>
-       *
        * @return Whether the stateIdentifier field is set.
        */
       public boolean hasStateIdentifier() {
@@ -7928,7 +6957,6 @@ public final class MessageFormats {
       }
       /**
        * <code>required string stateIdentifier = 1;</code>
-       *
        * @return The stateIdentifier.
        */
       public java.lang.String getStateIdentifier() {
@@ -7947,14 +6975,15 @@ public final class MessageFormats {
       }
       /**
        * <code>required string stateIdentifier = 1;</code>
-       *
        * @return The bytes for stateIdentifier.
        */
-      public org.apache.pekko.protobufv3.internal.ByteString getStateIdentifierBytes() {
+      public org.apache.pekko.protobufv3.internal.ByteString
+          getStateIdentifierBytes() {
         java.lang.Object ref = stateIdentifier_;
         if (ref instanceof String) {
-          org.apache.pekko.protobufv3.internal.ByteString b =
-              org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
+          org.apache.pekko.protobufv3.internal.ByteString b = 
+              org.apache.pekko.protobufv3.internal.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
           stateIdentifier_ = b;
           return b;
         } else {
@@ -7963,22 +6992,21 @@ public final class MessageFormats {
       }
       /**
        * <code>required string stateIdentifier = 1;</code>
-       *
        * @param value The stateIdentifier to set.
        * @return This builder for chaining.
        */
-      public Builder setStateIdentifier(java.lang.String value) {
+      public Builder setStateIdentifier(
+          java.lang.String value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000001;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
         stateIdentifier_ = value;
         onChanged();
         return this;
       }
       /**
        * <code>required string stateIdentifier = 1;</code>
-       *
        * @return This builder for chaining.
        */
       public Builder clearStateIdentifier() {
@@ -7989,16 +7017,15 @@ public final class MessageFormats {
       }
       /**
        * <code>required string stateIdentifier = 1;</code>
-       *
        * @param value The bytes for stateIdentifier to set.
        * @return This builder for chaining.
        */
       public Builder setStateIdentifierBytes(
           org.apache.pekko.protobufv3.internal.ByteString value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000001;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
         stateIdentifier_ = value;
         onChanged();
         return this;
@@ -8006,13 +7033,9 @@ public final class MessageFormats {
 
       private org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload data_;
       private org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload,
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder,
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder>
-          dataBuilder_;
+          org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder> dataBuilder_;
       /**
        * <code>required .PersistentPayload data = 2;</code>
-       *
        * @return Whether the data field is set.
        */
       public boolean hasData() {
@@ -8020,22 +7043,19 @@ public final class MessageFormats {
       }
       /**
        * <code>required .PersistentPayload data = 2;</code>
-       *
        * @return The data.
        */
       public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload getData() {
         if (dataBuilder_ == null) {
-          return data_ == null
-              ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                  .getDefaultInstance()
-              : data_;
+          return data_ == null ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance() : data_;
         } else {
           return dataBuilder_.getMessage();
         }
       }
-      /** <code>required .PersistentPayload data = 2;</code> */
-      public Builder setData(
-          org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload value) {
+      /**
+       * <code>required .PersistentPayload data = 2;</code>
+       */
+      public Builder setData(org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload value) {
         if (dataBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -8048,10 +7068,11 @@ public final class MessageFormats {
         bitField0_ |= 0x00000002;
         return this;
       }
-      /** <code>required .PersistentPayload data = 2;</code> */
+      /**
+       * <code>required .PersistentPayload data = 2;</code>
+       */
       public Builder setData(
-          org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder
-              builderForValue) {
+          org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder builderForValue) {
         if (dataBuilder_ == null) {
           data_ = builderForValue.build();
           onChanged();
@@ -8061,20 +7082,16 @@ public final class MessageFormats {
         bitField0_ |= 0x00000002;
         return this;
       }
-      /** <code>required .PersistentPayload data = 2;</code> */
-      public Builder mergeData(
-          org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload value) {
+      /**
+       * <code>required .PersistentPayload data = 2;</code>
+       */
+      public Builder mergeData(org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload value) {
         if (dataBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) != 0)
-              && data_ != null
-              && data_
-                  != org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                      .getDefaultInstance()) {
+          if (((bitField0_ & 0x00000002) != 0) &&
+              data_ != null &&
+              data_ != org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance()) {
             data_ =
-                org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                    .newBuilder(data_)
-                    .mergeFrom(value)
-                    .buildPartial();
+              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.newBuilder(data_).mergeFrom(value).buildPartial();
           } else {
             data_ = value;
           }
@@ -8085,7 +7102,9 @@ public final class MessageFormats {
         bitField0_ |= 0x00000002;
         return this;
       }
-      /** <code>required .PersistentPayload data = 2;</code> */
+      /**
+       * <code>required .PersistentPayload data = 2;</code>
+       */
       public Builder clearData() {
         if (dataBuilder_ == null) {
           data_ = null;
@@ -8096,48 +7115,45 @@ public final class MessageFormats {
         bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
-      /** <code>required .PersistentPayload data = 2;</code> */
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder
-          getDataBuilder() {
+      /**
+       * <code>required .PersistentPayload data = 2;</code>
+       */
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder getDataBuilder() {
         bitField0_ |= 0x00000002;
         onChanged();
         return getDataFieldBuilder().getBuilder();
       }
-      /** <code>required .PersistentPayload data = 2;</code> */
-      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder
-          getDataOrBuilder() {
+      /**
+       * <code>required .PersistentPayload data = 2;</code>
+       */
+      public org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder getDataOrBuilder() {
         if (dataBuilder_ != null) {
           return dataBuilder_.getMessageOrBuilder();
         } else {
-          return data_ == null
-              ? org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                  .getDefaultInstance()
-              : data_;
+          return data_ == null ?
+              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.getDefaultInstance() : data_;
         }
       }
-      /** <code>required .PersistentPayload data = 2;</code> */
+      /**
+       * <code>required .PersistentPayload data = 2;</code>
+       */
       private org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload,
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder,
-              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder>
+          org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder> 
           getDataFieldBuilder() {
         if (dataBuilder_ == null) {
-          dataBuilder_ =
-              new org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
-                  org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload,
-                  org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload
-                      .Builder,
-                  org.apache.pekko.persistence.serialization.MessageFormats
-                      .PersistentPayloadOrBuilder>(getData(), getParentForChildren(), isClean());
+          dataBuilder_ = new org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
+              org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayload.Builder, org.apache.pekko.persistence.serialization.MessageFormats.PersistentPayloadOrBuilder>(
+                  getData(),
+                  getParentForChildren(),
+                  isClean());
           data_ = null;
         }
         return dataBuilder_;
       }
 
-      private long timeoutNanos_;
+      private long timeoutNanos_ ;
       /**
        * <code>optional int64 timeoutNanos = 3;</code>
-       *
        * @return Whether the timeoutNanos field is set.
        */
       public boolean hasTimeoutNanos() {
@@ -8145,7 +7161,6 @@ public final class MessageFormats {
       }
       /**
        * <code>optional int64 timeoutNanos = 3;</code>
-       *
        * @return The timeoutNanos.
        */
       public long getTimeoutNanos() {
@@ -8153,7 +7168,6 @@ public final class MessageFormats {
       }
       /**
        * <code>optional int64 timeoutNanos = 3;</code>
-       *
        * @param value The timeoutNanos to set.
        * @return This builder for chaining.
        */
@@ -8165,7 +7179,6 @@ public final class MessageFormats {
       }
       /**
        * <code>optional int64 timeoutNanos = 3;</code>
-       *
        * @return This builder for chaining.
        */
       public Builder clearTimeoutNanos() {
@@ -8174,7 +7187,6 @@ public final class MessageFormats {
         onChanged();
         return this;
       }
-
       @java.lang.Override
       public final Builder setUnknownFields(
           final org.apache.pekko.protobufv3.internal.UnknownFieldSet unknownFields) {
@@ -8187,35 +7199,30 @@ public final class MessageFormats {
         return super.mergeUnknownFields(unknownFields);
       }
 
+
       // @@protoc_insertion_point(builder_scope:PersistentFSMSnapshot)
     }
 
     // @@protoc_insertion_point(class_scope:PersistentFSMSnapshot)
-    private static final org.apache.pekko.persistence.serialization.MessageFormats
-            .PersistentFSMSnapshot
-        DEFAULT_INSTANCE;
-
+    private static final org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE =
-          new org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot();
+      DEFAULT_INSTANCE = new org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot();
     }
 
-    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-        getDefaultInstance() {
+    public static org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
-    @java.lang.Deprecated
-    public static final org.apache.pekko.protobufv3.internal.Parser<PersistentFSMSnapshot> PARSER =
-        new org.apache.pekko.protobufv3.internal.AbstractParser<PersistentFSMSnapshot>() {
-          @java.lang.Override
-          public PersistentFSMSnapshot parsePartialFrom(
-              org.apache.pekko.protobufv3.internal.CodedInputStream input,
-              org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
-              throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
-            return new PersistentFSMSnapshot(input, extensionRegistry);
-          }
-        };
+    @java.lang.Deprecated public static final org.apache.pekko.protobufv3.internal.Parser<PersistentFSMSnapshot>
+        PARSER = new org.apache.pekko.protobufv3.internal.AbstractParser<PersistentFSMSnapshot>() {
+      @java.lang.Override
+      public PersistentFSMSnapshot parsePartialFrom(
+          org.apache.pekko.protobufv3.internal.CodedInputStream input,
+          org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+          throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
+        return new PersistentFSMSnapshot(input, extensionRegistry);
+      }
+    };
 
     public static org.apache.pekko.protobufv3.internal.Parser<PersistentFSMSnapshot> parser() {
       return PARSER;
@@ -8227,137 +7234,125 @@ public final class MessageFormats {
     }
 
     @java.lang.Override
-    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot
-        getDefaultInstanceForType() {
+    public org.apache.pekko.persistence.serialization.MessageFormats.PersistentFSMSnapshot getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
+
   }
 
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-      internal_static_PersistentMessage_descriptor;
-  private static final org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+    internal_static_PersistentMessage_descriptor;
+  private static final 
+    org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
       internal_static_PersistentMessage_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-      internal_static_PersistentPayload_descriptor;
-  private static final org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+    internal_static_PersistentPayload_descriptor;
+  private static final 
+    org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
       internal_static_PersistentPayload_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-      internal_static_AtomicWrite_descriptor;
-  private static final org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+    internal_static_AtomicWrite_descriptor;
+  private static final 
+    org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
       internal_static_AtomicWrite_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-      internal_static_AtLeastOnceDeliverySnapshot_descriptor;
-  private static final org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+    internal_static_AtLeastOnceDeliverySnapshot_descriptor;
+  private static final 
+    org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
       internal_static_AtLeastOnceDeliverySnapshot_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-      internal_static_AtLeastOnceDeliverySnapshot_UnconfirmedDelivery_descriptor;
-  private static final org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+    internal_static_AtLeastOnceDeliverySnapshot_UnconfirmedDelivery_descriptor;
+  private static final 
+    org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
       internal_static_AtLeastOnceDeliverySnapshot_UnconfirmedDelivery_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-      internal_static_PersistentStateChangeEvent_descriptor;
-  private static final org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+    internal_static_PersistentStateChangeEvent_descriptor;
+  private static final 
+    org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
       internal_static_PersistentStateChangeEvent_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-      internal_static_PersistentFSMSnapshot_descriptor;
-  private static final org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+    internal_static_PersistentFSMSnapshot_descriptor;
+  private static final 
+    org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
       internal_static_PersistentFSMSnapshot_fieldAccessorTable;
 
-  public static org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor getDescriptor() {
+  public static org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor
+      getDescriptor() {
     return descriptor;
   }
-
-  private static org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor descriptor;
-
+  private static  org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor
+      descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\024MessageFormats.proto\"\343\001\n\021PersistentMes"
-          + "sage\022#\n\007payload\030\001 \001(\0132\022.PersistentPayloa"
-          + "d\022\022\n\nsequenceNr\030\002 \001(\003\022\025\n\rpersistenceId\030\003"
-          + " \001(\t\022\017\n\007deleted\030\004 \001(\010\022\016\n\006sender\030\013 \001(\t\022\020\n"
-          + "\010manifest\030\014 \001(\t\022\022\n\nwriterUuid\030\r \001(\t\022\021\n\tt"
-          + "imestamp\030\016 \001(\022\022$\n\010metadata\030\017 \001(\0132\022.Persi"
-          + "stentPayload\"S\n\021PersistentPayload\022\024\n\014ser"
-          + "ializerId\030\001 \002(\005\022\017\n\007payload\030\002 \002(\014\022\027\n\017payl"
-          + "oadManifest\030\003 \001(\014\"2\n\013AtomicWrite\022#\n\007payl"
-          + "oad\030\001 \003(\0132\022.PersistentMessage\"\356\001\n\033AtLeas"
-          + "tOnceDeliverySnapshot\022\031\n\021currentDelivery"
-          + "Id\030\001 \002(\003\022O\n\025unconfirmedDeliveries\030\002 \003(\0132"
-          + "0.AtLeastOnceDeliverySnapshot.Unconfirme"
-          + "dDelivery\032c\n\023UnconfirmedDelivery\022\022\n\ndeli"
-          + "veryId\030\001 \002(\003\022\023\n\013destination\030\002 \002(\t\022#\n\007pay"
-          + "load\030\003 \002(\0132\022.PersistentPayload\"\\\n\032Persis"
-          + "tentStateChangeEvent\022\027\n\017stateIdentifier\030"
-          + "\001 \002(\t\022\017\n\007timeout\030\002 \001(\t\022\024\n\014timeoutNanos\030\003"
-          + " \001(\003\"h\n\025PersistentFSMSnapshot\022\027\n\017stateId"
-          + "entifier\030\001 \002(\t\022 \n\004data\030\002 \002(\0132\022.Persisten"
-          + "tPayload\022\024\n\014timeoutNanos\030\003 \001(\003B\"\n\036akka.p"
-          + "ersistence.serializationH\001"
+      "\n\024MessageFormats.proto\"\343\001\n\021PersistentMes" +
+      "sage\022#\n\007payload\030\001 \001(\0132\022.PersistentPayloa" +
+      "d\022\022\n\nsequenceNr\030\002 \001(\003\022\025\n\rpersistenceId\030\003" +
+      " \001(\t\022\017\n\007deleted\030\004 \001(\010\022\016\n\006sender\030\013 \001(\t\022\020\n" +
+      "\010manifest\030\014 \001(\t\022\022\n\nwriterUuid\030\r \001(\t\022\021\n\tt" +
+      "imestamp\030\016 \001(\022\022$\n\010metadata\030\017 \001(\0132\022.Persi" +
+      "stentPayload\"S\n\021PersistentPayload\022\024\n\014ser" +
+      "ializerId\030\001 \002(\005\022\017\n\007payload\030\002 \002(\014\022\027\n\017payl" +
+      "oadManifest\030\003 \001(\014\"2\n\013AtomicWrite\022#\n\007payl" +
+      "oad\030\001 \003(\0132\022.PersistentMessage\"\356\001\n\033AtLeas" +
+      "tOnceDeliverySnapshot\022\031\n\021currentDelivery" +
+      "Id\030\001 \002(\003\022O\n\025unconfirmedDeliveries\030\002 \003(\0132" +
+      "0.AtLeastOnceDeliverySnapshot.Unconfirme" +
+      "dDelivery\032c\n\023UnconfirmedDelivery\022\022\n\ndeli" +
+      "veryId\030\001 \002(\003\022\023\n\013destination\030\002 \002(\t\022#\n\007pay" +
+      "load\030\003 \002(\0132\022.PersistentPayload\"\\\n\032Persis" +
+      "tentStateChangeEvent\022\027\n\017stateIdentifier\030" +
+      "\001 \002(\t\022\017\n\007timeout\030\002 \001(\t\022\024\n\014timeoutNanos\030\003" +
+      " \001(\003\"h\n\025PersistentFSMSnapshot\022\027\n\017stateId" +
+      "entifier\030\001 \002(\t\022 \n\004data\030\002 \002(\0132\022.Persisten" +
+      "tPayload\022\024\n\014timeoutNanos\030\003 \001(\003B.\n*org.ap" +
+      "ache.pekko.persistence.serializationH\001"
     };
-    descriptor =
-        org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor
-            .internalBuildGeneratedFileFrom(
-                descriptorData,
-                new org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor[] {});
-    internal_static_PersistentMessage_descriptor = getDescriptor().getMessageTypes().get(0);
-    internal_static_PersistentMessage_fieldAccessorTable =
-        new org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-            internal_static_PersistentMessage_descriptor,
-            new java.lang.String[] {
-              "Payload",
-              "SequenceNr",
-              "PersistenceId",
-              "Deleted",
-              "Sender",
-              "Manifest",
-              "WriterUuid",
-              "Timestamp",
-              "Metadata",
-            });
-    internal_static_PersistentPayload_descriptor = getDescriptor().getMessageTypes().get(1);
-    internal_static_PersistentPayload_fieldAccessorTable =
-        new org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-            internal_static_PersistentPayload_descriptor,
-            new java.lang.String[] {
-              "SerializerId", "Payload", "PayloadManifest",
-            });
-    internal_static_AtomicWrite_descriptor = getDescriptor().getMessageTypes().get(2);
-    internal_static_AtomicWrite_fieldAccessorTable =
-        new org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-            internal_static_AtomicWrite_descriptor,
-            new java.lang.String[] {
-              "Payload",
-            });
+    descriptor = org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor
+      .internalBuildGeneratedFileFrom(descriptorData,
+        new org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor[] {
+        });
+    internal_static_PersistentMessage_descriptor =
+      getDescriptor().getMessageTypes().get(0);
+    internal_static_PersistentMessage_fieldAccessorTable = new
+      org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_PersistentMessage_descriptor,
+        new java.lang.String[] { "Payload", "SequenceNr", "PersistenceId", "Deleted", "Sender", "Manifest", "WriterUuid", "Timestamp", "Metadata", });
+    internal_static_PersistentPayload_descriptor =
+      getDescriptor().getMessageTypes().get(1);
+    internal_static_PersistentPayload_fieldAccessorTable = new
+      org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_PersistentPayload_descriptor,
+        new java.lang.String[] { "SerializerId", "Payload", "PayloadManifest", });
+    internal_static_AtomicWrite_descriptor =
+      getDescriptor().getMessageTypes().get(2);
+    internal_static_AtomicWrite_fieldAccessorTable = new
+      org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_AtomicWrite_descriptor,
+        new java.lang.String[] { "Payload", });
     internal_static_AtLeastOnceDeliverySnapshot_descriptor =
-        getDescriptor().getMessageTypes().get(3);
-    internal_static_AtLeastOnceDeliverySnapshot_fieldAccessorTable =
-        new org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-            internal_static_AtLeastOnceDeliverySnapshot_descriptor,
-            new java.lang.String[] {
-              "CurrentDeliveryId", "UnconfirmedDeliveries",
-            });
+      getDescriptor().getMessageTypes().get(3);
+    internal_static_AtLeastOnceDeliverySnapshot_fieldAccessorTable = new
+      org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_AtLeastOnceDeliverySnapshot_descriptor,
+        new java.lang.String[] { "CurrentDeliveryId", "UnconfirmedDeliveries", });
     internal_static_AtLeastOnceDeliverySnapshot_UnconfirmedDelivery_descriptor =
-        internal_static_AtLeastOnceDeliverySnapshot_descriptor.getNestedTypes().get(0);
-    internal_static_AtLeastOnceDeliverySnapshot_UnconfirmedDelivery_fieldAccessorTable =
-        new org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-            internal_static_AtLeastOnceDeliverySnapshot_UnconfirmedDelivery_descriptor,
-            new java.lang.String[] {
-              "DeliveryId", "Destination", "Payload",
-            });
+      internal_static_AtLeastOnceDeliverySnapshot_descriptor.getNestedTypes().get(0);
+    internal_static_AtLeastOnceDeliverySnapshot_UnconfirmedDelivery_fieldAccessorTable = new
+      org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_AtLeastOnceDeliverySnapshot_UnconfirmedDelivery_descriptor,
+        new java.lang.String[] { "DeliveryId", "Destination", "Payload", });
     internal_static_PersistentStateChangeEvent_descriptor =
-        getDescriptor().getMessageTypes().get(4);
-    internal_static_PersistentStateChangeEvent_fieldAccessorTable =
-        new org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-            internal_static_PersistentStateChangeEvent_descriptor,
-            new java.lang.String[] {
-              "StateIdentifier", "Timeout", "TimeoutNanos",
-            });
-    internal_static_PersistentFSMSnapshot_descriptor = getDescriptor().getMessageTypes().get(5);
-    internal_static_PersistentFSMSnapshot_fieldAccessorTable =
-        new org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-            internal_static_PersistentFSMSnapshot_descriptor,
-            new java.lang.String[] {
-              "StateIdentifier", "Data", "TimeoutNanos",
-            });
+      getDescriptor().getMessageTypes().get(4);
+    internal_static_PersistentStateChangeEvent_fieldAccessorTable = new
+      org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_PersistentStateChangeEvent_descriptor,
+        new java.lang.String[] { "StateIdentifier", "Timeout", "TimeoutNanos", });
+    internal_static_PersistentFSMSnapshot_descriptor =
+      getDescriptor().getMessageTypes().get(5);
+    internal_static_PersistentFSMSnapshot_fieldAccessorTable = new
+      org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_PersistentFSMSnapshot_descriptor,
+        new java.lang.String[] { "StateIdentifier", "Data", "TimeoutNanos", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/remote-tests/src/test/java/org/apache/pekko/remote/artery/protobuf/TestMessages.java
+++ b/remote-tests/src/test/java/org/apache/pekko/remote/artery/protobuf/TestMessages.java
@@ -2235,8 +2235,8 @@ public final class TestMessages {
       "d\030\001 \002(\004\022\014\n\004name\030\002 \002(\t\022\016\n\006status\030\003 \002(\010\022\023\n" +
       "\013description\030\004 \001(\t\022\017\n\007payload\030\005 \001(\014\022\024\n\005i" +
       "tems\030\006 \003(\0132\005.Item\" \n\004Item\022\n\n\002id\030\001 \002(\004\022\014\n" +
-      "\004name\030\002 \002(\tB\035\n\033org.apache.pekko.remote.artery.protob" +
-      "uf"
+      "\004name\030\002 \002(\tB)\n\'org.apache.pekko.remote.a" +
+      "rtery.protobuf"
     };
     descriptor = org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/remote/src/main/java/org/apache/pekko/remote/WireFormats.java
+++ b/remote/src/main/java/org/apache/pekko/remote/WireFormats.java
@@ -30,7 +30,7 @@ public final class WireFormats {
   /**
    * <pre>
    **
-   * Defines the type of the AkkaControlMessage command type
+   * Defines the type of the PekkoControlMessage command type
    * </pre>
    *
    * Protobuf enum {@code CommandType}
@@ -9688,7 +9688,7 @@ public final class WireFormats {
   }
 
   public interface PekkoProtocolMessageOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:AkkaProtocolMessage)
+      // @@protoc_insertion_point(interface_extends:PekkoProtocolMessage)
       org.apache.pekko.protobufv3.internal.MessageOrBuilder {
 
     /**
@@ -9703,19 +9703,19 @@ public final class WireFormats {
     org.apache.pekko.protobufv3.internal.ByteString getPayload();
 
     /**
-     * <code>optional .AkkaControlMessage instruction = 2;</code>
+     * <code>optional .PekkoControlMessage instruction = 2;</code>
      * @return Whether the instruction field is set.
      */
     boolean hasInstruction();
     /**
-     * <code>optional .AkkaControlMessage instruction = 2;</code>
+     * <code>optional .PekkoControlMessage instruction = 2;</code>
      * @return The instruction.
      */
-    PekkoControlMessage getInstruction();
+    org.apache.pekko.remote.WireFormats.PekkoControlMessage getInstruction();
     /**
-     * <code>optional .AkkaControlMessage instruction = 2;</code>
+     * <code>optional .PekkoControlMessage instruction = 2;</code>
      */
-    PekkoControlMessageOrBuilder getInstructionOrBuilder();
+    org.apache.pekko.remote.WireFormats.PekkoControlMessageOrBuilder getInstructionOrBuilder();
   }
   /**
    * <pre>
@@ -9724,14 +9724,14 @@ public final class WireFormats {
    * Message contains either a payload or an instruction.
    * </pre>
    *
-   * Protobuf type {@code AkkaProtocolMessage}
+   * Protobuf type {@code PekkoProtocolMessage}
    */
   public  static final class PekkoProtocolMessage extends
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:AkkaProtocolMessage)
-          PekkoProtocolMessageOrBuilder {
+      // @@protoc_insertion_point(message_implements:PekkoProtocolMessage)
+      PekkoProtocolMessageOrBuilder {
   private static final long serialVersionUID = 0L;
-    // Use AkkaProtocolMessage.newBuilder() to construct.
+    // Use PekkoProtocolMessage.newBuilder() to construct.
     private PekkoProtocolMessage(org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
@@ -9776,11 +9776,11 @@ public final class WireFormats {
               break;
             }
             case 18: {
-              PekkoControlMessage.Builder subBuilder = null;
+              org.apache.pekko.remote.WireFormats.PekkoControlMessage.Builder subBuilder = null;
               if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = instruction_.toBuilder();
               }
-              instruction_ = input.readMessage(PekkoControlMessage.PARSER, extensionRegistry);
+              instruction_ = input.readMessage(org.apache.pekko.remote.WireFormats.PekkoControlMessage.PARSER, extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(instruction_);
                 instruction_ = subBuilder.buildPartial();
@@ -9809,15 +9809,15 @@ public final class WireFormats {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.remote.WireFormats.internal_static_AkkaProtocolMessage_descriptor;
+      return org.apache.pekko.remote.WireFormats.internal_static_PekkoProtocolMessage_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.remote.WireFormats.internal_static_AkkaProtocolMessage_fieldAccessorTable
+      return org.apache.pekko.remote.WireFormats.internal_static_PekkoProtocolMessage_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              PekkoProtocolMessage.class, PekkoProtocolMessage.Builder.class);
+              org.apache.pekko.remote.WireFormats.PekkoProtocolMessage.class, org.apache.pekko.remote.WireFormats.PekkoProtocolMessage.Builder.class);
     }
 
     private int bitField0_;
@@ -9839,26 +9839,26 @@ public final class WireFormats {
     }
 
     public static final int INSTRUCTION_FIELD_NUMBER = 2;
-    private PekkoControlMessage instruction_;
+    private org.apache.pekko.remote.WireFormats.PekkoControlMessage instruction_;
     /**
-     * <code>optional .AkkaControlMessage instruction = 2;</code>
+     * <code>optional .PekkoControlMessage instruction = 2;</code>
      * @return Whether the instruction field is set.
      */
     public boolean hasInstruction() {
       return ((bitField0_ & 0x00000002) != 0);
     }
     /**
-     * <code>optional .AkkaControlMessage instruction = 2;</code>
+     * <code>optional .PekkoControlMessage instruction = 2;</code>
      * @return The instruction.
      */
-    public PekkoControlMessage getInstruction() {
-      return instruction_ == null ? PekkoControlMessage.getDefaultInstance() : instruction_;
+    public org.apache.pekko.remote.WireFormats.PekkoControlMessage getInstruction() {
+      return instruction_ == null ? org.apache.pekko.remote.WireFormats.PekkoControlMessage.getDefaultInstance() : instruction_;
     }
     /**
-     * <code>optional .AkkaControlMessage instruction = 2;</code>
+     * <code>optional .PekkoControlMessage instruction = 2;</code>
      */
-    public PekkoControlMessageOrBuilder getInstructionOrBuilder() {
-      return instruction_ == null ? PekkoControlMessage.getDefaultInstance() : instruction_;
+    public org.apache.pekko.remote.WireFormats.PekkoControlMessageOrBuilder getInstructionOrBuilder() {
+      return instruction_ == null ? org.apache.pekko.remote.WireFormats.PekkoControlMessage.getDefaultInstance() : instruction_;
     }
 
     private byte memoizedIsInitialized = -1;
@@ -9914,10 +9914,10 @@ public final class WireFormats {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof PekkoProtocolMessage)) {
+      if (!(obj instanceof org.apache.pekko.remote.WireFormats.PekkoProtocolMessage)) {
         return super.equals(obj);
       }
-      PekkoProtocolMessage other = (PekkoProtocolMessage) obj;
+      org.apache.pekko.remote.WireFormats.PekkoProtocolMessage other = (org.apache.pekko.remote.WireFormats.PekkoProtocolMessage) obj;
 
       if (hasPayload() != other.hasPayload()) return false;
       if (hasPayload()) {
@@ -9953,69 +9953,69 @@ public final class WireFormats {
       return hash;
     }
 
-    public static PekkoProtocolMessage parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoProtocolMessage parseFrom(
         java.nio.ByteBuffer data)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static PekkoProtocolMessage parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoProtocolMessage parseFrom(
         java.nio.ByteBuffer data,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static PekkoProtocolMessage parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoProtocolMessage parseFrom(
         org.apache.pekko.protobufv3.internal.ByteString data)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static PekkoProtocolMessage parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoProtocolMessage parseFrom(
         org.apache.pekko.protobufv3.internal.ByteString data,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static PekkoProtocolMessage parseFrom(byte[] data)
+    public static org.apache.pekko.remote.WireFormats.PekkoProtocolMessage parseFrom(byte[] data)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static PekkoProtocolMessage parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoProtocolMessage parseFrom(
         byte[] data,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static PekkoProtocolMessage parseFrom(java.io.InputStream input)
+    public static org.apache.pekko.remote.WireFormats.PekkoProtocolMessage parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static PekkoProtocolMessage parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoProtocolMessage parseFrom(
         java.io.InputStream input,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static PekkoProtocolMessage parseDelimitedFrom(java.io.InputStream input)
+    public static org.apache.pekko.remote.WireFormats.PekkoProtocolMessage parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static PekkoProtocolMessage parseDelimitedFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoProtocolMessage parseDelimitedFrom(
         java.io.InputStream input,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static PekkoProtocolMessage parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoProtocolMessage parseFrom(
         org.apache.pekko.protobufv3.internal.CodedInputStream input)
         throws java.io.IOException {
       return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static PekkoProtocolMessage parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoProtocolMessage parseFrom(
         org.apache.pekko.protobufv3.internal.CodedInputStream input,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -10028,7 +10028,7 @@ public final class WireFormats {
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(PekkoProtocolMessage prototype) {
+    public static Builder newBuilder(org.apache.pekko.remote.WireFormats.PekkoProtocolMessage prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
     @java.lang.Override
@@ -10050,26 +10050,26 @@ public final class WireFormats {
      * Message contains either a payload or an instruction.
      * </pre>
      *
-     * Protobuf type {@code AkkaProtocolMessage}
+     * Protobuf type {@code PekkoProtocolMessage}
      */
     public static final class Builder extends
         org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:AkkaProtocolMessage)
-            PekkoProtocolMessageOrBuilder {
+        // @@protoc_insertion_point(builder_implements:PekkoProtocolMessage)
+        org.apache.pekko.remote.WireFormats.PekkoProtocolMessageOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.remote.WireFormats.internal_static_AkkaProtocolMessage_descriptor;
+        return org.apache.pekko.remote.WireFormats.internal_static_PekkoProtocolMessage_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.remote.WireFormats.internal_static_AkkaProtocolMessage_fieldAccessorTable
+        return org.apache.pekko.remote.WireFormats.internal_static_PekkoProtocolMessage_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                PekkoProtocolMessage.class, PekkoProtocolMessage.Builder.class);
+                org.apache.pekko.remote.WireFormats.PekkoProtocolMessage.class, org.apache.pekko.remote.WireFormats.PekkoProtocolMessage.Builder.class);
       }
 
-      // Construct using org.apache.pekko.remote.WireFormats.AkkaProtocolMessage.newBuilder()
+      // Construct using org.apache.pekko.remote.WireFormats.PekkoProtocolMessage.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
@@ -10102,17 +10102,17 @@ public final class WireFormats {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.remote.WireFormats.internal_static_AkkaProtocolMessage_descriptor;
+        return org.apache.pekko.remote.WireFormats.internal_static_PekkoProtocolMessage_descriptor;
       }
 
       @java.lang.Override
-      public PekkoProtocolMessage getDefaultInstanceForType() {
-        return PekkoProtocolMessage.getDefaultInstance();
+      public org.apache.pekko.remote.WireFormats.PekkoProtocolMessage getDefaultInstanceForType() {
+        return org.apache.pekko.remote.WireFormats.PekkoProtocolMessage.getDefaultInstance();
       }
 
       @java.lang.Override
-      public PekkoProtocolMessage build() {
-        PekkoProtocolMessage result = buildPartial();
+      public org.apache.pekko.remote.WireFormats.PekkoProtocolMessage build() {
+        org.apache.pekko.remote.WireFormats.PekkoProtocolMessage result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
@@ -10120,8 +10120,8 @@ public final class WireFormats {
       }
 
       @java.lang.Override
-      public PekkoProtocolMessage buildPartial() {
-        PekkoProtocolMessage result = new PekkoProtocolMessage(this);
+      public org.apache.pekko.remote.WireFormats.PekkoProtocolMessage buildPartial() {
+        org.apache.pekko.remote.WireFormats.PekkoProtocolMessage result = new org.apache.pekko.remote.WireFormats.PekkoProtocolMessage(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
@@ -10175,16 +10175,16 @@ public final class WireFormats {
       }
       @java.lang.Override
       public Builder mergeFrom(org.apache.pekko.protobufv3.internal.Message other) {
-        if (other instanceof PekkoProtocolMessage) {
-          return mergeFrom((PekkoProtocolMessage)other);
+        if (other instanceof org.apache.pekko.remote.WireFormats.PekkoProtocolMessage) {
+          return mergeFrom((org.apache.pekko.remote.WireFormats.PekkoProtocolMessage)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(PekkoProtocolMessage other) {
-        if (other == PekkoProtocolMessage.getDefaultInstance()) return this;
+      public Builder mergeFrom(org.apache.pekko.remote.WireFormats.PekkoProtocolMessage other) {
+        if (other == org.apache.pekko.remote.WireFormats.PekkoProtocolMessage.getDefaultInstance()) return this;
         if (other.hasPayload()) {
           setPayload(other.getPayload());
         }
@@ -10211,11 +10211,11 @@ public final class WireFormats {
           org.apache.pekko.protobufv3.internal.CodedInputStream input,
           org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        PekkoProtocolMessage parsedMessage = null;
+        org.apache.pekko.remote.WireFormats.PekkoProtocolMessage parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException e) {
-          parsedMessage = (PekkoProtocolMessage) e.getUnfinishedMessage();
+          parsedMessage = (org.apache.pekko.remote.WireFormats.PekkoProtocolMessage) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -10266,31 +10266,31 @@ public final class WireFormats {
         return this;
       }
 
-      private PekkoControlMessage instruction_;
+      private org.apache.pekko.remote.WireFormats.PekkoControlMessage instruction_;
       private org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
-              PekkoControlMessage, PekkoControlMessage.Builder, PekkoControlMessageOrBuilder> instructionBuilder_;
+          org.apache.pekko.remote.WireFormats.PekkoControlMessage, org.apache.pekko.remote.WireFormats.PekkoControlMessage.Builder, org.apache.pekko.remote.WireFormats.PekkoControlMessageOrBuilder> instructionBuilder_;
       /**
-       * <code>optional .AkkaControlMessage instruction = 2;</code>
+       * <code>optional .PekkoControlMessage instruction = 2;</code>
        * @return Whether the instruction field is set.
        */
       public boolean hasInstruction() {
         return ((bitField0_ & 0x00000002) != 0);
       }
       /**
-       * <code>optional .AkkaControlMessage instruction = 2;</code>
+       * <code>optional .PekkoControlMessage instruction = 2;</code>
        * @return The instruction.
        */
-      public PekkoControlMessage getInstruction() {
+      public org.apache.pekko.remote.WireFormats.PekkoControlMessage getInstruction() {
         if (instructionBuilder_ == null) {
-          return instruction_ == null ? PekkoControlMessage.getDefaultInstance() : instruction_;
+          return instruction_ == null ? org.apache.pekko.remote.WireFormats.PekkoControlMessage.getDefaultInstance() : instruction_;
         } else {
           return instructionBuilder_.getMessage();
         }
       }
       /**
-       * <code>optional .AkkaControlMessage instruction = 2;</code>
+       * <code>optional .PekkoControlMessage instruction = 2;</code>
        */
-      public Builder setInstruction(PekkoControlMessage value) {
+      public Builder setInstruction(org.apache.pekko.remote.WireFormats.PekkoControlMessage value) {
         if (instructionBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -10304,10 +10304,10 @@ public final class WireFormats {
         return this;
       }
       /**
-       * <code>optional .AkkaControlMessage instruction = 2;</code>
+       * <code>optional .PekkoControlMessage instruction = 2;</code>
        */
       public Builder setInstruction(
-          PekkoControlMessage.Builder builderForValue) {
+          org.apache.pekko.remote.WireFormats.PekkoControlMessage.Builder builderForValue) {
         if (instructionBuilder_ == null) {
           instruction_ = builderForValue.build();
           onChanged();
@@ -10318,15 +10318,15 @@ public final class WireFormats {
         return this;
       }
       /**
-       * <code>optional .AkkaControlMessage instruction = 2;</code>
+       * <code>optional .PekkoControlMessage instruction = 2;</code>
        */
-      public Builder mergeInstruction(PekkoControlMessage value) {
+      public Builder mergeInstruction(org.apache.pekko.remote.WireFormats.PekkoControlMessage value) {
         if (instructionBuilder_ == null) {
           if (((bitField0_ & 0x00000002) != 0) &&
               instruction_ != null &&
-              instruction_ != PekkoControlMessage.getDefaultInstance()) {
+              instruction_ != org.apache.pekko.remote.WireFormats.PekkoControlMessage.getDefaultInstance()) {
             instruction_ =
-              PekkoControlMessage.newBuilder(instruction_).mergeFrom(value).buildPartial();
+              org.apache.pekko.remote.WireFormats.PekkoControlMessage.newBuilder(instruction_).mergeFrom(value).buildPartial();
           } else {
             instruction_ = value;
           }
@@ -10338,7 +10338,7 @@ public final class WireFormats {
         return this;
       }
       /**
-       * <code>optional .AkkaControlMessage instruction = 2;</code>
+       * <code>optional .PekkoControlMessage instruction = 2;</code>
        */
       public Builder clearInstruction() {
         if (instructionBuilder_ == null) {
@@ -10351,33 +10351,33 @@ public final class WireFormats {
         return this;
       }
       /**
-       * <code>optional .AkkaControlMessage instruction = 2;</code>
+       * <code>optional .PekkoControlMessage instruction = 2;</code>
        */
-      public PekkoControlMessage.Builder getInstructionBuilder() {
+      public org.apache.pekko.remote.WireFormats.PekkoControlMessage.Builder getInstructionBuilder() {
         bitField0_ |= 0x00000002;
         onChanged();
         return getInstructionFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .AkkaControlMessage instruction = 2;</code>
+       * <code>optional .PekkoControlMessage instruction = 2;</code>
        */
-      public PekkoControlMessageOrBuilder getInstructionOrBuilder() {
+      public org.apache.pekko.remote.WireFormats.PekkoControlMessageOrBuilder getInstructionOrBuilder() {
         if (instructionBuilder_ != null) {
           return instructionBuilder_.getMessageOrBuilder();
         } else {
           return instruction_ == null ?
-              PekkoControlMessage.getDefaultInstance() : instruction_;
+              org.apache.pekko.remote.WireFormats.PekkoControlMessage.getDefaultInstance() : instruction_;
         }
       }
       /**
-       * <code>optional .AkkaControlMessage instruction = 2;</code>
+       * <code>optional .PekkoControlMessage instruction = 2;</code>
        */
       private org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
-              PekkoControlMessage, PekkoControlMessage.Builder, PekkoControlMessageOrBuilder>
+          org.apache.pekko.remote.WireFormats.PekkoControlMessage, org.apache.pekko.remote.WireFormats.PekkoControlMessage.Builder, org.apache.pekko.remote.WireFormats.PekkoControlMessageOrBuilder> 
           getInstructionFieldBuilder() {
         if (instructionBuilder_ == null) {
           instructionBuilder_ = new org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
-                  PekkoControlMessage, PekkoControlMessage.Builder, PekkoControlMessageOrBuilder>(
+              org.apache.pekko.remote.WireFormats.PekkoControlMessage, org.apache.pekko.remote.WireFormats.PekkoControlMessage.Builder, org.apache.pekko.remote.WireFormats.PekkoControlMessageOrBuilder>(
                   getInstruction(),
                   getParentForChildren(),
                   isClean());
@@ -10398,16 +10398,16 @@ public final class WireFormats {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:AkkaProtocolMessage)
+      // @@protoc_insertion_point(builder_scope:PekkoProtocolMessage)
     }
 
-    // @@protoc_insertion_point(class_scope:AkkaProtocolMessage)
-    private static final PekkoProtocolMessage DEFAULT_INSTANCE;
+    // @@protoc_insertion_point(class_scope:PekkoProtocolMessage)
+    private static final org.apache.pekko.remote.WireFormats.PekkoProtocolMessage DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new PekkoProtocolMessage();
+      DEFAULT_INSTANCE = new org.apache.pekko.remote.WireFormats.PekkoProtocolMessage();
     }
 
-    public static PekkoProtocolMessage getDefaultInstance() {
+    public static org.apache.pekko.remote.WireFormats.PekkoProtocolMessage getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
@@ -10432,14 +10432,14 @@ public final class WireFormats {
     }
 
     @java.lang.Override
-    public PekkoProtocolMessage getDefaultInstanceForType() {
+    public org.apache.pekko.remote.WireFormats.PekkoProtocolMessage getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
   }
 
   public interface PekkoControlMessageOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:AkkaControlMessage)
+      // @@protoc_insertion_point(interface_extends:PekkoControlMessage)
       org.apache.pekko.protobufv3.internal.MessageOrBuilder {
 
     /**
@@ -10454,19 +10454,19 @@ public final class WireFormats {
     org.apache.pekko.remote.WireFormats.CommandType getCommandType();
 
     /**
-     * <code>optional .AkkaHandshakeInfo handshakeInfo = 2;</code>
+     * <code>optional .PekkoHandshakeInfo handshakeInfo = 2;</code>
      * @return Whether the handshakeInfo field is set.
      */
     boolean hasHandshakeInfo();
     /**
-     * <code>optional .AkkaHandshakeInfo handshakeInfo = 2;</code>
+     * <code>optional .PekkoHandshakeInfo handshakeInfo = 2;</code>
      * @return The handshakeInfo.
      */
-    PekkoHandshakeInfo getHandshakeInfo();
+    org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo getHandshakeInfo();
     /**
-     * <code>optional .AkkaHandshakeInfo handshakeInfo = 2;</code>
+     * <code>optional .PekkoHandshakeInfo handshakeInfo = 2;</code>
      */
-    PekkoHandshakeInfoOrBuilder getHandshakeInfoOrBuilder();
+    org.apache.pekko.remote.WireFormats.PekkoHandshakeInfoOrBuilder getHandshakeInfoOrBuilder();
   }
   /**
    * <pre>
@@ -10474,14 +10474,14 @@ public final class WireFormats {
    * Defines some control messages for the remoting
    * </pre>
    *
-   * Protobuf type {@code AkkaControlMessage}
+   * Protobuf type {@code PekkoControlMessage}
    */
   public  static final class PekkoControlMessage extends
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:AkkaControlMessage)
-          PekkoControlMessageOrBuilder {
+      // @@protoc_insertion_point(message_implements:PekkoControlMessage)
+      PekkoControlMessageOrBuilder {
   private static final long serialVersionUID = 0L;
-    // Use AkkaControlMessage.newBuilder() to construct.
+    // Use PekkoControlMessage.newBuilder() to construct.
     private PekkoControlMessage(org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
@@ -10533,11 +10533,11 @@ public final class WireFormats {
               break;
             }
             case 18: {
-              PekkoHandshakeInfo.Builder subBuilder = null;
+              org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo.Builder subBuilder = null;
               if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = handshakeInfo_.toBuilder();
               }
-              handshakeInfo_ = input.readMessage(PekkoHandshakeInfo.PARSER, extensionRegistry);
+              handshakeInfo_ = input.readMessage(org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo.PARSER, extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(handshakeInfo_);
                 handshakeInfo_ = subBuilder.buildPartial();
@@ -10566,15 +10566,15 @@ public final class WireFormats {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.remote.WireFormats.internal_static_AkkaControlMessage_descriptor;
+      return org.apache.pekko.remote.WireFormats.internal_static_PekkoControlMessage_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.remote.WireFormats.internal_static_AkkaControlMessage_fieldAccessorTable
+      return org.apache.pekko.remote.WireFormats.internal_static_PekkoControlMessage_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              PekkoControlMessage.class, PekkoControlMessage.Builder.class);
+              org.apache.pekko.remote.WireFormats.PekkoControlMessage.class, org.apache.pekko.remote.WireFormats.PekkoControlMessage.Builder.class);
     }
 
     private int bitField0_;
@@ -10598,26 +10598,26 @@ public final class WireFormats {
     }
 
     public static final int HANDSHAKEINFO_FIELD_NUMBER = 2;
-    private PekkoHandshakeInfo handshakeInfo_;
+    private org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo handshakeInfo_;
     /**
-     * <code>optional .AkkaHandshakeInfo handshakeInfo = 2;</code>
+     * <code>optional .PekkoHandshakeInfo handshakeInfo = 2;</code>
      * @return Whether the handshakeInfo field is set.
      */
     public boolean hasHandshakeInfo() {
       return ((bitField0_ & 0x00000002) != 0);
     }
     /**
-     * <code>optional .AkkaHandshakeInfo handshakeInfo = 2;</code>
+     * <code>optional .PekkoHandshakeInfo handshakeInfo = 2;</code>
      * @return The handshakeInfo.
      */
-    public PekkoHandshakeInfo getHandshakeInfo() {
-      return handshakeInfo_ == null ? PekkoHandshakeInfo.getDefaultInstance() : handshakeInfo_;
+    public org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo getHandshakeInfo() {
+      return handshakeInfo_ == null ? org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo.getDefaultInstance() : handshakeInfo_;
     }
     /**
-     * <code>optional .AkkaHandshakeInfo handshakeInfo = 2;</code>
+     * <code>optional .PekkoHandshakeInfo handshakeInfo = 2;</code>
      */
-    public PekkoHandshakeInfoOrBuilder getHandshakeInfoOrBuilder() {
-      return handshakeInfo_ == null ? PekkoHandshakeInfo.getDefaultInstance() : handshakeInfo_;
+    public org.apache.pekko.remote.WireFormats.PekkoHandshakeInfoOrBuilder getHandshakeInfoOrBuilder() {
+      return handshakeInfo_ == null ? org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo.getDefaultInstance() : handshakeInfo_;
     }
 
     private byte memoizedIsInitialized = -1;
@@ -10677,10 +10677,10 @@ public final class WireFormats {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof PekkoControlMessage)) {
+      if (!(obj instanceof org.apache.pekko.remote.WireFormats.PekkoControlMessage)) {
         return super.equals(obj);
       }
-      PekkoControlMessage other = (PekkoControlMessage) obj;
+      org.apache.pekko.remote.WireFormats.PekkoControlMessage other = (org.apache.pekko.remote.WireFormats.PekkoControlMessage) obj;
 
       if (hasCommandType() != other.hasCommandType()) return false;
       if (hasCommandType()) {
@@ -10715,69 +10715,69 @@ public final class WireFormats {
       return hash;
     }
 
-    public static PekkoControlMessage parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoControlMessage parseFrom(
         java.nio.ByteBuffer data)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static PekkoControlMessage parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoControlMessage parseFrom(
         java.nio.ByteBuffer data,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static PekkoControlMessage parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoControlMessage parseFrom(
         org.apache.pekko.protobufv3.internal.ByteString data)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static PekkoControlMessage parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoControlMessage parseFrom(
         org.apache.pekko.protobufv3.internal.ByteString data,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static PekkoControlMessage parseFrom(byte[] data)
+    public static org.apache.pekko.remote.WireFormats.PekkoControlMessage parseFrom(byte[] data)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static PekkoControlMessage parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoControlMessage parseFrom(
         byte[] data,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static PekkoControlMessage parseFrom(java.io.InputStream input)
+    public static org.apache.pekko.remote.WireFormats.PekkoControlMessage parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static PekkoControlMessage parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoControlMessage parseFrom(
         java.io.InputStream input,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static PekkoControlMessage parseDelimitedFrom(java.io.InputStream input)
+    public static org.apache.pekko.remote.WireFormats.PekkoControlMessage parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static PekkoControlMessage parseDelimitedFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoControlMessage parseDelimitedFrom(
         java.io.InputStream input,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static PekkoControlMessage parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoControlMessage parseFrom(
         org.apache.pekko.protobufv3.internal.CodedInputStream input)
         throws java.io.IOException {
       return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static PekkoControlMessage parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoControlMessage parseFrom(
         org.apache.pekko.protobufv3.internal.CodedInputStream input,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -10790,7 +10790,7 @@ public final class WireFormats {
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(PekkoControlMessage prototype) {
+    public static Builder newBuilder(org.apache.pekko.remote.WireFormats.PekkoControlMessage prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
     @java.lang.Override
@@ -10811,26 +10811,26 @@ public final class WireFormats {
      * Defines some control messages for the remoting
      * </pre>
      *
-     * Protobuf type {@code AkkaControlMessage}
+     * Protobuf type {@code PekkoControlMessage}
      */
     public static final class Builder extends
         org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:AkkaControlMessage)
-            PekkoControlMessageOrBuilder {
+        // @@protoc_insertion_point(builder_implements:PekkoControlMessage)
+        org.apache.pekko.remote.WireFormats.PekkoControlMessageOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.remote.WireFormats.internal_static_AkkaControlMessage_descriptor;
+        return org.apache.pekko.remote.WireFormats.internal_static_PekkoControlMessage_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.remote.WireFormats.internal_static_AkkaControlMessage_fieldAccessorTable
+        return org.apache.pekko.remote.WireFormats.internal_static_PekkoControlMessage_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                PekkoControlMessage.class, PekkoControlMessage.Builder.class);
+                org.apache.pekko.remote.WireFormats.PekkoControlMessage.class, org.apache.pekko.remote.WireFormats.PekkoControlMessage.Builder.class);
       }
 
-      // Construct using org.apache.pekko.remote.WireFormats.AkkaControlMessage.newBuilder()
+      // Construct using org.apache.pekko.remote.WireFormats.PekkoControlMessage.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
@@ -10863,17 +10863,17 @@ public final class WireFormats {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.remote.WireFormats.internal_static_AkkaControlMessage_descriptor;
+        return org.apache.pekko.remote.WireFormats.internal_static_PekkoControlMessage_descriptor;
       }
 
       @java.lang.Override
-      public PekkoControlMessage getDefaultInstanceForType() {
-        return PekkoControlMessage.getDefaultInstance();
+      public org.apache.pekko.remote.WireFormats.PekkoControlMessage getDefaultInstanceForType() {
+        return org.apache.pekko.remote.WireFormats.PekkoControlMessage.getDefaultInstance();
       }
 
       @java.lang.Override
-      public PekkoControlMessage build() {
-        PekkoControlMessage result = buildPartial();
+      public org.apache.pekko.remote.WireFormats.PekkoControlMessage build() {
+        org.apache.pekko.remote.WireFormats.PekkoControlMessage result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
@@ -10881,8 +10881,8 @@ public final class WireFormats {
       }
 
       @java.lang.Override
-      public PekkoControlMessage buildPartial() {
-        PekkoControlMessage result = new PekkoControlMessage(this);
+      public org.apache.pekko.remote.WireFormats.PekkoControlMessage buildPartial() {
+        org.apache.pekko.remote.WireFormats.PekkoControlMessage result = new org.apache.pekko.remote.WireFormats.PekkoControlMessage(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
@@ -10936,16 +10936,16 @@ public final class WireFormats {
       }
       @java.lang.Override
       public Builder mergeFrom(org.apache.pekko.protobufv3.internal.Message other) {
-        if (other instanceof PekkoControlMessage) {
-          return mergeFrom((PekkoControlMessage)other);
+        if (other instanceof org.apache.pekko.remote.WireFormats.PekkoControlMessage) {
+          return mergeFrom((org.apache.pekko.remote.WireFormats.PekkoControlMessage)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(PekkoControlMessage other) {
-        if (other == PekkoControlMessage.getDefaultInstance()) return this;
+      public Builder mergeFrom(org.apache.pekko.remote.WireFormats.PekkoControlMessage other) {
+        if (other == org.apache.pekko.remote.WireFormats.PekkoControlMessage.getDefaultInstance()) return this;
         if (other.hasCommandType()) {
           setCommandType(other.getCommandType());
         }
@@ -10975,11 +10975,11 @@ public final class WireFormats {
           org.apache.pekko.protobufv3.internal.CodedInputStream input,
           org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        PekkoControlMessage parsedMessage = null;
+        org.apache.pekko.remote.WireFormats.PekkoControlMessage parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException e) {
-          parsedMessage = (PekkoControlMessage) e.getUnfinishedMessage();
+          parsedMessage = (org.apache.pekko.remote.WireFormats.PekkoControlMessage) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -11032,31 +11032,31 @@ public final class WireFormats {
         return this;
       }
 
-      private PekkoHandshakeInfo handshakeInfo_;
+      private org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo handshakeInfo_;
       private org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
-              PekkoHandshakeInfo, PekkoHandshakeInfo.Builder, PekkoHandshakeInfoOrBuilder> handshakeInfoBuilder_;
+          org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo, org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo.Builder, org.apache.pekko.remote.WireFormats.PekkoHandshakeInfoOrBuilder> handshakeInfoBuilder_;
       /**
-       * <code>optional .AkkaHandshakeInfo handshakeInfo = 2;</code>
+       * <code>optional .PekkoHandshakeInfo handshakeInfo = 2;</code>
        * @return Whether the handshakeInfo field is set.
        */
       public boolean hasHandshakeInfo() {
         return ((bitField0_ & 0x00000002) != 0);
       }
       /**
-       * <code>optional .AkkaHandshakeInfo handshakeInfo = 2;</code>
+       * <code>optional .PekkoHandshakeInfo handshakeInfo = 2;</code>
        * @return The handshakeInfo.
        */
-      public PekkoHandshakeInfo getHandshakeInfo() {
+      public org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo getHandshakeInfo() {
         if (handshakeInfoBuilder_ == null) {
-          return handshakeInfo_ == null ? PekkoHandshakeInfo.getDefaultInstance() : handshakeInfo_;
+          return handshakeInfo_ == null ? org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo.getDefaultInstance() : handshakeInfo_;
         } else {
           return handshakeInfoBuilder_.getMessage();
         }
       }
       /**
-       * <code>optional .AkkaHandshakeInfo handshakeInfo = 2;</code>
+       * <code>optional .PekkoHandshakeInfo handshakeInfo = 2;</code>
        */
-      public Builder setHandshakeInfo(PekkoHandshakeInfo value) {
+      public Builder setHandshakeInfo(org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo value) {
         if (handshakeInfoBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -11070,10 +11070,10 @@ public final class WireFormats {
         return this;
       }
       /**
-       * <code>optional .AkkaHandshakeInfo handshakeInfo = 2;</code>
+       * <code>optional .PekkoHandshakeInfo handshakeInfo = 2;</code>
        */
       public Builder setHandshakeInfo(
-          PekkoHandshakeInfo.Builder builderForValue) {
+          org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo.Builder builderForValue) {
         if (handshakeInfoBuilder_ == null) {
           handshakeInfo_ = builderForValue.build();
           onChanged();
@@ -11084,15 +11084,15 @@ public final class WireFormats {
         return this;
       }
       /**
-       * <code>optional .AkkaHandshakeInfo handshakeInfo = 2;</code>
+       * <code>optional .PekkoHandshakeInfo handshakeInfo = 2;</code>
        */
-      public Builder mergeHandshakeInfo(PekkoHandshakeInfo value) {
+      public Builder mergeHandshakeInfo(org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo value) {
         if (handshakeInfoBuilder_ == null) {
           if (((bitField0_ & 0x00000002) != 0) &&
               handshakeInfo_ != null &&
-              handshakeInfo_ != PekkoHandshakeInfo.getDefaultInstance()) {
+              handshakeInfo_ != org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo.getDefaultInstance()) {
             handshakeInfo_ =
-              PekkoHandshakeInfo.newBuilder(handshakeInfo_).mergeFrom(value).buildPartial();
+              org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo.newBuilder(handshakeInfo_).mergeFrom(value).buildPartial();
           } else {
             handshakeInfo_ = value;
           }
@@ -11104,7 +11104,7 @@ public final class WireFormats {
         return this;
       }
       /**
-       * <code>optional .AkkaHandshakeInfo handshakeInfo = 2;</code>
+       * <code>optional .PekkoHandshakeInfo handshakeInfo = 2;</code>
        */
       public Builder clearHandshakeInfo() {
         if (handshakeInfoBuilder_ == null) {
@@ -11117,33 +11117,33 @@ public final class WireFormats {
         return this;
       }
       /**
-       * <code>optional .AkkaHandshakeInfo handshakeInfo = 2;</code>
+       * <code>optional .PekkoHandshakeInfo handshakeInfo = 2;</code>
        */
-      public PekkoHandshakeInfo.Builder getHandshakeInfoBuilder() {
+      public org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo.Builder getHandshakeInfoBuilder() {
         bitField0_ |= 0x00000002;
         onChanged();
         return getHandshakeInfoFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .AkkaHandshakeInfo handshakeInfo = 2;</code>
+       * <code>optional .PekkoHandshakeInfo handshakeInfo = 2;</code>
        */
-      public PekkoHandshakeInfoOrBuilder getHandshakeInfoOrBuilder() {
+      public org.apache.pekko.remote.WireFormats.PekkoHandshakeInfoOrBuilder getHandshakeInfoOrBuilder() {
         if (handshakeInfoBuilder_ != null) {
           return handshakeInfoBuilder_.getMessageOrBuilder();
         } else {
           return handshakeInfo_ == null ?
-              PekkoHandshakeInfo.getDefaultInstance() : handshakeInfo_;
+              org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo.getDefaultInstance() : handshakeInfo_;
         }
       }
       /**
-       * <code>optional .AkkaHandshakeInfo handshakeInfo = 2;</code>
+       * <code>optional .PekkoHandshakeInfo handshakeInfo = 2;</code>
        */
       private org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
-              PekkoHandshakeInfo, PekkoHandshakeInfo.Builder, PekkoHandshakeInfoOrBuilder>
+          org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo, org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo.Builder, org.apache.pekko.remote.WireFormats.PekkoHandshakeInfoOrBuilder> 
           getHandshakeInfoFieldBuilder() {
         if (handshakeInfoBuilder_ == null) {
           handshakeInfoBuilder_ = new org.apache.pekko.protobufv3.internal.SingleFieldBuilderV3<
-                  PekkoHandshakeInfo, PekkoHandshakeInfo.Builder, PekkoHandshakeInfoOrBuilder>(
+              org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo, org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo.Builder, org.apache.pekko.remote.WireFormats.PekkoHandshakeInfoOrBuilder>(
                   getHandshakeInfo(),
                   getParentForChildren(),
                   isClean());
@@ -11164,16 +11164,16 @@ public final class WireFormats {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:AkkaControlMessage)
+      // @@protoc_insertion_point(builder_scope:PekkoControlMessage)
     }
 
-    // @@protoc_insertion_point(class_scope:AkkaControlMessage)
-    private static final PekkoControlMessage DEFAULT_INSTANCE;
+    // @@protoc_insertion_point(class_scope:PekkoControlMessage)
+    private static final org.apache.pekko.remote.WireFormats.PekkoControlMessage DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new PekkoControlMessage();
+      DEFAULT_INSTANCE = new org.apache.pekko.remote.WireFormats.PekkoControlMessage();
     }
 
-    public static PekkoControlMessage getDefaultInstance() {
+    public static org.apache.pekko.remote.WireFormats.PekkoControlMessage getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
@@ -11198,14 +11198,14 @@ public final class WireFormats {
     }
 
     @java.lang.Override
-    public PekkoControlMessage getDefaultInstanceForType() {
+    public org.apache.pekko.remote.WireFormats.PekkoControlMessage getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
   }
 
   public interface PekkoHandshakeInfoOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:AkkaHandshakeInfo)
+      // @@protoc_insertion_point(interface_extends:PekkoHandshakeInfo)
       org.apache.pekko.protobufv3.internal.MessageOrBuilder {
 
     /**
@@ -11252,14 +11252,14 @@ public final class WireFormats {
         getCookieBytes();
   }
   /**
-   * Protobuf type {@code AkkaHandshakeInfo}
+   * Protobuf type {@code PekkoHandshakeInfo}
    */
   public  static final class PekkoHandshakeInfo extends
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:AkkaHandshakeInfo)
-          PekkoHandshakeInfoOrBuilder {
+      // @@protoc_insertion_point(message_implements:PekkoHandshakeInfo)
+      PekkoHandshakeInfoOrBuilder {
   private static final long serialVersionUID = 0L;
-    // Use AkkaHandshakeInfo.newBuilder() to construct.
+    // Use PekkoHandshakeInfo.newBuilder() to construct.
     private PekkoHandshakeInfo(org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
@@ -11343,15 +11343,15 @@ public final class WireFormats {
     }
     public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.pekko.remote.WireFormats.internal_static_AkkaHandshakeInfo_descriptor;
+      return org.apache.pekko.remote.WireFormats.internal_static_PekkoHandshakeInfo_descriptor;
     }
 
     @java.lang.Override
     protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.pekko.remote.WireFormats.internal_static_AkkaHandshakeInfo_fieldAccessorTable
+      return org.apache.pekko.remote.WireFormats.internal_static_PekkoHandshakeInfo_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              PekkoHandshakeInfo.class, PekkoHandshakeInfo.Builder.class);
+              org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo.class, org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo.Builder.class);
     }
 
     private int bitField0_;
@@ -11505,10 +11505,10 @@ public final class WireFormats {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof PekkoHandshakeInfo)) {
+      if (!(obj instanceof org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo)) {
         return super.equals(obj);
       }
-      PekkoHandshakeInfo other = (PekkoHandshakeInfo) obj;
+      org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo other = (org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo) obj;
 
       if (hasOrigin() != other.hasOrigin()) return false;
       if (hasOrigin()) {
@@ -11554,69 +11554,69 @@ public final class WireFormats {
       return hash;
     }
 
-    public static PekkoHandshakeInfo parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo parseFrom(
         java.nio.ByteBuffer data)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static PekkoHandshakeInfo parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo parseFrom(
         java.nio.ByteBuffer data,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static PekkoHandshakeInfo parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo parseFrom(
         org.apache.pekko.protobufv3.internal.ByteString data)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static PekkoHandshakeInfo parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo parseFrom(
         org.apache.pekko.protobufv3.internal.ByteString data,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static PekkoHandshakeInfo parseFrom(byte[] data)
+    public static org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo parseFrom(byte[] data)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static PekkoHandshakeInfo parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo parseFrom(
         byte[] data,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static PekkoHandshakeInfo parseFrom(java.io.InputStream input)
+    public static org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static PekkoHandshakeInfo parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo parseFrom(
         java.io.InputStream input,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static PekkoHandshakeInfo parseDelimitedFrom(java.io.InputStream input)
+    public static org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static PekkoHandshakeInfo parseDelimitedFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo parseDelimitedFrom(
         java.io.InputStream input,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static PekkoHandshakeInfo parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo parseFrom(
         org.apache.pekko.protobufv3.internal.CodedInputStream input)
         throws java.io.IOException {
       return org.apache.pekko.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static PekkoHandshakeInfo parseFrom(
+    public static org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo parseFrom(
         org.apache.pekko.protobufv3.internal.CodedInputStream input,
         org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -11629,7 +11629,7 @@ public final class WireFormats {
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(PekkoHandshakeInfo prototype) {
+    public static Builder newBuilder(org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
     @java.lang.Override
@@ -11645,26 +11645,26 @@ public final class WireFormats {
       return builder;
     }
     /**
-     * Protobuf type {@code AkkaHandshakeInfo}
+     * Protobuf type {@code PekkoHandshakeInfo}
      */
     public static final class Builder extends
         org.apache.pekko.protobufv3.internal.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:AkkaHandshakeInfo)
-            PekkoHandshakeInfoOrBuilder {
+        // @@protoc_insertion_point(builder_implements:PekkoHandshakeInfo)
+        org.apache.pekko.remote.WireFormats.PekkoHandshakeInfoOrBuilder {
       public static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.pekko.remote.WireFormats.internal_static_AkkaHandshakeInfo_descriptor;
+        return org.apache.pekko.remote.WireFormats.internal_static_PekkoHandshakeInfo_descriptor;
       }
 
       @java.lang.Override
       protected org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.pekko.remote.WireFormats.internal_static_AkkaHandshakeInfo_fieldAccessorTable
+        return org.apache.pekko.remote.WireFormats.internal_static_PekkoHandshakeInfo_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                PekkoHandshakeInfo.class, PekkoHandshakeInfo.Builder.class);
+                org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo.class, org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo.Builder.class);
       }
 
-      // Construct using org.apache.pekko.remote.WireFormats.AkkaHandshakeInfo.newBuilder()
+      // Construct using org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
@@ -11699,17 +11699,17 @@ public final class WireFormats {
       @java.lang.Override
       public org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.pekko.remote.WireFormats.internal_static_AkkaHandshakeInfo_descriptor;
+        return org.apache.pekko.remote.WireFormats.internal_static_PekkoHandshakeInfo_descriptor;
       }
 
       @java.lang.Override
-      public PekkoHandshakeInfo getDefaultInstanceForType() {
-        return PekkoHandshakeInfo.getDefaultInstance();
+      public org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo getDefaultInstanceForType() {
+        return org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo.getDefaultInstance();
       }
 
       @java.lang.Override
-      public PekkoHandshakeInfo build() {
-        PekkoHandshakeInfo result = buildPartial();
+      public org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo build() {
+        org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
@@ -11717,8 +11717,8 @@ public final class WireFormats {
       }
 
       @java.lang.Override
-      public PekkoHandshakeInfo buildPartial() {
-        PekkoHandshakeInfo result = new PekkoHandshakeInfo(this);
+      public org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo buildPartial() {
+        org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo result = new org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
@@ -11776,16 +11776,16 @@ public final class WireFormats {
       }
       @java.lang.Override
       public Builder mergeFrom(org.apache.pekko.protobufv3.internal.Message other) {
-        if (other instanceof PekkoHandshakeInfo) {
-          return mergeFrom((PekkoHandshakeInfo)other);
+        if (other instanceof org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo) {
+          return mergeFrom((org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(PekkoHandshakeInfo other) {
-        if (other == PekkoHandshakeInfo.getDefaultInstance()) return this;
+      public Builder mergeFrom(org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo other) {
+        if (other == org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo.getDefaultInstance()) return this;
         if (other.hasOrigin()) {
           mergeOrigin(other.getOrigin());
         }
@@ -11821,11 +11821,11 @@ public final class WireFormats {
           org.apache.pekko.protobufv3.internal.CodedInputStream input,
           org.apache.pekko.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        PekkoHandshakeInfo parsedMessage = null;
+        org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException e) {
-          parsedMessage = (PekkoHandshakeInfo) e.getUnfinishedMessage();
+          parsedMessage = (org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -12089,16 +12089,16 @@ public final class WireFormats {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:AkkaHandshakeInfo)
+      // @@protoc_insertion_point(builder_scope:PekkoHandshakeInfo)
     }
 
-    // @@protoc_insertion_point(class_scope:AkkaHandshakeInfo)
-    private static final PekkoHandshakeInfo DEFAULT_INSTANCE;
+    // @@protoc_insertion_point(class_scope:PekkoHandshakeInfo)
+    private static final org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new PekkoHandshakeInfo();
+      DEFAULT_INSTANCE = new org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo();
     }
 
-    public static PekkoHandshakeInfo getDefaultInstance() {
+    public static org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
@@ -12123,7 +12123,7 @@ public final class WireFormats {
     }
 
     @java.lang.Override
-    public PekkoHandshakeInfo getDefaultInstanceForType() {
+    public org.apache.pekko.remote.WireFormats.PekkoHandshakeInfo getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -20494,20 +20494,20 @@ public final class WireFormats {
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
       internal_static_DeployData_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_AkkaProtocolMessage_descriptor;
+    internal_static_PekkoProtocolMessage_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_AkkaProtocolMessage_fieldAccessorTable;
+      internal_static_PekkoProtocolMessage_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_AkkaControlMessage_descriptor;
+    internal_static_PekkoControlMessage_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_AkkaControlMessage_fieldAccessorTable;
+      internal_static_PekkoControlMessage_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
-    internal_static_AkkaHandshakeInfo_descriptor;
+    internal_static_PekkoHandshakeInfo_descriptor;
   private static final 
     org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
-      internal_static_AkkaHandshakeInfo_fieldAccessorTable;
+      internal_static_PekkoHandshakeInfo_fieldAccessorTable;
   private static final org.apache.pekko.protobufv3.internal.Descriptors.Descriptor
     internal_static_FiniteDuration_descriptor;
   private static final 
@@ -20676,23 +20676,23 @@ public final class WireFormats {
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
         internal_static_DeployData_descriptor,
         new java.lang.String[] { "Path", "Config", "RouterConfig", "Scope", "Dispatcher", "ScopeSerializerId", "ScopeManifest", "ConfigSerializerId", "ConfigManifest", "RouterConfigSerializerId", "RouterConfigManifest", "Tags", });
-    internal_static_AkkaProtocolMessage_descriptor =
+    internal_static_PekkoProtocolMessage_descriptor =
       getDescriptor().getMessageTypes().get(8);
-    internal_static_AkkaProtocolMessage_fieldAccessorTable = new
+    internal_static_PekkoProtocolMessage_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_AkkaProtocolMessage_descriptor,
+        internal_static_PekkoProtocolMessage_descriptor,
         new java.lang.String[] { "Payload", "Instruction", });
-    internal_static_AkkaControlMessage_descriptor =
+    internal_static_PekkoControlMessage_descriptor =
       getDescriptor().getMessageTypes().get(9);
-    internal_static_AkkaControlMessage_fieldAccessorTable = new
+    internal_static_PekkoControlMessage_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_AkkaControlMessage_descriptor,
+        internal_static_PekkoControlMessage_descriptor,
         new java.lang.String[] { "CommandType", "HandshakeInfo", });
-    internal_static_AkkaHandshakeInfo_descriptor =
+    internal_static_PekkoHandshakeInfo_descriptor =
       getDescriptor().getMessageTypes().get(10);
-    internal_static_AkkaHandshakeInfo_fieldAccessorTable = new
+    internal_static_PekkoHandshakeInfo_fieldAccessorTable = new
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_AkkaHandshakeInfo_descriptor,
+        internal_static_PekkoHandshakeInfo_descriptor,
         new java.lang.String[] { "Origin", "Uid", "Cookie", });
     internal_static_FiniteDuration_descriptor =
       getDescriptor().getMessageTypes().get(11);

--- a/remote/src/test/java/org/apache/pekko/remote/ProtobufProtocol.java
+++ b/remote/src/test/java/org/apache/pekko/remote/ProtobufProtocol.java
@@ -73,7 +73,7 @@ public final class ProtobufProtocol {
   /**
    * Protobuf type {@code MyMessage}
    */
-  public static final class MyMessage extends
+  public  static final class MyMessage extends
       org.apache.pekko.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:MyMessage)
       MyMessageOrBuilder {

--- a/stream/src/main/java/org/apache/pekko/stream/StreamRefMessages.java
+++ b/stream/src/main/java/org/apache/pekko/stream/StreamRefMessages.java
@@ -5685,7 +5685,7 @@ public final class StreamRefMessages {
       "OnNext\022\r\n\005seqNr\030\001 \002(\003\022\031\n\007payload\030\002 \002(\0132\010" +
       ".Payload\"$\n\023RemoteStreamFailure\022\r\n\005cause" +
       "\030\001 \001(\014\"&\n\025RemoteStreamCompleted\022\r\n\005seqNr" +
-      "\030\001 \002(\003B\017\n\013org.apache.pekko.streamH\001"
+      "\030\001 \002(\003B\033\n\027org.apache.pekko.streamH\001"
     };
     descriptor = org.apache.pekko.protobufv3.internal.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,


### PR DESCRIPTION
By regenerating protobuf messages with `protobufGenerate` in sbt after the package renames.

Fixes #167, #164