### PR TITLE
[DRAFT] Some rudimentary version of how releasing could work

### DIFF
--- a/scripts/release/Dockerfile
+++ b/scripts/release/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:22.04
+
+ENV RUN DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y curl gnupg2 openjdk-8-jdk-headless openjdk-11-jdk-headless sudo
+RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list &&\
+    echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee /etc/apt/sources.list.d/sbt_old.list &&\
+    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add
+
+RUN apt-get update && apt-get install -y sbt git
+
+RUN useradd -U -u 1000 user
+RUN mkdir /home/user && chown user: /home/user
+RUN mkdir /build && chown user: /build
+
+USER user:user
+WORKDIR /build
+
+RUN mkdir -p /tmp/sbt-init/project && echo "sbt.version=1.8.2" > /tmp/sbt-init/project/build.properties && cd /tmp/sbt-init && sbt exit
+
+ENV BUILD_COMMIT=origin/main
+
+RUN git clone --depth 100 https://github.com/apache/incubator-pekko
+WORKDIR /build/incubator-pekko
+RUN git checkout $BUILD_COMMIT
+RUN sbt +update # prime sbt

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -1,0 +1,25 @@
+# Release build scripts
+
+The build environment can be setup using this command:
+
+```sh
+docker build pekko:build
+```
+
+This command will run the build, and provided gpg credentials by forwarding the GPG agent connection to the docker container.
+Understand the risk of exposing the gpg-agent to a container.
+
+```sh
+docker run \
+  -ti --rm \
+  -v `pwd`:/scripts:ro \
+  -v ${HOME}/.gnupg/:/home/user/.gnupg/:ro -v /run/user/$(id -u)/:/run/user/$(id -u)/:ro \
+  -e BUILD_COMMIT=origin/main \
+  -e GPG_SIGNING_KEY=8DEF770BCFC57CEC83BF0410DC20AD935AC6CEF4 \
+  pekko:build /scripts/build-release.sh
+```
+
+## Config environment settings
+
+ * `BUILD_COMMIT`: The commit to checkout and build
+ * `GPG_SIGNING_KEY`: The GPG key ID to use for signing artifacts

--- a/scripts/release/build-release.sh
+++ b/scripts/release/build-release.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -ex
+set -o pipefail
+
+# check config
+# BUILD_COMMIT
+# NEXUS_USER
+# NEXUS_PW
+# GPG_SIGNING_KEY
+
+# checkout
+git checkout $BUILD_COMMIT
+
+# generate source artifacts
+sbt sourceDistGenerate
+
+# sign source artifacts
+find target/dist -regex '.*\(tgz\|zip\)' | xargs -n1 /scripts/hash.sh
+find target/dist -regex '.*\(tgz\|zip\)' | xargs -n1 gpg --sign --armor --default-key $GPG_SIGNING_KEY --detach-sig
+
+# upload source artifacts
+# TODO
+
+# publish to Apache Nexus Staging
+echo "pgpSigningKey := Some(\"$GPG_SIGNING_KEY\")" > pgp-signing-key.sbt
+sbt +publishSigned
+
+# generate and upload docs
+# TODO

--- a/scripts/release/hash.sh
+++ b/scripts/release/hash.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+set -o pipefail
+
+sha512sum $1 > $1.sha512


### PR DESCRIPTION
Here are some ideas how releasing could later work. It's far from finished. 

In this setup, a docker image provides the base installation to use for building.

GPG keys are provided from the outside of the container by providing access to the host gpg-agent. Alternatively, we could provide keys similarly as `sbt-ci-release` does it by actually providing the secret as an environment value. Both options don't seem super compelling. The use of `gpg-agent` at least provides the possibility to also use smartcards/yubikeys for signing automatically.

The setup of `gpg-agent` propagation to the docker container is right now quite brittle:
 * it requires that the user id must match between host and container
 * it assumes a certain setup of how gpg-agent is connected that works on Ubuntu/Linux but might not work on other distros