### PR TITLE
Updates sbt-apache-sonatype

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,7 +20,7 @@ addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.30")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
 addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.2")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.2")
-addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.0")
+addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.1")
 addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.2.2")
 
 // allow access to snapshots for pekko-sbt-paradox


### PR DESCRIPTION
Updates sbt-apache-sonatype to latest version. I also did some quick cursory checking of relevant keys (i.e. `publishTo` and `apacheSonatypeLicenseFile`) and there appears to be no regressions.