### PR TITLE
Fix link to snapshots repository documentation

### DIFF
--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -5,7 +5,7 @@ project-info {
   shared-info {
     jdk-versions: ["Adopt OpenJDK 8", "Adopt OpenJDK 11"]
     snapshots: {
-      url: "project/links.html#snapshots-repository"
+      url: "https://pekko.apache.org/docs/pekko/current/project/links.html#snapshots-repository"
       text: "Snapshots are available"
       new-tab: false
     }


### PR DESCRIPTION
as a relative url either the link at https://pekko.apache.org/docs/pekko/current/actors.html or at https://pekko.apache.org/docs/pekko/current/typed/actors.html would be wrong