### PR TITLE
update Akka refs in PekkoSSLConfig.scala

### DIFF
--- a/stream/src/main/scala/com/typesafe/sslconfig/pekko/PekkoSSLConfig.scala
+++ b/stream/src/main/scala/com/typesafe/sslconfig/pekko/PekkoSSLConfig.scala
@@ -24,7 +24,7 @@ import pekko.annotation.InternalApi
 import pekko.event.Logging
 import scala.annotation.nowarn
 
-@deprecated("Use Tcp and TLS with SSLEngine parameters instead. Setup the SSLEngine with needed parameters.", "2.6.0")
+@deprecated("Use Tcp and TLS with SSLEngine parameters instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
 object PekkoSSLConfig extends ExtensionId[PekkoSSLConfig] with ExtensionIdProvider {
 
   //////////////////// EXTENSION SETUP ///////////////////
@@ -39,14 +39,14 @@ object PekkoSSLConfig extends ExtensionId[PekkoSSLConfig] with ExtensionIdProvid
     new PekkoSSLConfig(system, defaultSSLConfigSettings(system))
 
   def defaultSSLConfigSettings(system: ActorSystem): SSLConfigSettings = {
-    val akkaOverrides = system.settings.config.getConfig("pekko.ssl-config")
+    val pekkoOverrides = system.settings.config.getConfig("pekko.ssl-config")
     val defaults = system.settings.config.getConfig("ssl-config")
-    SSLConfigFactory.parse(akkaOverrides.withFallback(defaults))
+    SSLConfigFactory.parse(pekkoOverrides.withFallback(defaults))
   }
 
 }
 
-@deprecated("Use Tcp and TLS with SSLEngine parameters instead. Setup the SSLEngine with needed parameters.", "2.6.0")
+@deprecated("Use Tcp and TLS with SSLEngine parameters instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
 final class PekkoSSLConfig(system: ExtendedActorSystem, val config: SSLConfigSettings) extends Extension {
 
   private val mkLogger = new PekkoLoggerFactory(system)
@@ -143,6 +143,7 @@ final class PekkoSSLConfig(system: ExtendedActorSystem, val config: SSLConfigSet
     v
   }
 
+  @deprecated("validateDefaultTrustManager is not doing anything since akka 2.6.19 and should not be used", "Akka 2.6.19")
   def validateDefaultTrustManager(@nowarn("msg=never used") sslConfig: SSLConfigSettings): Unit = {
     log.warning(
       "validateDefaultTrustManager is not doing anything since akka 2.6.19, it was useful only in Java 7 and below");

--- a/stream/src/main/scala/com/typesafe/sslconfig/pekko/PekkoSSLConfig.scala
+++ b/stream/src/main/scala/com/typesafe/sslconfig/pekko/PekkoSSLConfig.scala
@@ -24,7 +24,8 @@ import pekko.annotation.InternalApi
 import pekko.event.Logging
 import scala.annotation.nowarn
 
-@deprecated("Use Tcp and TLS with SSLEngine parameters instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
+@deprecated("Use Tcp and TLS with SSLEngine parameters instead. Setup the SSLEngine with needed parameters.",
+  "Akka 2.6.0")
 object PekkoSSLConfig extends ExtensionId[PekkoSSLConfig] with ExtensionIdProvider {
 
   //////////////////// EXTENSION SETUP ///////////////////
@@ -46,7 +47,8 @@ object PekkoSSLConfig extends ExtensionId[PekkoSSLConfig] with ExtensionIdProvid
 
 }
 
-@deprecated("Use Tcp and TLS with SSLEngine parameters instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
+@deprecated("Use Tcp and TLS with SSLEngine parameters instead. Setup the SSLEngine with needed parameters.",
+  "Akka 2.6.0")
 final class PekkoSSLConfig(system: ExtendedActorSystem, val config: SSLConfigSettings) extends Extension {
 
   private val mkLogger = new PekkoLoggerFactory(system)
@@ -143,7 +145,8 @@ final class PekkoSSLConfig(system: ExtendedActorSystem, val config: SSLConfigSet
     v
   }
 
-  @deprecated("validateDefaultTrustManager is not doing anything since akka 2.6.19 and should not be used", "Akka 2.6.19")
+  @deprecated("validateDefaultTrustManager is not doing anything since akka 2.6.19 and should not be used",
+    "Akka 2.6.19")
   def validateDefaultTrustManager(@nowarn("msg=never used") sslConfig: SSLConfigSettings): Unit = {
     log.warning(
       "validateDefaultTrustManager is not doing anything since akka 2.6.19, it was useful only in Java 7 and below");


### PR DESCRIPTION
* this class is deprecated
* the deprecation notices were missed when I previously changed the version numbers on other deprecation notices to highlight the version number is an Akka version as opposed to a Pekko version
* renamed one akka named param
* added a further deprecation to highlight one particular function where calling it just leads to a log warning (and nothing else is done)