### PR TITLE
fix cron scheduling of nightly docs publishing 

### DIFF
--- a/.github/workflows/publish-nightly-docs.yml
+++ b/.github/workflows/publish-nightly-docs.yml
@@ -20,9 +20,9 @@
 name: Publish nightly documentation
 
 on:
-  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Not 100% sure this is needed but the GHA UI is missing the
scheduling information currently...