### PR TITLE
Add github PR check to make sure code is formatted

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -28,7 +28,13 @@ github:
     rebase:  true
 
   protected_branches:
-    main: { }
+    main:
+      required_status_checks:
+        # strict means "Require branches to be up to date before merging".
+        strict: false
+        # contexts are the names of checks that must pass
+        contexts:
+          - Code is formatted
 
 notifications:
   commits:              commits@pekko.apache.org


### PR DESCRIPTION
Adds a github PR status check which disallows PR's from being merged if the code is not formatted. Note that its been verified that this works in another pekko module (see https://github.com/apache/incubator-pekko-sbt-paradox/blob/main/.asf.yaml#L28-L35)