### PR TITLE
change deprecated versions to use Akka in name

### DIFF
--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/LoggingTestKit.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/LoggingTestKit.scala
@@ -117,7 +117,7 @@ import pekko.annotation.DoNotInherit
    *
    * Care is taken to remove the testkit when the block is finished or aborted.
    */
-  @deprecated("Use expect instead.", "2.6.0")
+  @deprecated("Use expect instead.", "Akka 2.6.0")
   def intercept[T](code: => T)(implicit system: ActorSystem[_]): T
 
 }

--- a/actor-tests/src/test/scala/org/apache/pekko/event/jul/JavaLoggerSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/event/jul/JavaLoggerSpec.scala
@@ -23,7 +23,7 @@ import org.apache.pekko
 import pekko.actor.{ Actor, ActorLogging, Props }
 import pekko.testkit.PekkoSpec
 
-@deprecated("Use SLF4J instead.", "2.6.0")
+@deprecated("Use SLF4J instead.", "Akka 2.6.0")
 object JavaLoggerSpec {
 
   val config = ConfigFactory.parseString("""
@@ -45,7 +45,7 @@ object JavaLoggerSpec {
   class SimulatedExc extends RuntimeException("Simulated error") with NoStackTrace
 }
 
-@deprecated("Use SLF4J instead.", "2.6.0")
+@deprecated("Use SLF4J instead.", "Akka 2.6.0")
 class JavaLoggerSpec extends PekkoSpec(JavaLoggerSpec.config) {
 
   val logger = logging.Logger.getLogger(classOf[JavaLoggerSpec.LogProducer].getName)

--- a/actor/src/main/scala/org/apache/pekko/actor/package.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/package.scala
@@ -16,8 +16,8 @@ package org.apache.pekko
 import language.implicitConversions
 
 package object actor {
-  @deprecated("implicit conversion is obsolete", "2.6.13")
+  @deprecated("implicit conversion is obsolete", "Akka 2.6.13")
   @inline implicit final def actorRef2Scala(ref: ActorRef): ScalaActorRef = ref.asInstanceOf[ScalaActorRef]
-  @deprecated("implicit conversion is obsolete", "2.6.13")
+  @deprecated("implicit conversion is obsolete", "Akka 2.6.13")
   @inline implicit final def scala2ActorRef(ref: ScalaActorRef): ActorRef = ref.asInstanceOf[ActorRef]
 }

--- a/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
@@ -105,7 +105,7 @@ object ExecutionContexts {
    * INTERNAL API
    */
   @InternalApi
-  @deprecated("Use ExecutionContexts.parasitic instead", "2.6.4")
+  @deprecated("Use ExecutionContexts.parasitic instead", "Akka 2.6.4")
   private[pekko] object sameThreadExecutionContext extends ExecutionContext with BatchingExecutor {
     override protected def unbatchedExecute(runnable: Runnable): Unit = parasitic.execute(runnable)
     override protected def resubmitOnBlock: Boolean = false // No point since we execute on same thread

--- a/actor/src/main/scala/org/apache/pekko/event/jul/JavaLogger.scala
+++ b/actor/src/main/scala/org/apache/pekko/event/jul/JavaLogger.scala
@@ -29,7 +29,7 @@ import pekko.util.unused
 /**
  * `java.util.logging` logger.
  */
-@deprecated("Use Slf4jLogger instead.", "2.6.0")
+@deprecated("Use Slf4jLogger instead.", "Akka 2.6.0")
 class JavaLogger extends Actor with RequiresMessageQueue[LoggerMessageQueueSemantics] {
   import Logger.mapLevel
 
@@ -59,7 +59,7 @@ class JavaLogger extends Actor with RequiresMessageQueue[LoggerMessageQueueSeman
 /**
  * Base trait for all classes that wants to be able use the JUL logging infrastructure.
  */
-@deprecated("Use SLF4J or direct java.util.logging instead.", "2.6.0")
+@deprecated("Use SLF4J or direct java.util.logging instead.", "Akka 2.6.0")
 trait JavaLogging {
   @transient
   lazy val log: logging.Logger = Logger(this.getClass.getName)
@@ -68,7 +68,7 @@ trait JavaLogging {
 /**
  * Logger is a factory for obtaining JUL Loggers
  */
-@deprecated("Use SLF4J or direct java.util.logging instead.", "2.6.0")
+@deprecated("Use SLF4J or direct java.util.logging instead.", "Akka 2.6.0")
 object Logger {
 
   /**
@@ -106,7 +106,7 @@ object Logger {
  * backend configuration to filter log events before publishing
  * the log events to the `eventStream`.
  */
-@deprecated("Use Slf4jLoggingFilter instead.", "2.6.0")
+@deprecated("Use Slf4jLoggingFilter instead.", "Akka 2.6.0")
 class JavaLoggingFilter(@unused settings: ActorSystem.Settings, eventStream: EventStream) extends LoggingFilter {
   import Logger.mapLevel
 

--- a/actor/src/main/scala/org/apache/pekko/io/Dns.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/Dns.scala
@@ -47,14 +47,14 @@ abstract class Dns {
    * Lookup if a DNS resolved is cached. The exact behavior of caching will depend on
    * the pekko.actor.io.dns.resolver that is configured.
    */
-  @deprecated("Use cached(DnsProtocol.Resolve)", "2.6.0")
+  @deprecated("Use cached(DnsProtocol.Resolve)", "Akka 2.6.0")
   def cached(@unused name: String): Option[Dns.Resolved] = None
 
   /**
    * If an entry is cached return it immediately. If it is not then
    * trigger a resolve and return None.
    */
-  @deprecated("Use resolve(DnsProtocol.Resolve)", "2.6.0")
+  @deprecated("Use resolve(DnsProtocol.Resolve)", "Akka 2.6.0")
   def resolve(name: String)(system: ActorSystem, sender: ActorRef): Option[Dns.Resolved] = {
     // doesn't delegate to new method as sender is expecting old protocol back
     val ret = cached(name)
@@ -76,12 +76,12 @@ abstract class Dns {
 object Dns extends ExtensionId[DnsExt] with ExtensionIdProvider {
   sealed trait Command
 
-  @deprecated("Use cached(DnsProtocol.Resolve)", "2.6.0")
+  @deprecated("Use cached(DnsProtocol.Resolve)", "Akka 2.6.0")
   case class Resolve(name: String) extends Command with ConsistentHashable {
     override def consistentHashKey = name
   }
 
-  @deprecated("Use cached(DnsProtocol.Resolved)", "2.6.0")
+  @deprecated("Use cached(DnsProtocol.Resolved)", "Akka 2.6.0")
   case class Resolved(name: String, ipv4: immutable.Seq[Inet4Address], ipv6: immutable.Seq[Inet6Address])
       extends Command {
     val addrOption: Option[InetAddress] = IpVersionSelector.getInetAddress(ipv4.headOption, ipv6.headOption)
@@ -93,7 +93,7 @@ object Dns extends ExtensionId[DnsExt] with ExtensionIdProvider {
     }
   }
 
-  @deprecated("Use cached(DnsProtocol.Resolved)", "2.6.0")
+  @deprecated("Use cached(DnsProtocol.Resolved)", "Akka 2.6.0")
   object Resolved {
     def apply(name: String, addresses: Iterable[InetAddress]): Resolved = {
       val ipv4: immutable.Seq[Inet4Address] =
@@ -103,7 +103,7 @@ object Dns extends ExtensionId[DnsExt] with ExtensionIdProvider {
       Resolved(name, ipv4, ipv6)
     }
 
-    @deprecated("Use cached(DnsProtocol.Resolve)", "2.6.0")
+    @deprecated("Use cached(DnsProtocol.Resolve)", "Akka 2.6.0")
     def apply(newProtocol: DnsProtocol.Resolved): Resolved = {
       Resolved(newProtocol.name,
         newProtocol.records.collect {
@@ -117,7 +117,7 @@ object Dns extends ExtensionId[DnsExt] with ExtensionIdProvider {
    * Lookup if a DNS resolved is cached. The exact behavior of caching will depend on
    * the pekko.actor.io.dns.resolver that is configured.
    */
-  @deprecated("use cached(DnsProtocol.Resolve)", "2.6.0")
+  @deprecated("use cached(DnsProtocol.Resolve)", "Akka 2.6.0")
   def cached(name: String)(system: ActorSystem): Option[Resolved] = {
     Dns(system).cache.cached(name)
   }
@@ -126,7 +126,7 @@ object Dns extends ExtensionId[DnsExt] with ExtensionIdProvider {
    * If an entry is cached return it immediately. If it is not then
    * trigger a resolve and return None.
    */
-  @deprecated("use resolve(DnsProtocol.Resolve)", "2.6.0")
+  @deprecated("use resolve(DnsProtocol.Resolve)", "Akka 2.6.0")
   @nowarn("msg=deprecated")
   def resolve(name: String)(system: ActorSystem, sender: ActorRef): Option[Resolved] = {
     Dns(system).cache.resolve(name)(system, sender)

--- a/actor/src/main/scala/org/apache/pekko/io/DnsProvider.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/DnsProvider.scala
@@ -23,7 +23,7 @@ import pekko.actor.Actor
  *
  *  TODO make private and remove deprecated in v1.1.0
  */
-@deprecated("Overriding the DNS implementation will be removed in future versions of Akka", "2.6.0")
+@deprecated("Overriding the DNS implementation will be removed in future versions of Akka", "Akka 2.6.0")
 trait DnsProvider {
 
   /**

--- a/actor/src/main/scala/org/apache/pekko/io/InetAddressDnsResolver.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/InetAddressDnsResolver.scala
@@ -109,9 +109,9 @@ class InetAddressDnsResolver(cache: SimpleDnsCache, config: Config) extends Acto
 
   val positiveCachePolicy: CachePolicy = getTtl("positive-ttl", positive = true)
   val negativeCachePolicy: CachePolicy = getTtl("negative-ttl", positive = false)
-  @deprecated("Use positiveCacheDuration instead", "2.5.17")
+  @deprecated("Use positiveCacheDuration instead", "Akka 2.5.17")
   val positiveTtl: Long = toLongTtl(positiveCachePolicy)
-  @deprecated("Use negativeCacheDuration instead", "2.5.17")
+  @deprecated("Use negativeCacheDuration instead", "Akka 2.5.17")
   val negativeTtl: Long = toLongTtl(negativeCachePolicy)
 
   private def toLongTtl(cp: CachePolicy): Long = {

--- a/actor/src/main/scala/org/apache/pekko/io/Tcp.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/Tcp.scala
@@ -369,7 +369,7 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
   /**
    * @see [[WritePath]]
    */
-  @deprecated("Use WritePath instead", "2.5.10")
+  @deprecated("Use WritePath instead", "Akka 2.5.10")
   final case class WriteFile(filePath: String, position: Long, count: Long, ack: Event) extends SimpleWriteCommand {
     require(position >= 0, "WriteFile.position must be >= 0")
     require(count > 0, "WriteFile.count must be > 0")

--- a/actor/src/main/scala/org/apache/pekko/pattern/Backoff.scala
+++ b/actor/src/main/scala/org/apache/pekko/pattern/Backoff.scala
@@ -79,7 +79,7 @@ object Backoff {
    *                       The supervisor will terminate itself after the maxNoOfRetries is reached.
    *                       In order to restart infinitely pass in `-1`.
    */
-  @deprecated("Use BackoffOpts.onFailure instead", "2.5.22")
+  @deprecated("Use BackoffOpts.onFailure instead", "Akka 2.5.22")
   def onFailure(
       childProps: Props,
       childName: String,
@@ -136,7 +136,7 @@ object Backoff {
    *                     random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *                     In order to skip this additional delay pass in `0`.
    */
-  @deprecated("Use BackoffOpts.onFailure instead", "2.5.22")
+  @deprecated("Use BackoffOpts.onFailure instead", "Akka 2.5.22")
   def onFailure(
       childProps: Props,
       childName: String,
@@ -195,7 +195,7 @@ object Backoff {
    *                       In order to restart infinitely pass in `-1`.
    */
   @Deprecated
-  @deprecated("Use BackoffOpts.onFailure instead", "2.5.22")
+  @deprecated("Use BackoffOpts.onFailure instead", "Akka 2.5.22")
   def onFailure(
       childProps: Props,
       childName: String,
@@ -252,7 +252,7 @@ object Backoff {
    *                     In order to skip this additional delay pass in `0`.
    */
   @Deprecated
-  @deprecated("Use the overloaded one which accepts maxNrOfRetries instead.", "2.5.17")
+  @deprecated("Use the overloaded one which accepts maxNrOfRetries instead.", "Akka 2.5.17")
   def onFailure(
       childProps: Props,
       childName: String,
@@ -317,7 +317,7 @@ object Backoff {
    *                       The supervisor will terminate itself after the maxNoOfRetries is reached.
    *                       In order to restart infinitely pass in `-1`.
    */
-  @deprecated("Use BackoffOpts.onStop instead", "2.5.22")
+  @deprecated("Use BackoffOpts.onStop instead", "Akka 2.5.22")
   def onStop(
       childProps: Props,
       childName: String,
@@ -381,7 +381,7 @@ object Backoff {
    *                     random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *                     In order to skip this additional delay pass in `0`.
    */
-  @deprecated("Use BackoffOpts.onStop instead", "2.5.22")
+  @deprecated("Use BackoffOpts.onStop instead", "Akka 2.5.22")
   def onStop(
       childProps: Props,
       childName: String,
@@ -447,7 +447,7 @@ object Backoff {
    *                       In order to restart infinitely pass in `-1`.
    */
   @Deprecated
-  @deprecated("Use BackoffOpts.onStop instead", "2.5.22")
+  @deprecated("Use BackoffOpts.onStop instead", "Akka 2.5.22")
   def onStop(
       childProps: Props,
       childName: String,
@@ -511,7 +511,7 @@ object Backoff {
    *                     In order to skip this additional delay pass in `0`.
    */
   @Deprecated
-  @deprecated("Use the overloaded one which accepts maxNrOfRetries instead.", "2.5.17")
+  @deprecated("Use the overloaded one which accepts maxNrOfRetries instead.", "Akka 2.5.17")
   def onStop(
       childProps: Props,
       childName: String,

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/ClusterShardingSettings.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/ClusterShardingSettings.scala
@@ -837,7 +837,7 @@ final class ClusterShardingSettings(
     val coordinatorSingletonSettings: ClusterSingletonManagerSettings,
     val leaseSettings: Option[LeaseUsageSettings]) {
 
-  @deprecated("Use constructor with coordinatorSingletonOverrideRole", "2.6.20")
+  @deprecated("Use constructor with coordinatorSingletonOverrideRole", "Akka 2.6.20")
   def this(
       numberOfShards: Int,
       role: Option[String],
@@ -868,7 +868,7 @@ final class ClusterShardingSettings(
       coordinatorSingletonSettings,
       leaseSettings)
 
-  @deprecated("Use constructor with passivationStrategySettings", "2.6.18")
+  @deprecated("Use constructor with passivationStrategySettings", "Akka 2.6.18")
   def this(
       numberOfShards: Int,
       role: Option[String],
@@ -899,7 +899,7 @@ final class ClusterShardingSettings(
       coordinatorSingletonSettings,
       leaseSettings)
 
-  @deprecated("Use constructor with leaseSettings", "2.6.11")
+  @deprecated("Use constructor with leaseSettings", "Akka 2.6.11")
   def this(
       numberOfShards: Int,
       role: Option[String],
@@ -928,7 +928,7 @@ final class ClusterShardingSettings(
       coordinatorSingletonSettings,
       None)
 
-  @deprecated("Use constructor with rememberEntitiesStoreMode", "2.6.6")
+  @deprecated("Use constructor with rememberEntitiesStoreMode", "Akka 2.6.6")
   def this(
       numberOfShards: Int,
       role: Option[String],

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/ShardingProducerController.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/ShardingProducerController.scala
@@ -214,7 +214,7 @@ object ShardingProducerController {
       val producerControllerSettings: ProducerController.Settings) {
 
     @Deprecated
-    @deprecated("use resendFirstUnconfirmedIdleTimeout", "2.6.19")
+    @deprecated("use resendFirstUnconfirmedIdleTimeout", "Akka 2.6.19")
     def resendFirsUnconfirmedIdleTimeout: FiniteDuration = resendFirstUnconfirmedIdleTimeout
 
     if (producerControllerSettings.chunkLargeMessagesBytes > 0)
@@ -241,7 +241,7 @@ object ShardingProducerController {
     def withResendFirstUnconfirmedIdleTimeout(newResendFirstUnconfirmedIdleTimeout: java.time.Duration): Settings =
       copy(resendFirstUnconfirmedIdleTimeout = newResendFirstUnconfirmedIdleTimeout.asScala)
 
-    @deprecated("use resendFirstUnconfirmedIdleTimeout", "2.6.19")
+    @deprecated("use resendFirstUnconfirmedIdleTimeout", "Akka 2.6.19")
     def withResendFirsUnconfirmedIdleTimeout(newResendFirstUnconfirmedIdleTimeout: FiniteDuration): Settings =
       copy(resendFirstUnconfirmedIdleTimeout = newResendFirstUnconfirmedIdleTimeout)
 

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ClusterShardingSettings.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ClusterShardingSettings.scala
@@ -1139,7 +1139,7 @@ final class ClusterShardingSettings(
     extends NoSerializationVerificationNeeded {
   @deprecated(
     "Use the ClusterShardingSettings factory methods or the constructor including coordinatorSingletonOverrideRole instead",
-    "2.6.20")
+    "Akka 2.6.20")
   def this(
       role: Option[String],
       rememberEntities: Boolean,
@@ -1168,7 +1168,7 @@ final class ClusterShardingSettings(
 
   @deprecated(
     "Use the ClusterShardingSettings factory methods or the constructor including passivationStrategySettings instead",
-    "2.6.18")
+    "Akka 2.6.18")
   def this(
       role: Option[String],
       rememberEntities: Boolean,
@@ -1197,7 +1197,7 @@ final class ClusterShardingSettings(
 
   @deprecated(
     "Use the ClusterShardingSettings factory methods or the constructor including rememberedEntitiesStore instead",
-    "2.6.7")
+    "Akka 2.6.7")
   def this(
       role: Option[String],
       rememberEntities: Boolean,

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ShardCoordinator.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ShardCoordinator.scala
@@ -1305,7 +1305,7 @@ abstract class ShardCoordinator(
  *
  * @see [[ClusterSharding$ ClusterSharding extension]]
  */
-@deprecated("Use `ddata` mode, persistence mode is deprecated.", "2.6.0")
+@deprecated("Use `ddata` mode, persistence mode is deprecated.", "Akka 2.6.0")
 class PersistentShardCoordinator(
     override val typeName: String,
     settings: ClusterShardingSettings,

--- a/cluster-tools/src/main/scala/org/apache/pekko/cluster/pubsub/DistributedPubSubMediator.scala
+++ b/cluster-tools/src/main/scala/org/apache/pekko/cluster/pubsub/DistributedPubSubMediator.scala
@@ -109,7 +109,7 @@ final class DistributedPubSubSettings(
     val sendToDeadLettersWhenNoSubscribers: Boolean)
     extends NoSerializationVerificationNeeded {
 
-  @deprecated("Use the other constructor instead.", "2.5.5")
+  @deprecated("Use the other constructor instead.", "Akka 2.5.5")
   def this(
       role: Option[String],
       routingLogic: RoutingLogic,

--- a/cluster-typed/src/main/scala/org/apache/pekko/cluster/typed/ClusterSingleton.scala
+++ b/cluster-typed/src/main/scala/org/apache/pekko/cluster/typed/ClusterSingleton.scala
@@ -63,7 +63,7 @@ final class ClusterSingletonSettings(
     val leaseSettings: Option[LeaseUsageSettings]) {
 
   // bin compat for 2.6.14
-  @deprecated("Use constructor with leaseSettings", "2.6.15")
+  @deprecated("Use constructor with leaseSettings", "Akka 2.6.15")
   def this(
       role: Option[String],
       dataCenter: Option[DataCenter],
@@ -304,7 +304,7 @@ final class ClusterSingletonManagerSettings(
     val leaseSettings: Option[LeaseUsageSettings]) {
 
   // bin compat for 2.6.14
-  @deprecated("Use constructor with leaseSettings", "2.6.15")
+  @deprecated("Use constructor with leaseSettings", "Akka 2.6.15")
   def this(
       singletonName: String,
       role: Option[String],

--- a/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/ORMap.scala
+++ b/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/ORMap.scala
@@ -298,7 +298,7 @@ final class ORMap[A, B <: ReplicatedData] private[pekko] (
    * passed to the `modify` function.
    */
   @Deprecated
-  @deprecated("use update for the Java API as updated is ambiguous with the Scala API", "2.5.20")
+  @deprecated("use update for the Java API as updated is ambiguous with the Scala API", "Akka 2.5.20")
   def updated(node: Cluster, key: A, initial: B, modify: java.util.function.Function[B, B]): ORMap[A, B] =
     updated(node.selfUniqueAddress, key, initial)(value => modify.apply(value))
 

--- a/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/Replicator.scala
+++ b/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/Replicator.scala
@@ -179,7 +179,7 @@ final class ReplicatorSettings(
     val logDataSizeExceeding: Option[Int]) {
 
   // for backwards compatibility
-  @deprecated("use full constructor", "2.6.11")
+  @deprecated("use full constructor", "Akka 2.6.11")
   def this(
       roles: Set[String],
       gossipInterval: FiniteDuration,
@@ -213,7 +213,7 @@ final class ReplicatorSettings(
       logDataSizeExceeding = Some(10 * 1024))
 
   // for backwards compatibility
-  @deprecated("use full constructor", "2.6.11")
+  @deprecated("use full constructor", "Akka 2.6.11")
   def this(
       roles: Set[String],
       gossipInterval: FiniteDuration,
@@ -245,7 +245,7 @@ final class ReplicatorSettings(
       preferOldest = false)
 
   // for backwards compatibility
-  @deprecated("use full constructor", "2.6.11")
+  @deprecated("use full constructor", "Akka 2.6.11")
   def this(
       role: Option[String],
       gossipInterval: FiniteDuration,
@@ -276,7 +276,7 @@ final class ReplicatorSettings(
       maxDeltaSize)
 
   // For backwards compatibility
-  @deprecated("use full constructor", "2.6.11")
+  @deprecated("use full constructor", "Akka 2.6.11")
   def this(
       role: Option[String],
       gossipInterval: FiniteDuration,
@@ -301,7 +301,7 @@ final class ReplicatorSettings(
       200)
 
   // For backwards compatibility
-  @deprecated("use full constructor", "2.6.11")
+  @deprecated("use full constructor", "Akka 2.6.11")
   def this(
       role: Option[String],
       gossipInterval: FiniteDuration,
@@ -328,7 +328,7 @@ final class ReplicatorSettings(
       200)
 
   // For backwards compatibility
-  @deprecated("use full constructor", "2.6.11")
+  @deprecated("use full constructor", "Akka 2.6.11")
   def this(
       role: Option[String],
       gossipInterval: FiniteDuration,

--- a/docs/src/main/paradox/stream/operators/Flow/lazyInitAsync.md
+++ b/docs/src/main/paradox/stream/operators/Flow/lazyInitAsync.md
@@ -10,7 +10,7 @@ Deprecated by @ref:[`Flow.lazyFutureFlow`](lazyFutureFlow.md) in combination wit
 
 ## Description
 
-`fromCompletionStage` has been deprecated in 2.6.0 use @ref:[lazyFutureFlow](lazyFutureFlow.md) in combination with @ref:[`prefixAndTail`](../Source-or-Flow/prefixAndTail.md)) instead.
+`fromCompletionStage` was deprecated in Akka 2.6.0 use @ref:[lazyFutureFlow](lazyFutureFlow.md) in combination with @ref:[`prefixAndTail`](../Source-or-Flow/prefixAndTail.md)) instead.
 
 Defers creation until a first element arrives.
 

--- a/docs/src/main/paradox/stream/operators/Sink/lazyInitAsync.md
+++ b/docs/src/main/paradox/stream/operators/Sink/lazyInitAsync.md
@@ -12,7 +12,7 @@ Deprecated by @ref:[`Sink.lazyFutureSink`](lazyFutureSink.md).
 
 ## Description
 
-`lazyInitAsync` has been deprecated in 2.6.0, use @ref:[lazyFutureSink](lazyFutureSink.md) instead.
+`lazyInitAsync` was deprecated in Akka 2.6.0, use @ref:[lazyFutureSink](lazyFutureSink.md) instead.
 
 Creates a real `Sink` upon receiving the first element. Internal `Sink` will not be created if there are no elements,
 because of completion or error.

--- a/docs/src/main/paradox/stream/operators/Source/fromCompletionStage.md
+++ b/docs/src/main/paradox/stream/operators/Source/fromCompletionStage.md
@@ -11,7 +11,7 @@ Deprecated by @ref:[`Source.completionStage`](completionStage.md).
 
 ## Description
 
-`fromCompletionStage` has been deprecated in 2.6.0, use @ref:[completionStage](completionStage.md) instead.
+`fromCompletionStage` was deprecated in Akka 2.6.0, use @ref:[completionStage](completionStage.md) instead.
 
 Send the single value of the `CompletionStage` when it completes and there is demand.
 If the `CompletionStage` completes with `null` stage is completed without emitting a value.

--- a/docs/src/main/paradox/stream/operators/Source/fromFuture.md
+++ b/docs/src/main/paradox/stream/operators/Source/fromFuture.md
@@ -11,7 +11,7 @@ Deprecated by @ref[`Source.future`](future.md).
 
 ## Description
 
-`fromFuture` has been deprecated in 2.6.0, use @ref:[future](future.md) instead.
+`fromFuture` was deprecated in Akka 2.6.0, use @ref:[future](future.md) instead.
 
 Send the single value of the `Future` when it completes and there is demand.
 If the future fails the stream is failed with that exception.

--- a/docs/src/main/paradox/stream/operators/Source/fromFutureSource.md
+++ b/docs/src/main/paradox/stream/operators/Source/fromFutureSource.md
@@ -11,7 +11,7 @@ Deprecated by @ref:[`Source.futureSource`](futureSource.md).
 
 ## Description
 
-`fromFutureSource` has been deprecated in 2.6.0, use @ref:[futureSource](futureSource.md) instead.
+`fromFutureSource` was deprecated in Akka 2.6.0, use @ref:[futureSource](futureSource.md) instead.
 
 Streams the elements of the given future source once it successfully completes.
 If the future fails the stream is failed.

--- a/docs/src/main/paradox/stream/operators/Source/fromSourceCompletionStage.md
+++ b/docs/src/main/paradox/stream/operators/Source/fromSourceCompletionStage.md
@@ -8,7 +8,7 @@ Deprecated by @ref:[`Source.completionStageSource`](completionStageSource.md).
 
 ## Description
 
-`fromSourceCompletionStage` has been deprecated in 2.6.0, use @ref:[completionStageSource](completionStageSource.md) instead.
+`fromSourceCompletionStage` was deprecated in Akka 2.6.0, use @ref:[completionStageSource](completionStageSource.md) instead.
 
 Streams the elements of an asynchronous source once its given *completion* operator completes.
 If the *completion* fails the stream is failed with that exception.

--- a/docs/src/main/paradox/stream/operators/Source/lazily.md
+++ b/docs/src/main/paradox/stream/operators/Source/lazily.md
@@ -11,7 +11,7 @@ Deprecated by @ref:[`Source.lazySource`](lazySource.md).
 
 ## Description
 
-`lazily` has been deprecated in 2.6.0, use @ref:[lazySource](lazySource.md) instead.
+`lazily` was deprecated in Akka 2.6.0, use @ref:[lazySource](lazySource.md) instead.
 
 Defers creation and materialization of a `Source` until there is demand.
 

--- a/docs/src/main/paradox/stream/operators/Source/lazilyAsync.md
+++ b/docs/src/main/paradox/stream/operators/Source/lazilyAsync.md
@@ -8,7 +8,7 @@ Deprecated by @ref:[`Source.lazyFutureSource`](lazyFutureSource.md).
 
 ## Description
 
-`lazilyAsync` has been deprecated in 2.6.0, use @ref:[lazyFutureSource](lazyFutureSource.md) instead.
+`lazilyAsync` was deprecated in Akka 2.6.0, use @ref:[lazyFutureSource](lazyFutureSource.md) instead.
 
 Defers creation and materialization of a `CompletionStage` until there is demand.
 

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/EventEnvelope.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/EventEnvelope.scala
@@ -35,7 +35,7 @@ object EventEnvelope extends AbstractFunction4[Offset, String, Long, Any, EventE
       meta: Option[Any]): EventEnvelope =
     new EventEnvelope(offset, persistenceId, sequenceNr, event, timestamp, meta)
 
-  @deprecated("for binary compatibility", "2.6.2")
+  @deprecated("for binary compatibility", "Akka 2.6.2")
   override def apply(offset: Offset, persistenceId: String, sequenceNr: Long, event: Any): EventEnvelope =
     new EventEnvelope(offset, persistenceId, sequenceNr, event)
 
@@ -61,7 +61,7 @@ final class EventEnvelope(
     extends Product4[Offset, String, Long, Any]
     with Serializable {
 
-  @deprecated("for binary compatibility", "2.6.2")
+  @deprecated("for binary compatibility", "Akka 2.6.2")
   def this(offset: Offset, persistenceId: String, sequenceNr: Long, event: Any) =
     this(offset, persistenceId, sequenceNr, event, 0L, None)
 

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/journal/leveldb/LeveldbReadJournalProvider.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/journal/leveldb/LeveldbReadJournalProvider.scala
@@ -18,7 +18,7 @@ import org.apache.pekko
 import pekko.actor.ExtendedActorSystem
 import pekko.persistence.query.ReadJournalProvider
 
-@deprecated("Use another journal/query implementation", "2.6.15")
+@deprecated("Use another journal/query implementation", "Akka 2.6.15")
 class LeveldbReadJournalProvider(system: ExtendedActorSystem, config: Config) extends ReadJournalProvider {
 
   val readJournal: scaladsl.LeveldbReadJournal = new scaladsl.LeveldbReadJournal(system, config)

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/journal/leveldb/javadsl/LeveldbReadJournal.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/journal/leveldb/javadsl/LeveldbReadJournal.scala
@@ -34,7 +34,7 @@ import pekko.stream.javadsl.Source
  * absolute path corresponding to the identifier, which is `"pekko.persistence.query.journal.leveldb"`
  * for the default [[LeveldbReadJournal#Identifier]]. See `reference.conf`.
  */
-@deprecated("Use another journal implementation", "2.6.15")
+@deprecated("Use another journal implementation", "Akka 2.6.15")
 class LeveldbReadJournal(scaladslReadJournal: pekko.persistence.query.journal.leveldb.scaladsl.LeveldbReadJournal)
     extends ReadJournal
     with PersistenceIdsQuery

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/journal/leveldb/scaladsl/LeveldbReadJournal.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/journal/leveldb/scaladsl/LeveldbReadJournal.scala
@@ -49,7 +49,7 @@ import pekko.util.ByteString
  * absolute path corresponding to the identifier, which is `"pekko.persistence.query.journal.leveldb"`
  * for the default [[LeveldbReadJournal#Identifier]]. See `reference.conf`.
  */
-@deprecated("Use another journal implementation", "2.6.15")
+@deprecated("Use another journal implementation", "Akka 2.6.15")
 class LeveldbReadJournal(system: ExtendedActorSystem, config: Config)
     extends ReadJournal
     with PersistenceIdsQuery

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/EventSourcedBehavior.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/EventSourcedBehavior.scala
@@ -138,7 +138,7 @@ abstract class EventSourcedBehavior[Command, Event, State] private[pekko] (
    * You may configure the behavior to skip replaying snapshots completely, in which case the recovery will be
    * performed by replaying all events -- which may take a long time.
    */
-  @deprecated("override recovery instead", "2.6.5")
+  @deprecated("override recovery instead", "Akka 2.6.5")
   def snapshotSelectionCriteria: SnapshotSelectionCriteria = SnapshotSelectionCriteria.latest
 
   /**

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehavior.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehavior.scala
@@ -170,7 +170,7 @@ object EventSourcedBehavior {
    * You may configure the behavior to skip replaying snapshots completely, in which case the recovery will be
    * performed by replaying all events -- which may take a long time.
    */
-  @deprecated("use withRecovery(Recovery.withSnapshotSelectionCriteria(...))", "2.6.5")
+  @deprecated("use withRecovery(Recovery.withSnapshotSelectionCriteria(...))", "Akka 2.6.5")
   def withSnapshotSelectionCriteria(selection: SnapshotSelectionCriteria): EventSourcedBehavior[Command, Event, State]
 
   /**

--- a/persistence/src/main/scala/org/apache/pekko/persistence/fsm/PersistentFSM.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/fsm/PersistentFSM.scala
@@ -75,7 +75,7 @@ private[pekko] class SnapshotAfter(config: Config) extends Extension {
  * Incoming messages are deferred until the state is applied.
  * State Data is constructed based on domain events, according to user's implementation of applyEvent function.
  */
-@deprecated("Use EventSourcedBehavior", "2.6.0")
+@deprecated("Use EventSourcedBehavior", "Akka 2.6.0")
 trait PersistentFSM[S <: FSMState, D, E] extends PersistentActor with PersistentFSMBase[S, D, E] with ActorLogging {
   import org.apache.pekko.persistence.fsm.PersistentFSM._
 
@@ -194,7 +194,7 @@ trait PersistentFSM[S <: FSMState, D, E] extends PersistentActor with Persistent
   }
 }
 
-@deprecated("Use EventSourcedBehavior", "2.6.0")
+@deprecated("Use EventSourcedBehavior", "Akka 2.6.0")
 object PersistentFSM {
 
   /**
@@ -447,7 +447,7 @@ object PersistentFSM {
     @Deprecated
     @deprecated(
       "Internal API easily to be confused with regular FSM's using. Use regular events (`applying`). Internally, `copy` can be used instead.",
-      "2.5.5")
+      "Akka 2.5.5")
     private[pekko] def using(@deprecatedName(Symbol("nextStateDate")) nextStateData: D): State[S, D, E] = {
       copy0(stateData = nextStateData)
     }
@@ -500,7 +500,7 @@ object PersistentFSM {
  *
  * Persistent Finite State Machine actor abstract base class.
  */
-@deprecated("Use EventSourcedBehavior", "2.6.0")
+@deprecated("Use EventSourcedBehavior", "Akka 2.6.0")
 abstract class AbstractPersistentFSM[S <: FSMState, D, E]
     extends AbstractPersistentFSMBase[S, D, E]
     with PersistentFSM[S, D, E] {
@@ -544,7 +544,7 @@ abstract class AbstractPersistentFSM[S <: FSMState, D, E]
  * Persistent Finite State Machine actor abstract base class with FSM Logging
  */
 @nowarn("msg=deprecated")
-@deprecated("Use EventSourcedBehavior", "2.6.0")
+@deprecated("Use EventSourcedBehavior", "Akka 2.6.0")
 abstract class AbstractPersistentLoggingFSM[S <: FSMState, D, E]
     extends AbstractPersistentFSM[S, D, E]
     with LoggingPersistentFSM[S, D, E]

--- a/persistence/src/main/scala/org/apache/pekko/persistence/fsm/PersistentFSMBase.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/fsm/PersistentFSMBase.scala
@@ -105,7 +105,7 @@ import pekko.util.unused
  *   isTimerActive("tock")
  * </pre>
  */
-@deprecated("Use EventSourcedBehavior", "2.6.0")
+@deprecated("Use EventSourcedBehavior", "Akka 2.6.0")
 trait PersistentFSMBase[S, D, E] extends Actor with Listeners with ActorLogging {
 
   import pekko.persistence.fsm.PersistentFSM._
@@ -637,7 +637,7 @@ trait PersistentFSMBase[S, D, E] extends Actor with Listeners with ActorLogging 
  * Stackable trait for [[pekko.actor.FSM]] which adds a rolling event log and
  * debug logging capabilities (analogous to [[pekko.event.LoggingReceive]]).
  */
-@deprecated("Use EventSourcedBehavior", "2.6.0")
+@deprecated("Use EventSourcedBehavior", "Akka 2.6.0")
 trait LoggingPersistentFSM[S, D, E] extends PersistentFSMBase[S, D, E] { this: Actor =>
 
   import pekko.persistence.fsm.PersistentFSM._
@@ -706,7 +706,7 @@ trait LoggingPersistentFSM[S, D, E] extends PersistentFSMBase[S, D, E] { this: A
 /**
  * Java API: compatible with lambda expressions
  */
-@deprecated("Use EventSourcedBehavior", "2.6.0")
+@deprecated("Use EventSourcedBehavior", "Akka 2.6.0")
 object AbstractPersistentFSMBase {
 
   /**
@@ -725,7 +725,7 @@ object AbstractPersistentFSMBase {
  *
  * Finite State Machine actor abstract base class.
  */
-@deprecated("Use EventSourcedBehavior", "2.6.0")
+@deprecated("Use EventSourcedBehavior", "Akka 2.6.0")
 abstract class AbstractPersistentFSMBase[S, D, E] extends PersistentFSMBase[S, D, E] {
   import java.util.{ List => JList }
 

--- a/persistence/src/main/scala/org/apache/pekko/persistence/journal/leveldb/LeveldbJournal.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/journal/leveldb/LeveldbJournal.scala
@@ -34,7 +34,7 @@ import pekko.util.Timeout
  *
  * Journal backed by a local LevelDB store. For production use.
  */
-@deprecated("Use another journal implementation", "2.6.15")
+@deprecated("Use another journal implementation", "Akka 2.6.15")
 private[persistence] class LeveldbJournal(cfg: Config) extends AsyncWriteJournal with LeveldbStore {
   import LeveldbJournal._
 

--- a/persistence/src/main/scala/org/apache/pekko/persistence/journal/leveldb/SharedLeveldbStore.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/journal/leveldb/SharedLeveldbStore.scala
@@ -31,7 +31,8 @@ import pekko.persistence.journal.AsyncWriteTarget
  * set for each actor system that uses the store via `SharedLeveldbJournal.setStore`. The
  * shared LevelDB store is for testing only.
  */
-@deprecated("Use another journal implementation or the in-mem journal in combination with the journal-proxy", "Akka 2.6.15")
+@deprecated("Use another journal implementation or the in-mem journal in combination with the journal-proxy",
+  "Akka 2.6.15")
 class SharedLeveldbStore(cfg: Config) extends LeveldbStore {
   import AsyncWriteTarget._
   import context.dispatcher

--- a/persistence/src/main/scala/org/apache/pekko/persistence/journal/leveldb/SharedLeveldbStore.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/journal/leveldb/SharedLeveldbStore.scala
@@ -31,7 +31,7 @@ import pekko.persistence.journal.AsyncWriteTarget
  * set for each actor system that uses the store via `SharedLeveldbJournal.setStore`. The
  * shared LevelDB store is for testing only.
  */
-@deprecated("Use another journal implementation or the in-mem journal in combination with the journal-proxy", "2.6.15")
+@deprecated("Use another journal implementation or the in-mem journal in combination with the journal-proxy", "Akka 2.6.15")
 class SharedLeveldbStore(cfg: Config) extends LeveldbStore {
   import AsyncWriteTarget._
   import context.dispatcher

--- a/remote/src/main/resources/reference.conf
+++ b/remote/src/main/resources/reference.conf
@@ -127,13 +127,13 @@ pekko {
 
       "org.apache.pekko.remote.serialization.SystemMessageSerializer" = 22
 
-      # deprecated in 2.6.0, moved to pekko-actor
+      # deprecated in Akka 2.6.0, moved to pekko-actor
       "org.apache.pekko.remote.serialization.LongSerializer" = 18
-      # deprecated in 2.6.0, moved to pekko-actor
+      # deprecated in Akka 2.6.0, moved to pekko-actor
       "org.apache.pekko.remote.serialization.IntSerializer" = 19
-      # deprecated in 2.6.0, moved to pekko-actor
+      # deprecated in Akka 2.6.0, moved to pekko-actor
       "org.apache.pekko.remote.serialization.StringSerializer" = 20
-      # deprecated in 2.6.0, moved to pekko-actor
+      # deprecated in Akka 2.6.0, moved to pekko-actor
       "org.apache.pekko.remote.serialization.ByteStringSerializer" = 21
     }
 

--- a/remote/src/main/scala/org/apache/pekko/remote/AckedDelivery.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/AckedDelivery.scala
@@ -18,7 +18,7 @@ import scala.collection.immutable._
 import org.apache.pekko
 import pekko.PekkoException
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 object SeqNo {
 
   implicit val ord: Ordering[SeqNo] = new Ordering[SeqNo] {
@@ -33,7 +33,7 @@ object SeqNo {
 /**
  * Implements a 64 bit sequence number with proper wrap-around ordering.
  */
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 final case class SeqNo(rawValue: Long) extends Ordered[SeqNo] {
 
   /**
@@ -55,7 +55,7 @@ final case class SeqNo(rawValue: Long) extends Ordered[SeqNo] {
   override def toString = String.valueOf(rawValue)
 }
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 object HasSequenceNumber {
   implicit def seqOrdering[T <: HasSequenceNumber]: Ordering[T] = new Ordering[T] {
     def compare(x: T, y: T) = x.seq.compare(y.seq)
@@ -66,7 +66,7 @@ object HasSequenceNumber {
  * Messages that are to be buffered in [[pekko.remote.AckedSendBuffer]] or [[pekko.remote.AckedReceiveBuffer]] has
  * to implement this interface to provide the sequence needed by the buffers.
  */
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 trait HasSequenceNumber {
 
   /**
@@ -81,16 +81,16 @@ trait HasSequenceNumber {
  * @param cumulativeAck Represents the highest sequence number received.
  * @param nacks Set of sequence numbers between the last delivered one and cumulativeAck that has been not yet received.
  */
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 final case class Ack(cumulativeAck: SeqNo, nacks: Set[SeqNo] = Set.empty) {
   override def toString = s"ACK[$cumulativeAck, ${nacks.mkString("{", ", ", "}")}]"
 }
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 class ResendBufferCapacityReachedException(c: Int)
     extends PekkoException(s"Resend buffer capacity of [$c] has been reached.")
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 class ResendUnfulfillableException
     extends PekkoException(
       "Unable to fulfill resend request since negatively acknowledged payload is no longer in buffer. " +
@@ -107,7 +107,7 @@ class ResendUnfulfillableException
  * @param maxSeq The maximum sequence number that has been stored in this buffer. Messages having lower sequence number
  *               will be not stored but rejected with [[java.lang.IllegalArgumentException]]
  */
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 final case class AckedSendBuffer[T <: HasSequenceNumber](
     capacity: Int,
     nonAcked: IndexedSeq[T] = Vector.empty[T],
@@ -163,7 +163,7 @@ final case class AckedSendBuffer[T <: HasSequenceNumber](
  * @param cumulativeAck The highest sequence number received so far.
  * @param buf Buffer of messages that are waiting for delivery
  */
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 final case class AckedReceiveBuffer[T <: HasSequenceNumber](
     lastDelivered: SeqNo = SeqNo(-1),
     cumulativeAck: SeqNo = SeqNo(-1),

--- a/remote/src/main/scala/org/apache/pekko/remote/RemoteSettings.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/RemoteSettings.scala
@@ -39,19 +39,19 @@ final class RemoteSettings(val config: Config) {
 
   val WarnAboutDirectUse: Boolean = getBoolean("pekko.remote.warn-about-direct-use")
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val LogReceive: Boolean = getBoolean("pekko.remote.classic.log-received-messages")
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val LogSend: Boolean = getBoolean("pekko.remote.classic.log-sent-messages")
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val LogFrameSizeExceeding: Option[Int] = {
     if (config.getString("pekko.remote.classic.log-frame-size-exceeding").toLowerCase == "off") None
     else Some(getBytes("pekko.remote.classic.log-frame-size-exceeding").toInt)
   }
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val UntrustedMode: Boolean = getBoolean("pekko.remote.classic.untrusted-mode")
 
   /**
@@ -60,11 +60,11 @@ final class RemoteSettings(val config: Config) {
   @nowarn("msg=deprecated")
   @InternalApi private[pekko] def untrustedMode: Boolean =
     if (Artery.Enabled) Artery.UntrustedMode else UntrustedMode
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val TrustedSelectionPaths: Set[String] =
     immutableSeq(getStringList("pekko.remote.classic.trusted-selection-paths")).toSet
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val RemoteLifecycleEventsLogLevel: LogLevel = toRootLowerCase(
     getString("pekko.remote.classic.log-remote-lifecycle-events")) match {
     case "on" => Logging.DebugLevel
@@ -76,7 +76,7 @@ final class RemoteSettings(val config: Config) {
       }
   }
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val Dispatcher: String = getString("pekko.remote.classic.use-dispatcher")
 
   @nowarn("msg=deprecated")
@@ -87,35 +87,35 @@ final class RemoteSettings(val config: Config) {
       if (Dispatcher.isEmpty) props else props.withDispatcher(Dispatcher)
     }
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val ShutdownTimeout: Timeout = {
     Timeout(config.getMillisDuration("pekko.remote.classic.shutdown-timeout"))
   }.requiring(_.duration > Duration.Zero, "shutdown-timeout must be > 0")
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val FlushWait: FiniteDuration = {
     config.getMillisDuration("pekko.remote.classic.flush-wait-on-shutdown")
   }.requiring(_ > Duration.Zero, "flush-wait-on-shutdown must be > 0")
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val StartupTimeout: Timeout = {
     Timeout(config.getMillisDuration("pekko.remote.classic.startup-timeout"))
   }.requiring(_.duration > Duration.Zero, "startup-timeout must be > 0")
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val RetryGateClosedFor: FiniteDuration = {
     config.getMillisDuration("pekko.remote.classic.retry-gate-closed-for")
   }.requiring(_ >= Duration.Zero, "retry-gate-closed-for must be >= 0")
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val UsePassiveConnections: Boolean = getBoolean("pekko.remote.classic.use-passive-connections")
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val BackoffPeriod: FiniteDuration = {
     config.getMillisDuration("pekko.remote.classic.backoff-interval")
   }.requiring(_ > Duration.Zero, "backoff-interval must be > 0")
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val LogBufferSizeExceeding: Int = {
     val key = "pekko.remote.classic.log-buffer-size-exceeding"
     config.getString(key).toLowerCase match {
@@ -124,32 +124,32 @@ final class RemoteSettings(val config: Config) {
     }
   }
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val SysMsgAckTimeout: FiniteDuration = {
     config.getMillisDuration("pekko.remote.classic.system-message-ack-piggyback-timeout")
   }.requiring(_ > Duration.Zero, "system-message-ack-piggyback-timeout must be > 0")
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val SysResendTimeout: FiniteDuration = {
     config.getMillisDuration("pekko.remote.classic.resend-interval")
   }.requiring(_ > Duration.Zero, "resend-interval must be > 0")
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val SysResendLimit: Int = {
     config.getInt("pekko.remote.classic.resend-limit")
   }.requiring(_ > 0, "resend-limit must be > 0")
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val SysMsgBufferSize: Int = {
     getInt("pekko.remote.classic.system-message-buffer-size")
   }.requiring(_ > 0, "system-message-buffer-size must be > 0")
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val InitialSysMsgDeliveryTimeout: FiniteDuration = {
     config.getMillisDuration("pekko.remote.classic.initial-system-message-delivery-timeout")
   }.requiring(_ > Duration.Zero, "initial-system-message-delivery-timeout must be > 0")
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val QuarantineSilentSystemTimeout: FiniteDuration = {
     val key = "pekko.remote.classic.quarantine-after-silence"
     config.getString(key).toLowerCase match {
@@ -159,14 +159,14 @@ final class RemoteSettings(val config: Config) {
     }
   }
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val QuarantineDuration: FiniteDuration = {
     config
       .getMillisDuration("pekko.remote.classic.prune-quarantine-marker-after")
       .requiring(_ > Duration.Zero, "prune-quarantine-marker-after must be > 0 ms")
   }
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val CommandAckTimeout: Timeout = {
     Timeout(config.getMillisDuration("pekko.remote.classic.command-ack-timeout"))
   }.requiring(_.duration > Duration.Zero, "command-ack-timeout must be > 0")
@@ -196,7 +196,7 @@ final class RemoteSettings(val config: Config) {
       transportConfig)
   }
 
-  @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+  @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val Adapters: Map[String, String] = configToMap(getConfig("pekko.remote.classic.adapters"))
 
   private def transportNames: immutable.Seq[String] =

--- a/remote/src/main/scala/org/apache/pekko/remote/RemotingLifecycleEvent.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/RemotingLifecycleEvent.scala
@@ -24,14 +24,14 @@ import pekko.event.Logging.LogLevel
 
 @nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 sealed trait RemotingLifecycleEvent extends Serializable {
   def logLevel: Logging.LogLevel
 }
 
 @nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 sealed trait AssociationEvent extends RemotingLifecycleEvent {
   def localAddress: Address
   def remoteAddress: Address
@@ -44,7 +44,7 @@ sealed trait AssociationEvent extends RemotingLifecycleEvent {
 }
 
 @SerialVersionUID(1L)
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 final case class AssociatedEvent(localAddress: Address, remoteAddress: Address, inbound: Boolean)
     extends AssociationEvent {
 
@@ -54,7 +54,7 @@ final case class AssociatedEvent(localAddress: Address, remoteAddress: Address, 
 }
 
 @SerialVersionUID(1L)
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 final case class DisassociatedEvent(localAddress: Address, remoteAddress: Address, inbound: Boolean)
     extends AssociationEvent {
   protected override def eventName: String = "Disassociated"
@@ -62,7 +62,7 @@ final case class DisassociatedEvent(localAddress: Address, remoteAddress: Addres
 }
 
 @SerialVersionUID(1L)
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 final case class AssociationErrorEvent(
     cause: Throwable,
     localAddress: Address,
@@ -85,14 +85,14 @@ final case class RemotingListenEvent(listenAddresses: Set[Address]) extends Remo
 }
 
 @SerialVersionUID(1L)
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 case object RemotingShutdownEvent extends RemotingLifecycleEvent {
   override def logLevel: Logging.LogLevel = Logging.InfoLevel
   override val toString: String = "Remoting shut down"
 }
 
 @SerialVersionUID(1L)
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 final case class RemotingErrorEvent(cause: Throwable) extends RemotingLifecycleEvent {
   def getCause: Throwable = cause
   override def logLevel: Logging.LogLevel = Logging.ErrorLevel
@@ -100,7 +100,7 @@ final case class RemotingErrorEvent(cause: Throwable) extends RemotingLifecycleE
 }
 
 // For binary compatibility
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 object QuarantinedEvent extends AbstractFunction2[Address, Int, QuarantinedEvent] {
 
   @deprecated("Use long uid apply", "2.4.x")
@@ -108,7 +108,7 @@ object QuarantinedEvent extends AbstractFunction2[Address, Int, QuarantinedEvent
 }
 
 @SerialVersionUID(1L)
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 final case class QuarantinedEvent(address: Address, longUid: Long) extends RemotingLifecycleEvent {
 
   override def logLevel: Logging.LogLevel = Logging.WarningLevel
@@ -131,7 +131,7 @@ final case class QuarantinedEvent(address: Address, longUid: Long) extends Remot
  * The `uniqueAddress` was quarantined but it was due to normal shutdown or cluster leaving/exiting.
  */
 @SerialVersionUID(1L)
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 final case class GracefulShutdownQuarantinedEvent(uniqueAddress: UniqueAddress, reason: String)
     extends RemotingLifecycleEvent {
   override def logLevel: Logging.LogLevel = Logging.InfoLevel
@@ -141,7 +141,7 @@ final case class GracefulShutdownQuarantinedEvent(uniqueAddress: UniqueAddress, 
 }
 
 @SerialVersionUID(1L)
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 final case class ThisActorSystemQuarantinedEvent(localAddress: Address, remoteAddress: Address)
     extends RemotingLifecycleEvent {
   override def logLevel: LogLevel = Logging.WarningLevel

--- a/remote/src/main/scala/org/apache/pekko/remote/serialization/PrimitiveSerializers.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/serialization/PrimitiveSerializers.scala
@@ -20,7 +20,7 @@ import pekko.actor.ExtendedActorSystem
 import pekko.serialization.BaseSerializer
 import pekko.serialization.ByteBufferSerializer
 
-@deprecated("Moved to org.apache.pekko.serialization.LongSerializer in pekko-actor", "2.6.0")
+@deprecated("Moved to org.apache.pekko.serialization.LongSerializer in pekko-actor", "Akka 2.6.0")
 class LongSerializer(val system: ExtendedActorSystem) extends BaseSerializer with ByteBufferSerializer {
   // this serializer is not used unless someone is instantiating it manually, it's not in config
   private val delegate = new pekko.serialization.LongSerializer(system)
@@ -33,7 +33,7 @@ class LongSerializer(val system: ExtendedActorSystem) extends BaseSerializer wit
   override def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = delegate.fromBinary(bytes, manifest)
 }
 
-@deprecated("Moved to org.apache.pekko.serialization.IntSerializer in pekko-actor", "2.6.0")
+@deprecated("Moved to org.apache.pekko.serialization.IntSerializer in pekko-actor", "Akka 2.6.0")
 class IntSerializer(val system: ExtendedActorSystem) extends BaseSerializer with ByteBufferSerializer {
   // this serializer is not used unless someone is instantiating it manually, it's not in config
   private val delegate = new pekko.serialization.IntSerializer(system)
@@ -46,7 +46,7 @@ class IntSerializer(val system: ExtendedActorSystem) extends BaseSerializer with
   override def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = delegate.fromBinary(bytes, manifest)
 }
 
-@deprecated("Moved to org.apache.pekko.serialization.StringSerializer in pekko-actor", "2.6.0")
+@deprecated("Moved to org.apache.pekko.serialization.StringSerializer in pekko-actor", "Akka 2.6.0")
 class StringSerializer(val system: ExtendedActorSystem) extends BaseSerializer with ByteBufferSerializer {
   // this serializer is not used unless someone is instantiating it manually, it's not in config
   private val delegate = new pekko.serialization.StringSerializer(system)
@@ -59,7 +59,7 @@ class StringSerializer(val system: ExtendedActorSystem) extends BaseSerializer w
   override def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = delegate.fromBinary(bytes, manifest)
 }
 
-@deprecated("Moved to org.apache.pekko.serialization.ByteStringSerializer in pekko-actor", "2.6.0")
+@deprecated("Moved to org.apache.pekko.serialization.ByteStringSerializer in pekko-actor", "Akka 2.6.0")
 class ByteStringSerializer(val system: ExtendedActorSystem) extends BaseSerializer with ByteBufferSerializer {
   // this serializer is not used unless someone is instantiating it manually, it's not in config
   private val delegate = new org.apache.pekko.serialization.ByteStringSerializer(system)

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/AbstractTransportAdapter.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/AbstractTransportAdapter.scala
@@ -28,7 +28,7 @@ import pekko.remote.transport.AssociationHandle.DisassociateInfo
 import pekko.remote.transport.Transport._
 import pekko.util.Timeout
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 trait TransportAdapterProvider {
 
   /**
@@ -37,7 +37,7 @@ trait TransportAdapterProvider {
   def create(wrappedTransport: Transport, system: ExtendedActorSystem): Transport
 }
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 class TransportAdapters(system: ExtendedActorSystem) extends Extension {
   val settings = RARP(system).provider.remoteSettings
 
@@ -57,7 +57,7 @@ class TransportAdapters(system: ExtendedActorSystem) extends Extension {
   }
 }
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 object TransportAdaptersExtension extends ExtensionId[TransportAdapters] with ExtensionIdProvider {
   override def get(system: ActorSystem): TransportAdapters = super.get(system)
   override def get(system: ClassicActorSystemProvider): TransportAdapters = super.get(system)
@@ -66,7 +66,7 @@ object TransportAdaptersExtension extends ExtensionId[TransportAdapters] with Ex
     new TransportAdapters(system)
 }
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 trait SchemeAugmenter {
   protected def addedSchemeIdentifier: String
 
@@ -85,7 +85,7 @@ trait SchemeAugmenter {
 /**
  * An adapter that wraps a transport and provides interception
  */
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 abstract class AbstractTransportAdapter(protected val wrappedTransport: Transport)(implicit val ec: ExecutionContext)
     extends Transport
     with SchemeAugmenter {
@@ -141,7 +141,7 @@ abstract class AbstractTransportAdapter(protected val wrappedTransport: Transpor
 
 }
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 abstract class AbstractTransportAdapterHandle(
     val originalLocalAddress: Address,
     val originalRemoteAddress: Address,
@@ -158,7 +158,7 @@ abstract class AbstractTransportAdapterHandle(
 
 }
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 object ActorTransportAdapter {
   sealed trait TransportOperation extends NoSerializationVerificationNeeded
 
@@ -174,7 +174,7 @@ object ActorTransportAdapter {
   implicit val AskTimeout: Timeout = Timeout(5.seconds)
 }
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 abstract class ActorTransportAdapter(wrappedTransport: Transport, system: ActorSystem)
     extends AbstractTransportAdapter(wrappedTransport)(system.dispatchers.internalDispatcher) {
 
@@ -211,7 +211,7 @@ abstract class ActorTransportAdapter(wrappedTransport: Transport, system: ActorS
     } yield stopResult && wrappedStopResult
 }
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 abstract class ActorTransportAdapterManager extends Actor with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
   import ActorTransportAdapter.{ ListenUnderlying, ListenerRegistered }
 

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/FailureInjectorTransportAdapter.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/FailureInjectorTransportAdapter.scala
@@ -31,10 +31,10 @@ import pekko.remote.transport.Transport._
 import pekko.util.ByteString
 
 @SerialVersionUID(1L)
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 final case class FailureInjectorException(msg: String) extends PekkoException(msg) with NoStackTrace
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 class FailureInjectorProvider extends TransportAdapterProvider {
 
   override def create(wrappedTransport: Transport, system: ExtendedActorSystem): Transport =
@@ -50,7 +50,7 @@ private[remote] object FailureInjectorTransportAdapter {
 
   trait FailureInjectorCommand
   @SerialVersionUID(1L)
-  @deprecated("Not implemented", "2.5.22")
+  @deprecated("Not implemented", "Akka 2.5.22")
   final case class All(mode: GremlinMode)
   @SerialVersionUID(1L)
   final case class One(remoteAddress: Address, mode: GremlinMode)

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/TestTransport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/TestTransport.scala
@@ -35,7 +35,7 @@ import pekko.util.ByteString
  * requested to do. This class is not optimized for performance and MUST not be used as an in-memory transport in
  * production systems.
  */
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 class TestTransport(
     val localAddress: Address,
     final val registry: TestTransport.AssociationRegistry,
@@ -186,7 +186,7 @@ class TestTransport(
 
 }
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 object TestTransport {
 
   type Behavior[A, B] = (A) => Future[B]
@@ -457,7 +457,7 @@ object TestTransport {
  up via a string key. Until we find a better way to inject an AssociationRegistry to multiple actor systems it is
  strongly recommended to use long, randomly generated strings to key the registry to avoid interference between tests.
  */
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 object AssociationRegistry {
   import TestTransport._
   private final val registries = scala.collection.mutable.Map[String, AssociationRegistry]()
@@ -469,7 +469,7 @@ object AssociationRegistry {
   def clear(): Unit = this.synchronized { registries.clear() }
 }
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 final case class TestAssociationHandle(
     localAddress: Address,
     remoteAddress: Address,

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/ThrottlerTransportAdapter.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/ThrottlerTransportAdapter.scala
@@ -47,7 +47,7 @@ import pekko.remote.transport.ThrottlerTransportAdapter._
 import pekko.remote.transport.Transport._
 import pekko.util.{ ByteString, Timeout }
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 class ThrottlerProvider extends TransportAdapterProvider {
 
   override def create(wrappedTransport: Transport, system: ExtendedActorSystem): Transport =
@@ -218,7 +218,7 @@ object ThrottlerTransportAdapter {
   def unthrottledThrottleMode(): ThrottleMode = Unthrottled
 }
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 class ThrottlerTransportAdapter(_wrappedTransport: Transport, _system: ExtendedActorSystem)
     extends ActorTransportAdapter(_wrappedTransport, _system) {
 

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/Transport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/Transport.scala
@@ -26,7 +26,7 @@ import pekko.event.LoggingAdapter
 import pekko.remote.transport.AssociationHandle.HandleEventListener
 import pekko.util.{ unused, ByteString }
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 object Transport {
 
   trait AssociationEvent extends NoSerializationVerificationNeeded
@@ -79,7 +79,7 @@ object Transport {
  * Transport implementations that are loaded dynamically by the remoting must have a constructor that accepts a
  * [[com.typesafe.config.Config]] and an [[pekko.actor.ExtendedActorSystem]] as parameters.
  */
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 trait Transport {
   import org.apache.pekko.remote.transport.Transport._
 
@@ -163,7 +163,7 @@ trait Transport {
 
 }
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 object AssociationHandle {
 
   /**
@@ -230,7 +230,7 @@ object AssociationHandle {
  * returned by [[pekko.remote.transport.AssociationHandle#readHandlerPromise]]. Incoming data is not processed until
  * this registration takes place.
  */
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 trait AssociationHandle {
 
   /**

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/netty/NettyTransport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/netty/NettyTransport.scala
@@ -68,7 +68,7 @@ import pekko.util.Helpers
 import pekko.util.Helpers.Requiring
 import pekko.util.OptionVal
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 object NettyFutureBridge {
   def apply(nettyFuture: ChannelFuture): Future[Channel] = {
     val p = Promise[Channel]()
@@ -105,7 +105,7 @@ object NettyFutureBridge {
 }
 
 @SerialVersionUID(1L)
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 class NettyTransportException(msg: String, cause: Throwable)
     extends RuntimeException(msg, cause)
     with OnlyCauseStackTrace {
@@ -113,14 +113,14 @@ class NettyTransportException(msg: String, cause: Throwable)
 }
 
 @SerialVersionUID(1L)
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 class NettyTransportExceptionNoStack(msg: String, cause: Throwable)
     extends NettyTransportException(msg, cause)
     with NoStackTrace {
   def this(msg: String) = this(msg, null)
 }
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 class NettyTransportSettings(config: Config) {
 
   import config._
@@ -347,7 +347,7 @@ private[transport] object NettyTransport {
     addressFromSocketAddress(addr, schemeIdentifier, systemName, hostName, port = None)
 }
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 class NettyTransport(val settings: NettyTransportSettings, val system: ExtendedActorSystem) extends Transport {
 
   def this(system: ExtendedActorSystem, conf: Config) = this(new NettyTransportSettings(conf), system)

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/netty/SSLEngineProvider.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/netty/SSLEngineProvider.scala
@@ -37,7 +37,7 @@ import pekko.remote.RemoteTransportException
 import pekko.remote.artery.tcp.SecureRandomFactory
 import pekko.stream.TLSRole
 
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 trait SSLEngineProvider {
 
   def createServerSSLEngine(): SSLEngine
@@ -51,7 +51,7 @@ trait SSLEngineProvider {
  *
  * Subclass may override protected methods to replace certain parts, such as key and trust manager.
  */
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 class ConfigSSLEngineProvider(protected val log: MarkerLoggingAdapter, private val settings: SSLSettings)
     extends SSLEngineProvider {
 

--- a/remote/src/test/scala/org/apache/pekko/remote/serialization/PrimitivesSerializationSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/serialization/PrimitivesSerializationSpec.scala
@@ -34,7 +34,7 @@ object PrimitivesSerializationSpec {
   val testConfig = ConfigFactory.parseString(serializationTestOverrides).withFallback(PekkoSpec.testConf)
 }
 
-@deprecated("Moved to org.apache.pekko.serialization.* in pekko-actor", "2.6.0")
+@deprecated("Moved to org.apache.pekko.serialization.* in pekko-actor", "Akka 2.6.0")
 class PrimitivesSerializationSpec extends PekkoSpec(PrimitivesSerializationSpec.testConfig) {
 
   val buffer = {

--- a/stream-typed/src/main/scala/org/apache/pekko/stream/typed/javadsl/ActorSource.scala
+++ b/stream-typed/src/main/scala/org/apache/pekko/stream/typed/javadsl/ActorSource.scala
@@ -136,7 +136,7 @@ object ActorSource {
    * @deprecated Use actorRefWithBackpressure instead
    */
   @Deprecated
-  @deprecated("Use actorRefWithBackpressure instead", "2.6.0")
+  @deprecated("Use actorRefWithBackpressure instead", "Akka 2.6.0")
   def actorRefWithAck[T, Ack](
       ackTo: ActorRef[Ack],
       ackMessage: Ack,

--- a/stream-typed/src/main/scala/org/apache/pekko/stream/typed/scaladsl/ActorSource.scala
+++ b/stream-typed/src/main/scala/org/apache/pekko/stream/typed/scaladsl/ActorSource.scala
@@ -120,7 +120,7 @@ object ActorSource {
    * The actor will be stopped when the stream is completed, failed or canceled from downstream,
    * i.e. you can watch it to get notified when that happens.
    */
-  @deprecated("Use actorRefWithBackpressure instead", "2.6.0")
+  @deprecated("Use actorRefWithBackpressure instead", "Akka 2.6.0")
   def actorRefWithAck[T, Ack](
       ackTo: ActorRef[Ack],
       ackMessage: Ack,

--- a/stream/src/main/scala/com/typesafe/sslconfig/pekko/SSLEngineConfigurator.scala
+++ b/stream/src/main/scala/com/typesafe/sslconfig/pekko/SSLEngineConfigurator.scala
@@ -21,12 +21,14 @@ import com.typesafe.sslconfig.ssl.SSLConfigSettings
  * Gives the chance to configure the SSLContext before it is going to be used.
  * The passed in context will be already set in client mode and provided with hostInfo during initialization.
  */
-@deprecated("Use Tcp and TLS with SSLEngine parameters instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
+@deprecated("Use Tcp and TLS with SSLEngine parameters instead. Setup the SSLEngine with needed parameters.",
+  "Akka 2.6.0")
 trait SSLEngineConfigurator {
   def configure(engine: SSLEngine, sslContext: SSLContext): SSLEngine
 }
 
-@deprecated("Use Tcp and TLS with SSLEngine parameters instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
+@deprecated("Use Tcp and TLS with SSLEngine parameters instead. Setup the SSLEngine with needed parameters.",
+  "Akka 2.6.0")
 final class DefaultSSLEngineConfigurator(
     config: SSLConfigSettings,
     enabledProtocols: Array[String],

--- a/stream/src/main/scala/com/typesafe/sslconfig/pekko/SSLEngineConfigurator.scala
+++ b/stream/src/main/scala/com/typesafe/sslconfig/pekko/SSLEngineConfigurator.scala
@@ -21,12 +21,12 @@ import com.typesafe.sslconfig.ssl.SSLConfigSettings
  * Gives the chance to configure the SSLContext before it is going to be used.
  * The passed in context will be already set in client mode and provided with hostInfo during initialization.
  */
-@deprecated("Use Tcp and TLS with SSLEngine parameters instead. Setup the SSLEngine with needed parameters.", "2.6.0")
+@deprecated("Use Tcp and TLS with SSLEngine parameters instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
 trait SSLEngineConfigurator {
   def configure(engine: SSLEngine, sslContext: SSLContext): SSLEngine
 }
 
-@deprecated("Use Tcp and TLS with SSLEngine parameters instead. Setup the SSLEngine with needed parameters.", "2.6.0")
+@deprecated("Use Tcp and TLS with SSLEngine parameters instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
 final class DefaultSSLEngineConfigurator(
     config: SSLConfigSettings,
     enabledProtocols: Array[String],

--- a/stream/src/main/scala/org/apache/pekko/stream/ActorMaterializer.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/ActorMaterializer.scala
@@ -896,7 +896,8 @@ final class StreamSubscriptionTimeoutSettings(
       "Use attribute 'ActorAttributes.StreamSubscriptionTimeoutMode' to read the concrete setting value",
       "Akka 2.6.0")
     val mode: StreamSubscriptionTimeoutTerminationMode,
-    @deprecated("Use attribute 'ActorAttributes.StreamSubscriptionTimeout' to read the concrete setting value", "Akka 2.6.0")
+    @deprecated("Use attribute 'ActorAttributes.StreamSubscriptionTimeout' to read the concrete setting value",
+      "Akka 2.6.0")
     val timeout: FiniteDuration) {
   override def equals(other: Any): Boolean = other match {
     case s: StreamSubscriptionTimeoutSettings => s.mode == mode && s.timeout == timeout

--- a/stream/src/main/scala/org/apache/pekko/stream/ActorMaterializer.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/ActorMaterializer.scala
@@ -53,7 +53,7 @@ object ActorMaterializer {
    */
   @deprecated(
     "Use the system wide materializer with stream attributes or configuration settings to change defaults",
-    "2.6.0")
+    "Akka 2.6.0")
   def apply(materializerSettings: Option[ActorMaterializerSettings] = None, namePrefix: Option[String] = None)(
       implicit context: ActorRefFactory): ActorMaterializer = {
     val system = actorSystemOf(context)
@@ -76,7 +76,7 @@ object ActorMaterializer {
    */
   @deprecated(
     "Use the system wide materializer with stream attributes or configuration settings to change defaults",
-    "2.6.0")
+    "Akka 2.6.0")
   def apply(materializerSettings: ActorMaterializerSettings, namePrefix: String)(
       implicit context: ActorRefFactory): ActorMaterializer = {
 
@@ -110,7 +110,7 @@ object ActorMaterializer {
    */
   @deprecated(
     "Use the system wide materializer or Materializer.apply(actorContext) with stream attributes or configuration settings to change defaults",
-    "2.6.0")
+    "Akka 2.6.0")
   def apply(materializerSettings: ActorMaterializerSettings)(implicit context: ActorRefFactory): ActorMaterializer =
     apply(Some(materializerSettings), None)
 
@@ -127,7 +127,7 @@ object ActorMaterializer {
    */
   @deprecated(
     "Use the system wide materializer or Materializer.create(actorContext) with stream attributes or configuration settings to change defaults",
-    "2.6.0")
+    "Akka 2.6.0")
   def create(context: ActorRefFactory): ActorMaterializer =
     apply()(context)
 
@@ -145,7 +145,7 @@ object ActorMaterializer {
    */
   @deprecated(
     "Use the system wide materializer or Materializer.create(actorContext) with stream attributes or configuration settings to change defaults",
-    "2.6.0")
+    "Akka 2.6.0")
   def create(context: ActorRefFactory, namePrefix: String): ActorMaterializer = {
     val system = actorSystemOf(context)
     val settings = ActorMaterializerSettings(system)
@@ -161,7 +161,7 @@ object ActorMaterializer {
    */
   @deprecated(
     "Use the system wide materializer or Materializer.create(actorContext) with stream attributes or configuration settings to change defaults",
-    "2.6.0")
+    "Akka 2.6.0")
   def create(settings: ActorMaterializerSettings, context: ActorRefFactory): ActorMaterializer =
     apply(Option(settings), None)(context)
 
@@ -179,7 +179,7 @@ object ActorMaterializer {
    */
   @deprecated(
     "Use the system wide materializer or Materializer.create(actorContext) with stream attributes or configuration settings to change defaults",
-    "2.6.0")
+    "Akka 2.6.0")
   def create(settings: ActorMaterializerSettings, context: ActorRefFactory, namePrefix: String): ActorMaterializer =
     apply(Option(settings), Option(namePrefix))(context)
 
@@ -205,7 +205,7 @@ private[pekko] object ActorMaterializerHelper {
   /**
    * INTERNAL API
    */
-  @deprecated("The Materializer now has all methods the ActorMaterializer used to have", "2.6.0")
+  @deprecated("The Materializer now has all methods the ActorMaterializer used to have", "Akka 2.6.0")
   private[pekko] def downcast(materializer: Materializer): ActorMaterializer =
     materializer match {
       case m: ActorMaterializer => m
@@ -219,12 +219,12 @@ private[pekko] object ActorMaterializerHelper {
 /**
  * An ActorMaterializer takes a stream blueprint and turns it into a running stream.
  */
-@deprecated("The Materializer now has all methods the ActorMaterializer used to have", "2.6.0")
+@deprecated("The Materializer now has all methods the ActorMaterializer used to have", "Akka 2.6.0")
 abstract class ActorMaterializer extends Materializer with MaterializerLoggingProvider {
 
   @deprecated(
     "Use attributes to access settings from stages, see https://doc.akka.io/docs/akka/2.6/project/migration-guide-2.5.x-2.6.x.html",
-    "2.6.0")
+    "Akka 2.6.0")
   def settings: ActorMaterializerSettings
 
   /**
@@ -296,7 +296,7 @@ object ActorMaterializerSettings {
    */
   @deprecated(
     "Use config or attributes to configure the materializer. See migration guide for details https://doc.akka.io/docs/akka/2.6/project/migration-guide-2.5.x-2.6.x.html",
-    "2.6.0")
+    "Akka 2.6.0")
   def apply(
       initialInputBufferSize: Int,
       maxInputBufferSize: Int,
@@ -335,7 +335,7 @@ object ActorMaterializerSettings {
    */
   @deprecated(
     "Use config or attributes to configure the materializer. See migration guide for details https://doc.akka.io/docs/akka/2.6/project/migration-guide-2.5.x-2.6.x.html",
-    "2.6.0")
+    "Akka 2.6.0")
   def apply(system: ActorSystem): ActorMaterializerSettings =
     apply(system.settings.config.getConfig("pekko.stream.materializer"))
 
@@ -347,7 +347,7 @@ object ActorMaterializerSettings {
    */
   @deprecated(
     "Use config or attributes to configure the materializer. See migration guide for details https://doc.akka.io/docs/akka/2.6/project/migration-guide-2.5.x-2.6.x.html",
-    "2.6.0")
+    "Akka 2.6.0")
   def apply(config: Config): ActorMaterializerSettings =
     new ActorMaterializerSettings(
       initialInputBufferSize = config.getInt("initial-input-buffer-size"),
@@ -373,7 +373,7 @@ object ActorMaterializerSettings {
    */
   @deprecated(
     "Use config or attributes to configure the materializer. See migration guide for details https://doc.akka.io/docs/akka/2.6/project/migration-guide-2.5.x-2.6.x.html",
-    "2.6.0")
+    "Akka 2.6.0")
   def create(
       initialInputBufferSize: Int,
       maxInputBufferSize: Int,
@@ -409,7 +409,7 @@ object ActorMaterializerSettings {
    */
   @deprecated(
     "Use config or attributes to configure the materializer. See migration guide for details https://doc.akka.io/docs/akka/2.6/project/migration-guide-2.5.x-2.6.x.html",
-    "2.6.0")
+    "Akka 2.6.0")
   def create(system: ActorSystem): ActorMaterializerSettings =
     apply(system)
 
@@ -421,7 +421,7 @@ object ActorMaterializerSettings {
    */
   @deprecated(
     "Use config or attributes to configure the materializer. See migration guide for details https://doc.akka.io/docs/akka/2.6/project/migration-guide-2.5.x-2.6.x.html",
-    "2.6.0")
+    "Akka 2.6.0")
   def create(config: Config): ActorMaterializerSettings =
     apply(config)
 
@@ -441,30 +441,30 @@ final class ActorMaterializerSettings @InternalApi private (
      * since these settings allow for overriding using [[Attributes]]. They must always be gotten from the effective
      * attributes.
      */
-    @deprecated("Use attribute 'Attributes.InputBuffer' to read the concrete setting value", "2.6.0")
+    @deprecated("Use attribute 'Attributes.InputBuffer' to read the concrete setting value", "Akka 2.6.0")
     val initialInputBufferSize: Int,
-    @deprecated("Use attribute 'Attributes.InputBuffer' to read the concrete setting value", "2.6.0")
+    @deprecated("Use attribute 'Attributes.InputBuffer' to read the concrete setting value", "Akka 2.6.0")
     val maxInputBufferSize: Int,
-    @deprecated("Use attribute 'ActorAttributes.Dispatcher' to read the concrete setting value", "2.6.0")
+    @deprecated("Use attribute 'ActorAttributes.Dispatcher' to read the concrete setting value", "Akka 2.6.0")
     val dispatcher: String,
-    @deprecated("Use attribute 'ActorAttributes.SupervisionStrategy' to read the concrete setting value", "2.6.0")
+    @deprecated("Use attribute 'ActorAttributes.SupervisionStrategy' to read the concrete setting value", "Akka 2.6.0")
     val supervisionDecider: Supervision.Decider,
     val subscriptionTimeoutSettings: StreamSubscriptionTimeoutSettings,
-    @deprecated("Use attribute 'ActorAttributes.DebugLogging' to read the concrete setting value", "2.6.0")
+    @deprecated("Use attribute 'ActorAttributes.DebugLogging' to read the concrete setting value", "Akka 2.6.0")
     val debugLogging: Boolean,
-    @deprecated("Use attribute 'ActorAttributes.OutputBurstLimit' to read the concrete setting value", "2.6.0")
+    @deprecated("Use attribute 'ActorAttributes.OutputBurstLimit' to read the concrete setting value", "Akka 2.6.0")
     val outputBurstLimit: Int,
-    @deprecated("Use attribute 'ActorAttributes.FuzzingMode' to read the concrete setting value", "2.6.0")
+    @deprecated("Use attribute 'ActorAttributes.FuzzingMode' to read the concrete setting value", "Akka 2.6.0")
     val fuzzingMode: Boolean,
-    @deprecated("No longer has any effect", "2.6.0")
+    @deprecated("No longer has any effect", "Akka 2.6.0")
     val autoFusing: Boolean,
-    @deprecated("Use attribute 'ActorAttributes.MaxFixedBufferSize' to read the concrete setting value", "2.6.0")
+    @deprecated("Use attribute 'ActorAttributes.MaxFixedBufferSize' to read the concrete setting value", "Akka 2.6.0")
     val maxFixedBufferSize: Int,
-    @deprecated("Use attribute 'ActorAttributes.SyncProcessingLimit' to read the concrete setting value", "2.6.0")
+    @deprecated("Use attribute 'ActorAttributes.SyncProcessingLimit' to read the concrete setting value", "Akka 2.6.0")
     val syncProcessingLimit: Int,
     val ioSettings: IOSettings,
     val streamRefSettings: StreamRefSettings,
-    @deprecated("Use attribute 'ActorAttributes.BlockingIoDispatcher' to read the concrete setting value", "2.6.0")
+    @deprecated("Use attribute 'ActorAttributes.BlockingIoDispatcher' to read the concrete setting value", "Akka 2.6.0")
     val blockingIoDispatcher: String) {
 
   require(initialInputBufferSize > 0, "initialInputBufferSize must be > 0")
@@ -476,7 +476,7 @@ final class ActorMaterializerSettings @InternalApi private (
     s"initialInputBufferSize($initialInputBufferSize) must be <= maxInputBufferSize($maxInputBufferSize)")
 
   // backwards compatibility when added IOSettings, shouldn't be needed since private, but added to satisfy mima
-  @deprecated("Use ActorMaterializerSettings.apply or ActorMaterializerSettings.create instead", "2.5.10")
+  @deprecated("Use ActorMaterializerSettings.apply or ActorMaterializerSettings.create instead", "Akka 2.5.10")
   def this(
       initialInputBufferSize: Int,
       maxInputBufferSize: Int,
@@ -508,7 +508,7 @@ final class ActorMaterializerSettings @InternalApi private (
       ConfigFactory.defaultReference().getString(ActorAttributes.IODispatcher.dispatcher))
 
   // backwards compatibility when added IOSettings, shouldn't be needed since private, but added to satisfy mima
-  @deprecated("Use ActorMaterializerSettings.apply or ActorMaterializerSettings.create instead", "2.5.10")
+  @deprecated("Use ActorMaterializerSettings.apply or ActorMaterializerSettings.create instead", "Akka 2.5.10")
   def this(
       initialInputBufferSize: Int,
       maxInputBufferSize: Int,
@@ -539,7 +539,7 @@ final class ActorMaterializerSettings @InternalApi private (
       ConfigFactory.defaultReference().getString(ActorAttributes.IODispatcher.dispatcher))
 
   // backwards compatibility when added IOSettings, shouldn't be needed since private, but added to satisfy mima
-  @deprecated("Use ActorMaterializerSettings.apply or ActorMaterializerSettings.create instead", "2.5.10")
+  @deprecated("Use ActorMaterializerSettings.apply or ActorMaterializerSettings.create instead", "Akka 2.5.10")
   def this(
       initialInputBufferSize: Int,
       maxInputBufferSize: Int,
@@ -610,7 +610,7 @@ final class ActorMaterializerSettings @InternalApi private (
    * FIXME: this is used for all kinds of buffers, not only the stream actor, some use initial some use max,
    *        document and or fix if it should not be like that. Search for get[Attributes.InputBuffer] to see how it is used
    */
-  @deprecated("Use attribute 'Attributes.InputBuffer' to change setting value", "2.6.0")
+  @deprecated("Use attribute 'Attributes.InputBuffer' to change setting value", "Akka 2.6.0")
   def withInputBuffer(initialSize: Int, maxSize: Int): ActorMaterializerSettings = {
     if (initialSize == this.initialInputBufferSize && maxSize == this.maxInputBufferSize) this
     else copy(initialInputBufferSize = initialSize, maxInputBufferSize = maxSize)
@@ -621,7 +621,7 @@ final class ActorMaterializerSettings @InternalApi private (
    * with the [[ActorMaterializer]]. This can be overridden for individual parts of the
    * stream topology by using [[pekko.stream.Attributes#dispatcher]].
    */
-  @deprecated("Use attribute 'ActorAttributes.Dispatcher' to change setting value", "2.6.0")
+  @deprecated("Use attribute 'ActorAttributes.Dispatcher' to change setting value", "Akka 2.6.0")
   def withDispatcher(dispatcher: String): ActorMaterializerSettings = {
     if (this.dispatcher == dispatcher) this
     else copy(dispatcher = dispatcher)
@@ -635,7 +635,7 @@ final class ActorMaterializerSettings @InternalApi private (
    * Note that supervision in streams are implemented on a per operator basis and is not supported
    * by every operator.
    */
-  @deprecated("Use attribute 'ActorAttributes.supervisionStrategy' to change setting value", "2.6.0")
+  @deprecated("Use attribute 'ActorAttributes.supervisionStrategy' to change setting value", "Akka 2.6.0")
   def withSupervisionStrategy(decider: Supervision.Decider): ActorMaterializerSettings = {
     if (decider eq this.supervisionDecider) this
     else copy(supervisionDecider = decider)
@@ -649,7 +649,7 @@ final class ActorMaterializerSettings @InternalApi private (
    * Note that supervision in streams are implemented on a per operator basis and is not supported
    * by every operator.
    */
-  @deprecated("Use attribute 'ActorAttributes.SupervisionStrategy' to change setting value", "2.6.0")
+  @deprecated("Use attribute 'ActorAttributes.SupervisionStrategy' to change setting value", "Akka 2.6.0")
   def withSupervisionStrategy(
       decider: function.Function[Throwable, Supervision.Directive]): ActorMaterializerSettings = {
     import Supervision._
@@ -665,7 +665,7 @@ final class ActorMaterializerSettings @InternalApi private (
    * Test utility: fuzzing mode means that GraphStage events are not processed
    * in FIFO order within a fused subgraph, but randomized.
    */
-  @deprecated("Use attribute 'ActorAttributes.FuzzingMode' to change setting value", "2.6.0")
+  @deprecated("Use attribute 'ActorAttributes.FuzzingMode' to change setting value", "Akka 2.6.0")
   def withFuzzing(enable: Boolean): ActorMaterializerSettings =
     if (enable == this.fuzzingMode) this
     else copy(fuzzingMode = enable)
@@ -673,7 +673,7 @@ final class ActorMaterializerSettings @InternalApi private (
   /**
    * Maximum number of elements emitted in batch if downstream signals large demand.
    */
-  @deprecated("Use attribute 'ActorAttributes.OutputBurstLimit' to change setting value", "2.6.0")
+  @deprecated("Use attribute 'ActorAttributes.OutputBurstLimit' to change setting value", "Akka 2.6.0")
   def withOutputBurstLimit(limit: Int): ActorMaterializerSettings =
     if (limit == this.outputBurstLimit) this
     else copy(outputBurstLimit = limit)
@@ -681,7 +681,7 @@ final class ActorMaterializerSettings @InternalApi private (
   /**
    * Limit for number of messages that can be processed synchronously in stream to substream communication
    */
-  @deprecated("Use attribute 'ActorAttributes.SyncProcessingLimit' to change setting value", "2.6.0")
+  @deprecated("Use attribute 'ActorAttributes.SyncProcessingLimit' to change setting value", "Akka 2.6.0")
   def withSyncProcessingLimit(limit: Int): ActorMaterializerSettings =
     if (limit == this.syncProcessingLimit) this
     else copy(syncProcessingLimit = limit)
@@ -689,7 +689,7 @@ final class ActorMaterializerSettings @InternalApi private (
   /**
    * Enable to log all elements that are dropped due to failures (at DEBUG level).
    */
-  @deprecated("Use attribute 'ActorAttributes.DebugLogging' to change setting value", "2.6.0")
+  @deprecated("Use attribute 'ActorAttributes.DebugLogging' to change setting value", "Akka 2.6.0")
   def withDebugLogging(enable: Boolean): ActorMaterializerSettings =
     if (enable == this.debugLogging) this
     else copy(debugLogging = enable)
@@ -699,7 +699,7 @@ final class ActorMaterializerSettings @InternalApi private (
    * This defaults to a large value because it is usually better to fail early when
    * system memory is not sufficient to hold the buffer.
    */
-  @deprecated("Use attribute 'ActorAttributes.MaxFixedBufferSize' to change setting value", "2.6.0")
+  @deprecated("Use attribute 'ActorAttributes.MaxFixedBufferSize' to change setting value", "Akka 2.6.0")
   def withMaxFixedBufferSize(size: Int): ActorMaterializerSettings =
     if (size == this.maxFixedBufferSize) this
     else copy(maxFixedBufferSize = size)
@@ -721,7 +721,7 @@ final class ActorMaterializerSettings @InternalApi private (
     if (streamRefSettings == this.streamRefSettings) this
     else copy(streamRefSettings = streamRefSettings)
 
-  @deprecated("Use attribute 'ActorAttributes.BlockingIoDispatcher' to change setting value", "2.6.0")
+  @deprecated("Use attribute 'ActorAttributes.BlockingIoDispatcher' to change setting value", "Akka 2.6.0")
   def withBlockingIoDispatcher(newBlockingIoDispatcher: String): ActorMaterializerSettings =
     if (newBlockingIoDispatcher == blockingIoDispatcher) this
     else copy(blockingIoDispatcher = newBlockingIoDispatcher)
@@ -780,13 +780,13 @@ final class ActorMaterializerSettings @InternalApi private (
 object IOSettings {
   @deprecated(
     "Use setting 'pekko.stream.materializer.io.tcp.write-buffer-size' or attribute TcpAttributes.writeBufferSize instead",
-    "2.6.0")
+    "Akka 2.6.0")
   def apply(system: ActorSystem): IOSettings =
     apply(system.settings.config.getConfig("pekko.stream.materializer.io"))
 
   @deprecated(
     "Use setting 'pekko.stream.materializer.io.tcp.write-buffer-size' or attribute TcpAttributes.writeBufferSize instead",
-    "2.6.0")
+    "Akka 2.6.0")
   def apply(config: Config): IOSettings =
     new IOSettings(
       tcpWriteBufferSize = math.min(Int.MaxValue, config.getBytes("tcp.write-buffer-size")).toInt,
@@ -794,38 +794,38 @@ object IOSettings {
 
   @deprecated(
     "Use setting 'pekko.stream.materializer.io.tcp.write-buffer-size' or attribute TcpAttributes.writeBufferSize instead",
-    "2.6.0")
+    "Akka 2.6.0")
   def apply(tcpWriteBufferSize: Int): IOSettings =
     new IOSettings(tcpWriteBufferSize)
 
   /** Java API */
   @deprecated(
     "Use setting 'pekko.stream.materializer.io.tcp.write-buffer-size' or attribute TcpAttributes.writeBufferSize instead",
-    "2.6.0")
+    "Akka 2.6.0")
   def create(config: Config) = apply(config)
 
   /** Java API */
   @deprecated(
     "Use setting 'pekko.stream.materializer.io.tcp.write-buffer-size' or attribute TcpAttributes.writeBufferSize instead",
-    "2.6.0")
+    "Akka 2.6.0")
   def create(system: ActorSystem) = apply(system)
 
   /** Java API */
   @deprecated(
     "Use setting 'pekko.stream.materializer.io.tcp.write-buffer-size' or attribute TcpAttributes.writeBufferSize instead",
-    "2.6.0")
+    "Akka 2.6.0")
   def create(tcpWriteBufferSize: Int): IOSettings =
     apply(tcpWriteBufferSize)
 }
 
 @nowarn("msg=deprecated")
 final class IOSettings private (
-    @deprecated("Use attribute 'TcpAttributes.TcpWriteBufferSize' to read the concrete setting value", "2.6.0")
+    @deprecated("Use attribute 'TcpAttributes.TcpWriteBufferSize' to read the concrete setting value", "Akka 2.6.0")
     val tcpWriteBufferSize: Int,
     val coalesceWrites: Int) {
 
   // constructor for binary compatibility with version 2.6.15 and earlier
-  @deprecated("Use attribute 'TcpAttributes.TcpWriteBufferSize' to read the concrete setting value", "2.6.0")
+  @deprecated("Use attribute 'TcpAttributes.TcpWriteBufferSize' to read the concrete setting value", "Akka 2.6.0")
   def this(tcpWriteBufferSize: Int) = this(tcpWriteBufferSize, coalesceWrites = 10)
 
   def withTcpWriteBufferSize(value: Int): IOSettings = copy(tcpWriteBufferSize = value)
@@ -894,9 +894,9 @@ object StreamSubscriptionTimeoutSettings {
 final class StreamSubscriptionTimeoutSettings(
     @deprecated(
       "Use attribute 'ActorAttributes.StreamSubscriptionTimeoutMode' to read the concrete setting value",
-      "2.6.0")
+      "Akka 2.6.0")
     val mode: StreamSubscriptionTimeoutTerminationMode,
-    @deprecated("Use attribute 'ActorAttributes.StreamSubscriptionTimeout' to read the concrete setting value", "2.6.0")
+    @deprecated("Use attribute 'ActorAttributes.StreamSubscriptionTimeout' to read the concrete setting value", "Akka 2.6.0")
     val timeout: FiniteDuration) {
   override def equals(other: Any): Boolean = other match {
     case s: StreamSubscriptionTimeoutSettings => s.mode == mode && s.timeout == timeout

--- a/stream/src/main/scala/org/apache/pekko/stream/Attributes.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/Attributes.scala
@@ -266,14 +266,14 @@ final case class Attributes(attributeList: List[Attributes.Attribute] = Nil) {
    * Java API: Get the least specific attribute (added first) of a given `Class` or subclass thereof.
    * If no such attribute exists the `default` value is returned.
    */
-  @deprecated("Attributes should always be most specific, use getAttribute[T]", "2.5.7")
+  @deprecated("Attributes should always be most specific, use getAttribute[T]", "Akka 2.5.7")
   def getFirstAttribute[T <: Attribute](c: Class[T], default: T): T =
     getFirstAttribute(c).orElse(default)
 
   /**
    * Java API: Get the least specific attribute (added first) of a given `Class` or subclass thereof.
    */
-  @deprecated("Attributes should always be most specific, use get[T]", "2.5.7")
+  @deprecated("Attributes should always be most specific, use get[T]", "Akka 2.5.7")
   def getFirstAttribute[T <: Attribute](c: Class[T]): Optional[T] =
     attributeList.reverseIterator.collectFirst { case attr if c.isInstance(attr) => c.cast(attr) }.asJava
 
@@ -281,7 +281,7 @@ final case class Attributes(attributeList: List[Attributes.Attribute] = Nil) {
    * Scala API: Get the least specific attribute (added first) of a given type parameter T `Class` or subclass thereof.
    * If no such attribute exists the `default` value is returned.
    */
-  @deprecated("Attributes should always be most specific, use get[T]", "2.5.7")
+  @deprecated("Attributes should always be most specific, use get[T]", "Akka 2.5.7")
   def getFirst[T <: Attribute: ClassTag](default: T): T = {
     getFirst[T] match {
       case Some(a) => a
@@ -292,7 +292,7 @@ final case class Attributes(attributeList: List[Attributes.Attribute] = Nil) {
   /**
    * Scala API: Get the least specific attribute (added first) of a given type parameter T `Class` or subclass thereof.
    */
-  @deprecated("Attributes should always be most specific, use get[T]", "2.5.7")
+  @deprecated("Attributes should always be most specific, use get[T]", "Akka 2.5.7")
   def getFirst[T <: Attribute: ClassTag]: Option[T] = {
     val c = classTag[T].runtimeClass.asInstanceOf[Class[T]]
     attributeList.reverseIterator.collectFirst { case attr if c.isInstance(attr) => c.cast(attr) }

--- a/stream/src/main/scala/org/apache/pekko/stream/FanInShape1N.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/FanInShape1N.scala
@@ -19,7 +19,7 @@ import scala.collection.immutable
 @Deprecated
 @deprecated(
   "FanInShape1N was removed because it was not used anywhere. Use a custom shape extending from FanInShape directly.",
-  "2.5.5")
+  "Akka 2.5.5")
 class FanInShape1N[-T0, -T1, +O](val n: Int, _init: FanInShape.Init[O]) extends FanInShape[O](_init) {
 
   // ports get added to `FanInShape.inlets` as a side-effect of calling `newInlet`
@@ -37,7 +37,7 @@ class FanInShape1N[-T0, -T1, +O](val n: Int, _init: FanInShape.Init[O]) extends 
     new FanInShape1N(n, init)
   override def deepCopy(): FanInShape1N[T0, T1, O] = super.deepCopy().asInstanceOf[FanInShape1N[T0, T1, O]]
 
-  @deprecated("Use 'inlets' or 'in(id)' instead.", "2.5.5")
+  @deprecated("Use 'inlets' or 'in(id)' instead.", "Akka 2.5.5")
   def in1Seq: immutable.IndexedSeq[Inlet[T1 @uncheckedVariance]] = _in1Seq
 
   // cannot deprecate a lazy val because of genjavadoc problem https://github.com/typesafehub/genjavadoc/issues/85

--- a/stream/src/main/scala/org/apache/pekko/stream/IOResult.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/IOResult.scala
@@ -30,11 +30,11 @@ import pekko.Done
 @nowarn("msg=deprecated") // Status
 final case class IOResult(
     count: Long,
-    @deprecated("status is always set to Success(Done)", "2.6.0") status: Try[Done]) {
+    @deprecated("status is always set to Success(Done)", "Akka 2.6.0") status: Try[Done]) {
 
   def withCount(value: Long): IOResult = copy(count = value)
 
-  @deprecated("status is always set to Success(Done)", "2.6.0")
+  @deprecated("status is always set to Success(Done)", "Akka 2.6.0")
   def withStatus(value: Try[Done]): IOResult = copy(status = value)
 
   /**
@@ -45,14 +45,14 @@ final case class IOResult(
   /**
    * Java API: Indicates whether IO operation completed successfully or not.
    */
-  @deprecated("status is always set to Success(Done)", "2.6.0")
+  @deprecated("status is always set to Success(Done)", "Akka 2.6.0")
   def wasSuccessful: Boolean = status.isSuccess
 
   /**
    * Java API: If the IO operation resulted in an error, returns the corresponding [[Throwable]]
    * or throws [[UnsupportedOperationException]] otherwise.
    */
-  @deprecated("status is always set to Success(Done)", "2.6.0")
+  @deprecated("status is always set to Success(Done)", "Akka 2.6.0")
   def getError: Throwable = status match {
     case Failure(t) => t
     case Success(_) => throw new UnsupportedOperationException("IO operation was successful.")
@@ -69,7 +69,7 @@ object IOResult {
     new IOResult(count, Success(Done))
 
   /** JAVA API: Creates failed IOResult, `count` should be the number of bytes (or other unit, please document in your APIs) processed before failing */
-  @deprecated("use IOOperationIncompleteException", "2.6.0")
+  @deprecated("use IOOperationIncompleteException", "Akka 2.6.0")
   def createFailed(count: Long, ex: Throwable): IOResult =
     new IOResult(count, Failure(ex))
 }
@@ -78,7 +78,7 @@ object IOResult {
  * This exception signals that a stream has been completed by an onError signal
  * while there was still IO operations in progress.
  */
-@deprecated("use IOOperationIncompleteException", "2.6.0")
+@deprecated("use IOOperationIncompleteException", "Akka 2.6.0")
 final case class AbruptIOTerminationException(ioResult: IOResult, cause: Throwable)
     extends RuntimeException("Stream terminated without completing IO operation.", cause)
     with NoStackTrace

--- a/stream/src/main/scala/org/apache/pekko/stream/Materializer.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/Materializer.scala
@@ -36,7 +36,7 @@ import pekko.event.LoggingAdapter
  * Not for user extension
  */
 @implicitNotFound("A Materializer is required.  You may want to have the ActorSystem in implicit scope")
-@nowarn("msg=deprecated") // Name(symbol) is deprecated but older Scala versions don't have a string signature, since "2.5.8"
+@nowarn("msg=deprecated") // Name(symbol) is deprecated but older Scala versions don't have a string signature, since "Akka 2.5.8"
 @DoNotInherit
 abstract class Materializer {
 
@@ -196,7 +196,7 @@ abstract class Materializer {
   @InternalApi
   private[pekko] def actorOf(context: MaterializationContext, props: Props): ActorRef
 
-  @deprecated("Use attributes to access settings from stages", "2.6.0")
+  @deprecated("Use attributes to access settings from stages", "Akka 2.6.0")
   def settings: ActorMaterializerSettings
 }
 

--- a/stream/src/main/scala/org/apache/pekko/stream/OverflowStrategy.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/OverflowStrategy.scala
@@ -127,7 +127,7 @@ object OverflowStrategy {
    *
    * @deprecated Use {@link pekko.stream.javadsl.Source#queue(int,org.apache.pekko.stream.OverflowStrategy)} instead
    */
-  @deprecated("Use Source.queue instead", "2.6.11")
+  @deprecated("Use Source.queue instead", "Akka 2.6.11")
   @Deprecated
   def dropNew: OverflowStrategy = DropNew(Logging.DebugLevel)
 

--- a/stream/src/main/scala/org/apache/pekko/stream/StreamRefSettings.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/StreamRefSettings.scala
@@ -68,17 +68,17 @@ object StreamRefSettings {
 @DoNotInherit
 @nowarn("msg=deprecated")
 trait StreamRefSettings {
-  @deprecated("Use attribute 'StreamRefAttributes.BufferCapacity' to read the concrete setting value", "2.6.0")
+  @deprecated("Use attribute 'StreamRefAttributes.BufferCapacity' to read the concrete setting value", "Akka 2.6.0")
   def bufferCapacity: Int
   @deprecated(
     "Use attribute 'StreamRefAttributes.DemandRedeliveryInterval' to read the concrete setting value",
-    "2.6.0")
+    "Akka 2.6.0")
   def demandRedeliveryInterval: FiniteDuration
-  @deprecated("Use attribute 'StreamRefAttributes.SubscriptionTimeout' to read the concrete setting value", "2.6.0")
+  @deprecated("Use attribute 'StreamRefAttributes.SubscriptionTimeout' to read the concrete setting value", "Akka 2.6.0")
   def subscriptionTimeout: FiniteDuration
   @deprecated(
     "Use attribute 'StreamRefAttributes.FinalTerminationSignalDeadline' to read the concrete setting value",
-    "2.6.0")
+    "Akka 2.6.0")
   def finalTerminationSignalDeadline: FiniteDuration
 
   // --- with... methods ---

--- a/stream/src/main/scala/org/apache/pekko/stream/StreamRefSettings.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/StreamRefSettings.scala
@@ -74,7 +74,8 @@ trait StreamRefSettings {
     "Use attribute 'StreamRefAttributes.DemandRedeliveryInterval' to read the concrete setting value",
     "Akka 2.6.0")
   def demandRedeliveryInterval: FiniteDuration
-  @deprecated("Use attribute 'StreamRefAttributes.SubscriptionTimeout' to read the concrete setting value", "Akka 2.6.0")
+  @deprecated("Use attribute 'StreamRefAttributes.SubscriptionTimeout' to read the concrete setting value",
+    "Akka 2.6.0")
   def subscriptionTimeout: FiniteDuration
   @deprecated(
     "Use attribute 'StreamRefAttributes.FinalTerminationSignalDeadline' to read the concrete setting value",

--- a/stream/src/main/scala/org/apache/pekko/stream/UniformFanInShape.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/UniformFanInShape.scala
@@ -42,7 +42,7 @@ class UniformFanInShape[-T, +O](val n: Int, _init: FanInShape.Init[O]) extends F
   final override def inlets: immutable.Seq[Inlet[T @uncheckedVariance]] =
     super.inlets.asInstanceOf[immutable.Seq[Inlet[T]]]
 
-  @deprecated("Use 'inlets' or 'in(id)' instead.", "2.5.5")
+  @deprecated("Use 'inlets' or 'in(id)' instead.", "Akka 2.5.5")
   def inSeq: immutable.IndexedSeq[Inlet[T @uncheckedVariance]] = _inSeq
 
   // cannot deprecate a lazy val because of genjavadoc problem https://github.com/typesafehub/genjavadoc/issues/85

--- a/stream/src/main/scala/org/apache/pekko/stream/UniformFanOutShape.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/UniformFanOutShape.scala
@@ -37,7 +37,7 @@ class UniformFanOutShape[-I, +O](n: Int, _init: FanOutShape.Init[I @uncheckedVar
     super.outlets.asInstanceOf[immutable.Seq[Outlet[O]]]
 
   @Deprecated
-  @deprecated("use 'outlets' or 'out(id)' instead", "2.5.5")
+  @deprecated("use 'outlets' or 'out(id)' instead", "Akka 2.5.5")
   def outArray: Array[Outlet[O @uncheckedVariance]] = _outArray
 
   // cannot deprecate a lazy val because of genjavadoc problem https://github.com/typesafehub/genjavadoc/issues/85

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/ConstantFun.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/ConstantFun.scala
@@ -21,7 +21,7 @@ import pekko.japi.function.{ Function => JFun, Function2 => JFun2 }
 /**
  * INTERNAL API
  */
-@deprecated("Use org.apache.pekko.util.ConstantFun instead", "2.5.0")
+@deprecated("Use org.apache.pekko.util.ConstantFun instead", "Akka 2.5.0")
 @InternalApi private[pekko] object ConstantFun {
   private[this] val JavaIdentityFunction = new JFun[Any, Any] {
     @throws(classOf[Exception]) override def apply(param: Any): Any = param

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/io/ByteStringParser.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/io/ByteStringParser.scala
@@ -187,7 +187,7 @@ import pekko.util.ByteString
       throw new IllegalStateException("no initial parser installed: you must use startWith(...)")
   }
 
-  @deprecated("Deprecated for internal usage. Will not be emitted any more.", "2.6.20")
+  @deprecated("Deprecated for internal usage. Will not be emitted any more.", "Akka 2.6.20")
   class ParsingException(msg: String, cause: Throwable) extends RuntimeException(msg, cause)
 
   val NeedMoreData = new Exception with NoStackTrace

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/CoupledTerminationFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/CoupledTerminationFlow.scala
@@ -67,7 +67,7 @@ object CoupledTerminationFlow {
    *
    * The order in which the `in` and `out` sides receive their respective completion signals is not defined, do not rely on its ordering.
    */
-  @deprecated("Use `Flow.fromSinkAndSourceCoupledMat(..., ..., Keep.both())` instead", "2.5.2")
+  @deprecated("Use `Flow.fromSinkAndSourceCoupledMat(..., ..., Keep.both())` instead", "Akka 2.5.2")
   def fromSinkAndSource[I, O, M1, M2](in: Sink[I, M1], out: Source[O, M2]): Flow[I, O, (M1, M2)] =
     pekko.stream.scaladsl.Flow.fromSinkAndSourceCoupledMat(in, out)(pekko.stream.scaladsl.Keep.both).asJava
 }

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -95,7 +95,7 @@ object Flow {
    * exposes [[ActorMaterializer]] which is going to be used during materialization and
    * [[Attributes]] of the [[Flow]] returned by this method.
    */
-  @deprecated("Use 'fromMaterializer' instead", "2.6.0")
+  @deprecated("Use 'fromMaterializer' instead", "Akka 2.6.0")
   def setup[I, O, M](
       factory: BiFunction[ActorMaterializer, Attributes, Flow[I, O, M]]): Flow[I, O, CompletionStage[M]] =
     scaladsl.Flow.setup((mat, attr) => factory(mat, attr).asScala).mapMaterializedValue(_.toJava).asJava
@@ -269,7 +269,7 @@ object Flow {
    */
   @deprecated(
     "Use 'Flow.completionStageFlow' in combination with prefixAndTail(1) instead, see `completionStageFlow` operator docs for details",
-    "2.6.0")
+    "Akka 2.6.0")
   def lazyInit[I, O, M](
       flowFactory: function.Function[I, CompletionStage[Flow[I, O, M]]],
       fallback: function.Creator[M]): Flow[I, O, M] = {
@@ -296,7 +296,7 @@ object Flow {
    *
    * '''Cancels when''' downstream cancels
    */
-  @deprecated("Use 'Flow.lazyCompletionStageFlow' instead", "2.6.0")
+  @deprecated("Use 'Flow.lazyCompletionStageFlow' instead", "Akka 2.6.0")
   def lazyInitAsync[I, O, M](
       flowFactory: function.Creator[CompletionStage[Flow[I, O, M]]]): Flow[I, O, CompletionStage[Optional[M]]] = {
     import scala.compat.java8.FutureConverters._
@@ -1757,7 +1757,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * @deprecated use `recoverWithRetries` instead
    */
   @Deprecated
-  @deprecated("Use recoverWithRetries instead.", "2.6.6")
+  @deprecated("Use recoverWithRetries instead.", "Akka 2.6.6")
   def recoverWith(
       clazz: Class[_ <: Throwable],
       supplier: Supplier[Graph[SourceShape[Out], NotUsed]]): javadsl.Flow[In, Out, Mat] =
@@ -3817,7 +3817,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * @see [[#throttle]]
    */
   @Deprecated
-  @deprecated("Use throttle without `maximumBurst` parameter instead.", "2.5.12")
+  @deprecated("Use throttle without `maximumBurst` parameter instead.", "Akka 2.5.12")
   def throttleEven(elements: Int, per: java.time.Duration, mode: ThrottleMode): javadsl.Flow[In, Out, Mat] =
     throttleEven(elements, per.asScala, mode)
 
@@ -3832,7 +3832,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * @see [[#throttle]]
    */
   @Deprecated
-  @deprecated("Use throttle without `maximumBurst` parameter instead.", "2.5.12")
+  @deprecated("Use throttle without `maximumBurst` parameter instead.", "Akka 2.5.12")
   def throttleEven(
       cost: Int,
       per: FiniteDuration,
@@ -3851,7 +3851,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * @see [[#throttle]]
    */
   @Deprecated
-  @deprecated("Use throttle without `maximumBurst` parameter instead.", "2.5.12")
+  @deprecated("Use throttle without `maximumBurst` parameter instead.", "Akka 2.5.12")
   def throttleEven(
       cost: Int,
       per: java.time.Duration,
@@ -3890,7 +3890,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
    */
   @Deprecated
-  @deprecated("Use monitor() or monitorMat(combine) instead", "2.5.17")
+  @deprecated("Use monitor() or monitorMat(combine) instead", "Akka 2.5.17")
   def monitor[M]()(combine: function.Function2[Mat, FlowMonitor[Out], M]): javadsl.Flow[In, Out, M] =
     new Flow(delegate.monitorMat(combinerToScala(combine)))
 

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Sink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Sink.scala
@@ -328,7 +328,7 @@ object Sink {
    * @deprecated Use actorRefWithBackpressure instead
    */
   @Deprecated
-  @deprecated("Use actorRefWithBackpressure instead", "2.6.0")
+  @deprecated("Use actorRefWithBackpressure instead", "Akka 2.6.0")
   def actorRefWithAck[In](
       ref: ActorRef,
       onInitMessage: Any,
@@ -362,7 +362,7 @@ object Sink {
    * exposes [[ActorMaterializer]] which is going to be used during materialization and
    * [[Attributes]] of the [[Sink]] returned by this method.
    */
-  @deprecated("Use 'fromMaterializer' instead", "2.6.0")
+  @deprecated("Use 'fromMaterializer' instead", "Akka 2.6.0")
   def setup[T, M](factory: BiFunction[ActorMaterializer, Attributes, Sink[T, M]]): Sink[T, CompletionStage[M]] =
     scaladsl.Sink.setup((mat, attr) => factory(mat, attr).asScala).mapMaterializedValue(_.toJava).asJava
 
@@ -428,7 +428,7 @@ object Sink {
    * sink fails then the `Future` is completed with the exception.
    * Otherwise the `Future` is completed with the materialized value of the internal sink.
    */
-  @deprecated("Use 'Sink.lazyCompletionStageSink' in combination with 'Flow.prefixAndTail(1)' instead", "2.6.0")
+  @deprecated("Use 'Sink.lazyCompletionStageSink' in combination with 'Flow.prefixAndTail(1)' instead", "Akka 2.6.0")
   def lazyInit[T, M](
       sinkFactory: function.Function[T, CompletionStage[Sink[T, M]]],
       fallback: function.Creator[M]): Sink[T, CompletionStage[M]] =
@@ -448,7 +448,7 @@ object Sink {
    * sink fails then the `Future` is completed with the exception.
    * Otherwise the `Future` is completed with the materialized value of the internal sink.
    */
-  @deprecated("Use 'Sink.lazyCompletionStageSink' instead", "2.6.0")
+  @deprecated("Use 'Sink.lazyCompletionStageSink' instead", "Akka 2.6.0")
   def lazyInitAsync[T, M](
       sinkFactory: function.Creator[CompletionStage[Sink[T, M]]]): Sink[T, CompletionStage[Optional[M]]] = {
     val sSink = scaladsl.Sink

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -193,7 +193,7 @@ object Source {
    * may happen before or after materializing the `Flow`.
    * The stream terminates with a failure if the `Future` is completed with a failure.
    */
-  @deprecated("Use 'Source.future' instead", "2.6.0")
+  @deprecated("Use 'Source.future' instead", "Akka 2.6.0")
   def fromFuture[O](future: Future[O]): javadsl.Source[O, NotUsed] =
     new Source(scaladsl.Source.future(future))
 
@@ -203,7 +203,7 @@ object Source {
    * may happen before or after materializing the `Flow`.
    * The stream terminates with a failure if the `CompletionStage` is completed with a failure.
    */
-  @deprecated("Use 'Source.completionStage' instead", "2.6.0")
+  @deprecated("Use 'Source.completionStage' instead", "Akka 2.6.0")
   def fromCompletionStage[O](future: CompletionStage[O]): javadsl.Source[O, NotUsed] =
     new Source(scaladsl.Source.completionStage(future))
 
@@ -212,7 +212,7 @@ object Source {
    * If the [[Future]] fails the stream is failed with the exception from the future. If downstream cancels before the
    * stream completes the materialized [[Future]] will be failed with a [[StreamDetachedException]].
    */
-  @deprecated("Use 'Source.futureSource' (potentially together with `Source.fromGraph`) instead", "2.6.0")
+  @deprecated("Use 'Source.futureSource' (potentially together with `Source.fromGraph`) instead", "Akka 2.6.0")
   def fromFutureSource[T, M](future: Future[_ <: Graph[SourceShape[T], M]]): javadsl.Source[T, Future[M]] =
     new Source(scaladsl.Source.fromFutureSource(future))
 
@@ -222,7 +222,7 @@ object Source {
    * If downstream cancels before the stream completes the materialized [[CompletionStage]] will be failed
    * with a [[StreamDetachedException]]
    */
-  @deprecated("Use 'Source.completionStageSource' (potentially together with `Source.fromGraph`) instead", "2.6.0")
+  @deprecated("Use 'Source.completionStageSource' (potentially together with `Source.fromGraph`) instead", "Akka 2.6.0")
   def fromSourceCompletionStage[T, M](
       completion: CompletionStage[_ <: Graph[SourceShape[T], M]]): javadsl.Source[T, CompletionStage[M]] =
     completionStageSource(completion.thenApply(fromGraph[T, M]))
@@ -287,7 +287,7 @@ object Source {
    * the materialized future is completed with its value, if downstream cancels or fails without any demand the
    * `create` factory is never called and the materialized `CompletionStage` is failed.
    */
-  @deprecated("Use 'Source.lazySource' instead", "2.6.0")
+  @deprecated("Use 'Source.lazySource' instead", "Akka 2.6.0")
   def lazily[T, M](create: function.Creator[Source[T, M]]): Source[T, CompletionStage[M]] =
     scaladsl.Source.lazily[T, M](() => create.create().asScala).mapMaterializedValue(_.toJava).asJava
 
@@ -298,7 +298,7 @@ object Source {
    *
    * @see [[Source.lazily]]
    */
-  @deprecated("Use 'Source.lazyCompletionStage' instead", "2.6.0")
+  @deprecated("Use 'Source.lazyCompletionStage' instead", "Akka 2.6.0")
   def lazilyAsync[T](create: function.Creator[CompletionStage[T]]): Source[T, Future[NotUsed]] =
     scaladsl.Source.lazilyAsync[T](() => create.create().toScala).asJava
 
@@ -521,7 +521,7 @@ object Source {
    * @param overflowStrategy Strategy that is used when incoming elements cannot fit inside the buffer
    */
   @Deprecated
-  @deprecated("Use variant accepting completion and failure matchers", "2.6.0")
+  @deprecated("Use variant accepting completion and failure matchers", "Akka 2.6.0")
   def actorRef[T](bufferSize: Int, overflowStrategy: OverflowStrategy): Source[T, ActorRef] =
     new Source(scaladsl.Source.actorRef({
         case pekko.actor.Status.Success(s: CompletionStrategy) => s
@@ -580,7 +580,7 @@ object Source {
    * @deprecated Use actorRefWithBackpressure instead
    */
   @Deprecated
-  @deprecated("Use actorRefWithBackpressure instead", "2.6.0")
+  @deprecated("Use actorRefWithBackpressure instead", "Akka 2.6.0")
   def actorRefWithAck[T](
       ackMessage: Any,
       completionMatcher: pekko.japi.function.Function[Any, java.util.Optional[CompletionStrategy]],
@@ -621,7 +621,7 @@ object Source {
    * i.e. you can watch it to get notified when that happens.
    */
   @Deprecated
-  @deprecated("Use actorRefWithBackpressure accepting completion and failure matchers", "2.6.0")
+  @deprecated("Use actorRefWithBackpressure accepting completion and failure matchers", "Akka 2.6.0")
   def actorRefWithAck[T](ackMessage: Any): Source[T, ActorRef] =
     new Source(scaladsl.Source.actorRefWithBackpressure(ackMessage,
       {
@@ -655,7 +655,7 @@ object Source {
    * exposes [[ActorMaterializer]] which is going to be used during materialization and
    * [[Attributes]] of the [[Source]] returned by this method.
    */
-  @deprecated("Use 'fromMaterializer' instead", "2.6.0")
+  @deprecated("Use 'fromMaterializer' instead", "Akka 2.6.0")
   def setup[T, M](factory: BiFunction[ActorMaterializer, Attributes, Source[T, M]]): Source[T, CompletionStage[M]] =
     scaladsl.Source.setup((mat, attr) => factory(mat, attr).asScala).mapMaterializedValue(_.toJava).asJava
 
@@ -2276,7 +2276,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * @deprecated use `recoverWithRetries` instead
    */
   @Deprecated
-  @deprecated("Use recoverWithRetries instead.", "2.6.6")
+  @deprecated("Use recoverWithRetries instead.", "Akka 2.6.6")
   @nowarn("msg=deprecated")
   def recoverWith(pf: PartialFunction[Throwable, _ <: Graph[SourceShape[Out], NotUsed]]): Source[Out, Mat] =
     new Source(delegate.recoverWith(pf))
@@ -2303,7 +2303,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * @deprecated use `recoverWithRetries` instead
    */
   @Deprecated
-  @deprecated("Use recoverWithRetries instead.", "2.6.6")
+  @deprecated("Use recoverWithRetries instead.", "Akka 2.6.6")
   @nowarn("msg=deprecated")
   def recoverWith(
       clazz: Class[_ <: Throwable],
@@ -4357,7 +4357,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * @see [[#throttle]]
    */
   @Deprecated
-  @deprecated("Use throttle without `maximumBurst` parameter instead.", "2.5.12")
+  @deprecated("Use throttle without `maximumBurst` parameter instead.", "Akka 2.5.12")
   def throttleEven(elements: Int, per: FiniteDuration, mode: ThrottleMode): javadsl.Source[Out, Mat] =
     new Source(delegate.throttleEven(elements, per, mode))
 
@@ -4372,7 +4372,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * @see [[#throttle]]
    */
   @Deprecated
-  @deprecated("Use throttle without `maximumBurst` parameter instead.", "2.5.12")
+  @deprecated("Use throttle without `maximumBurst` parameter instead.", "Akka 2.5.12")
   def throttleEven(elements: Int, per: java.time.Duration, mode: ThrottleMode): javadsl.Source[Out, Mat] =
     throttleEven(elements, per.asScala, mode)
 
@@ -4387,7 +4387,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * @see [[#throttle]]
    */
   @Deprecated
-  @deprecated("Use throttle without `maximumBurst` parameter instead.", "2.5.12")
+  @deprecated("Use throttle without `maximumBurst` parameter instead.", "Akka 2.5.12")
   def throttleEven(
       cost: Int,
       per: FiniteDuration,
@@ -4406,7 +4406,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * @see [[#throttle]]
    */
   @Deprecated
-  @deprecated("Use throttle without `maximumBurst` parameter instead.", "2.5.12")
+  @deprecated("Use throttle without `maximumBurst` parameter instead.", "Akka 2.5.12")
   def throttleEven(
       cost: Int,
       per: java.time.Duration,
@@ -4444,7 +4444,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
    */
   @Deprecated
-  @deprecated("Use monitor() or monitorMat(combine) instead", "2.5.17")
+  @deprecated("Use monitor() or monitorMat(combine) instead", "Akka 2.5.17")
   def monitor[M]()(combine: function.Function2[Mat, FlowMonitor[Out], M]): javadsl.Source[Out, M] =
     new Source(delegate.monitorMat(combinerToScala(combine)))
 

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -2444,7 +2444,7 @@ class SubFlow[In, Out, Mat](
    * @see [[#throttle]]
    */
   @Deprecated
-  @deprecated("Use throttle without `maximumBurst` parameter instead.", "2.5.12")
+  @deprecated("Use throttle without `maximumBurst` parameter instead.", "Akka 2.5.12")
   def throttleEven(elements: Int, per: FiniteDuration, mode: ThrottleMode): javadsl.SubFlow[In, Out, Mat] =
     new SubFlow(delegate.throttleEven(elements, per, mode))
 
@@ -2459,7 +2459,7 @@ class SubFlow[In, Out, Mat](
    * @see [[#throttle]]
    */
   @Deprecated
-  @deprecated("Use throttle without `maximumBurst` parameter instead.", "2.5.12")
+  @deprecated("Use throttle without `maximumBurst` parameter instead.", "Akka 2.5.12")
   def throttleEven(elements: Int, per: java.time.Duration, mode: ThrottleMode): javadsl.SubFlow[In, Out, Mat] =
     throttleEven(elements, per.asScala, mode)
 
@@ -2474,7 +2474,7 @@ class SubFlow[In, Out, Mat](
    * @see [[#throttle]]
    */
   @Deprecated
-  @deprecated("Use throttle without `maximumBurst` parameter instead.", "2.5.12")
+  @deprecated("Use throttle without `maximumBurst` parameter instead.", "Akka 2.5.12")
   def throttleEven(
       cost: Int,
       per: FiniteDuration,
@@ -2493,7 +2493,7 @@ class SubFlow[In, Out, Mat](
    * @see [[#throttle]]
    */
   @Deprecated
-  @deprecated("Use throttle without `maximumBurst` parameter instead.", "2.5.12")
+  @deprecated("Use throttle without `maximumBurst` parameter instead.", "Akka 2.5.12")
   def throttleEven(
       cost: Int,
       per: java.time.Duration,

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -2417,7 +2417,7 @@ class SubSource[Out, Mat](
    * @see [[#throttle]]
    */
   @Deprecated
-  @deprecated("Use throttle without `maximumBurst` parameter instead.", "2.5.12")
+  @deprecated("Use throttle without `maximumBurst` parameter instead.", "Akka 2.5.12")
   def throttleEven(elements: Int, per: FiniteDuration, mode: ThrottleMode): javadsl.SubSource[Out, Mat] =
     new SubSource(delegate.throttleEven(elements, per, mode))
 
@@ -2432,7 +2432,7 @@ class SubSource[Out, Mat](
    * @see [[#throttle]]
    */
   @Deprecated
-  @deprecated("Use throttle without `maximumBurst` parameter instead.", "2.5.12")
+  @deprecated("Use throttle without `maximumBurst` parameter instead.", "Akka 2.5.12")
   def throttleEven(elements: Int, per: java.time.Duration, mode: ThrottleMode): javadsl.SubSource[Out, Mat] =
     throttleEven(elements, per.asScala, mode)
 
@@ -2447,7 +2447,7 @@ class SubSource[Out, Mat](
    * @see [[#throttle]]
    */
   @Deprecated
-  @deprecated("Use throttle without `maximumBurst` parameter instead.", "2.5.12")
+  @deprecated("Use throttle without `maximumBurst` parameter instead.", "Akka 2.5.12")
   def throttleEven(
       cost: Int,
       per: FiniteDuration,
@@ -2466,7 +2466,7 @@ class SubSource[Out, Mat](
    * @see [[#throttle]]
    */
   @Deprecated
-  @deprecated("Use throttle without `maximumBurst` parameter instead.", "2.5.12")
+  @deprecated("Use throttle without `maximumBurst` parameter instead.", "Akka 2.5.12")
   def throttleEven(
       cost: Int,
       per: java.time.Duration,

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/TLS.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/TLS.scala
@@ -76,7 +76,8 @@ object TLS {
    *
    * This method uses the default closing behavior or [[IgnoreComplete]].
    */
-  @deprecated("Use create that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
+  @deprecated("Use create that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.",
+    "Akka 2.6.0")
   def create(
       sslContext: SSLContext,
       sslConfig: Optional[PekkoSSLConfig],
@@ -95,7 +96,8 @@ object TLS {
    *
    * This method uses the default closing behavior or [[IgnoreComplete]].
    */
-  @deprecated("Use create that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
+  @deprecated("Use create that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.",
+    "Akka 2.6.0")
   def create(
       sslContext: SSLContext,
       firstSession: NegotiateNewSession,
@@ -118,7 +120,8 @@ object TLS {
    * The SSLEngine may use this information e.g. when an endpoint identification algorithm was
    * configured using [[javax.net.ssl.SSLParameters.setEndpointIdentificationAlgorithm]].
    */
-  @deprecated("Use create that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
+  @deprecated("Use create that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.",
+    "Akka 2.6.0")
   def create(
       sslContext: SSLContext,
       sslConfig: Optional[PekkoSSLConfig],
@@ -151,7 +154,8 @@ object TLS {
    * The SSLEngine may use this information e.g. when an endpoint identification algorithm was
    * configured using [[javax.net.ssl.SSLParameters.setEndpointIdentificationAlgorithm]].
    */
-  @deprecated("Use create that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
+  @deprecated("Use create that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.",
+    "Akka 2.6.0")
   def create(
       sslContext: SSLContext,
       firstSession: NegotiateNewSession,

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/TLS.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/TLS.scala
@@ -76,7 +76,7 @@ object TLS {
    *
    * This method uses the default closing behavior or [[IgnoreComplete]].
    */
-  @deprecated("Use create that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "2.6.0")
+  @deprecated("Use create that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
   def create(
       sslContext: SSLContext,
       sslConfig: Optional[PekkoSSLConfig],
@@ -95,7 +95,7 @@ object TLS {
    *
    * This method uses the default closing behavior or [[IgnoreComplete]].
    */
-  @deprecated("Use create that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "2.6.0")
+  @deprecated("Use create that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
   def create(
       sslContext: SSLContext,
       firstSession: NegotiateNewSession,
@@ -118,7 +118,7 @@ object TLS {
    * The SSLEngine may use this information e.g. when an endpoint identification algorithm was
    * configured using [[javax.net.ssl.SSLParameters.setEndpointIdentificationAlgorithm]].
    */
-  @deprecated("Use create that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "2.6.0")
+  @deprecated("Use create that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
   def create(
       sslContext: SSLContext,
       sslConfig: Optional[PekkoSSLConfig],
@@ -151,7 +151,7 @@ object TLS {
    * The SSLEngine may use this information e.g. when an endpoint identification algorithm was
    * configured using [[javax.net.ssl.SSLParameters.setEndpointIdentificationAlgorithm]].
    */
-  @deprecated("Use create that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "2.6.0")
+  @deprecated("Use create that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
   def create(
       sslContext: SSLContext,
       firstSession: NegotiateNewSession,

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Tcp.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Tcp.scala
@@ -208,7 +208,7 @@ class Tcp(system: ExtendedActorSystem) extends pekko.actor.Extension {
    *                  independently whether the client is still attempting to write. This setting is recommended
    *                  for servers, and therefore it is the default setting.
    */
-  @deprecated("Use bind that takes a java.time.Duration parameter instead.", "2.6.0")
+  @deprecated("Use bind that takes a java.time.Duration parameter instead.", "Akka 2.6.0")
   def bind(
       interface: String,
       port: Int,
@@ -291,7 +291,7 @@ class Tcp(system: ExtendedActorSystem) extends pekko.actor.Extension {
    *                  If set to false, the connection will immediately closed once the client closes its write side,
    *                  independently whether the server is still attempting to write.
    */
-  @deprecated("Use bind that takes a java.time.Duration parameter instead.", "2.6.0")
+  @deprecated("Use bind that takes a java.time.Duration parameter instead.", "Akka 2.6.0")
   def outgoingConnection(
       remoteAddress: InetSocketAddress,
       localAddress: Optional[InetSocketAddress],
@@ -331,7 +331,7 @@ class Tcp(system: ExtendedActorSystem) extends pekko.actor.Extension {
   @deprecated(
     "Use outgoingConnectionWithTls that takes a SSLEngine factory instead. " +
     "Setup the SSLEngine with needed parameters.",
-    "2.6.0")
+    "Akka 2.6.0")
   def outgoingTlsConnection(
       host: String,
       port: Int,
@@ -354,7 +354,7 @@ class Tcp(system: ExtendedActorSystem) extends pekko.actor.Extension {
   @deprecated(
     "Use outgoingConnectionWithTls that takes a SSLEngine factory instead. " +
     "Setup the SSLEngine with needed parameters.",
-    "2.6.0")
+    "Akka 2.6.0")
   def outgoingTlsConnection(
       remoteAddress: InetSocketAddress,
       sslContext: SSLContext,
@@ -442,7 +442,7 @@ class Tcp(system: ExtendedActorSystem) extends pekko.actor.Extension {
   @deprecated(
     "Use bindWithTls that takes a SSLEngine factory instead. " +
     "Setup the SSLEngine with needed parameters.",
-    "2.6.0")
+    "Akka 2.6.0")
   def bindTls(
       interface: String,
       port: Int,
@@ -468,7 +468,7 @@ class Tcp(system: ExtendedActorSystem) extends pekko.actor.Extension {
   @deprecated(
     "Use bindWithTls that takes a SSLEngine factory instead. " +
     "Setup the SSLEngine with needed parameters.",
-    "2.6.0")
+    "Akka 2.6.0")
   def bindTls(
       interface: String,
       port: Int,

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/CoupledTerminationFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/CoupledTerminationFlow.scala
@@ -69,7 +69,7 @@ object CoupledTerminationFlow {
    *
    * The order in which the `in` and `out` sides receive their respective completion signals is not defined, do not rely on its ordering.
    */
-  @deprecated("Use `Flow.fromSinkAndSourceCoupledMat(..., ...)(Keep.both)` instead", "2.5.2")
+  @deprecated("Use `Flow.fromSinkAndSourceCoupledMat(..., ...)(Keep.both)` instead", "Akka 2.5.2")
   def fromSinkAndSource[I, O, M1, M2](in: Sink[I, M1], out: Source[O, M2]): Flow[I, O, (M1, M2)] =
     Flow.fromSinkAndSourceCoupledMat(in, out)(Keep.both)
 

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -433,7 +433,7 @@ object Flow {
    * exposes [[ActorMaterializer]] which is going to be used during materialization and
    * [[Attributes]] of the [[Flow]] returned by this method.
    */
-  @deprecated("Use 'fromMaterializer' instead", "2.6.0")
+  @deprecated("Use 'fromMaterializer' instead", "Akka 2.6.0")
   def setup[T, U, M](factory: (ActorMaterializer, Attributes) => Flow[T, U, M]): Flow[T, U, Future[M]] =
     Flow.fromGraph(new SetupFlowStage((materializer, attributes) =>
       factory(ActorMaterializerHelper.downcast(materializer), attributes)))
@@ -616,7 +616,7 @@ object Flow {
    */
   @deprecated(
     "Use 'Flow.futureFlow' in combination with prefixAndTail(1) instead, see `futureFlow` operator docs for details",
-    "2.6.0")
+    "Akka 2.6.0")
   def lazyInit[I, O, M](flowFactory: I => Future[Flow[I, O, M]], fallback: () => M): Flow[I, O, M] =
     Flow[I]
       .flatMapPrefix(1) {
@@ -646,7 +646,7 @@ object Flow {
    *  This behaviour can be controlled by setting the [[pekko.stream.Attributes.NestedMaterializationCancellationPolicy.PropagateToNested]] attribute,
    * this will delay downstream cancellation until nested flow's materialization which is then immediately cancelled (with the original cancellation cause).
    */
-  @deprecated("Use 'Flow.lazyFutureFlow' instead", "2.6.0")
+  @deprecated("Use 'Flow.lazyFutureFlow' instead", "Akka 2.6.0")
   def lazyInitAsync[I, O, M](flowFactory: () => Future[Flow[I, O, M]]): Flow[I, O, Future[Option[M]]] =
     Flow.lazyFutureFlow(flowFactory).mapMaterializedValue {
       implicit val ec = pekko.dispatch.ExecutionContexts.parasitic
@@ -2610,7 +2610,7 @@ trait FlowOps[+Out, +Mat] {
    * @see [[throttle]]
    */
   @Deprecated
-  @deprecated("Use throttle without `maximumBurst` parameter instead.", "2.5.12")
+  @deprecated("Use throttle without `maximumBurst` parameter instead.", "Akka 2.5.12")
   def throttleEven(elements: Int, per: FiniteDuration, mode: ThrottleMode): Repr[Out] =
     throttle(elements, per, Throttle.AutomaticMaximumBurst, ConstantFun.oneInt, mode)
 
@@ -2625,7 +2625,7 @@ trait FlowOps[+Out, +Mat] {
    * @see [[throttle]]
    */
   @Deprecated
-  @deprecated("Use throttle without `maximumBurst` parameter instead.", "2.5.12")
+  @deprecated("Use throttle without `maximumBurst` parameter instead.", "Akka 2.5.12")
   def throttleEven(cost: Int, per: FiniteDuration, costCalculation: (Out) => Int, mode: ThrottleMode): Repr[Out] =
     throttle(cost, per, Throttle.AutomaticMaximumBurst, costCalculation, mode)
 
@@ -3953,7 +3953,7 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
    */
   @Deprecated
-  @deprecated("Use monitor() or monitorMat(combine) instead", "2.5.17")
+  @deprecated("Use monitor() or monitorMat(combine) instead", "Akka 2.5.17")
   def monitor[Mat2]()(combine: (Mat, FlowMonitor[Out]) => Mat2): ReprMat[Out, Mat2] =
     viaMat(GraphStages.monitor)(combine)
 

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Graph.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Graph.scala
@@ -805,7 +805,7 @@ final class Partition[T](val outputPorts: Int, val partitioner: T => Int, val ea
   /**
    * Sets `eagerCancel` to `false`.
    */
-  @deprecated("Use the constructor which also specifies the `eagerCancel` parameter", "2.5.10")
+  @deprecated("Use the constructor which also specifies the `eagerCancel` parameter", "Akka 2.5.10")
   def this(outputPorts: Int, partitioner: T => Int) = this(outputPorts, partitioner, false)
 
   val in: Inlet[T] = Inlet[T]("Partition.in")
@@ -1221,7 +1221,7 @@ class ZipWithN[A, O](zipper: immutable.Seq[A] => O)(n: Int) extends GraphStage[U
   override val shape = new UniformFanInShape[A, O](n)
   def out: Outlet[O] = shape.out
 
-  @deprecated("use `shape.inlets` or `shape.in(id)` instead", "2.5.5")
+  @deprecated("use `shape.inlets` or `shape.in(id)` instead", "Akka 2.5.5")
   def inSeq: immutable.IndexedSeq[Inlet[A]] = shape.inlets.asInstanceOf[immutable.IndexedSeq[Inlet[A]]]
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Sink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Sink.scala
@@ -185,7 +185,7 @@ object Sink {
    * exposes [[ActorMaterializer]] which is going to be used during materialization and
    * [[Attributes]] of the [[Sink]] returned by this method.
    */
-  @deprecated("Use 'fromMaterializer' instead", "2.6.0")
+  @deprecated("Use 'fromMaterializer' instead", "Akka 2.6.0")
   def setup[T, M](factory: (ActorMaterializer, Attributes) => Sink[T, M]): Sink[T, Future[M]] =
     fromMaterializer { (mat, attr) =>
       factory(ActorMaterializerHelper.downcast(mat), attr)
@@ -497,7 +497,7 @@ object Sink {
    * to use a bounded mailbox with zero `mailbox-push-timeout-time` or use a rate
    * limiting operator in front of this `Sink`.
    */
-  @deprecated("Use variant accepting both on complete and on failure message", "2.6.0")
+  @deprecated("Use variant accepting both on complete and on failure message", "Akka 2.6.0")
   def actorRef[T](ref: ActorRef, onCompleteMessage: Any): Sink[T, NotUsed] =
     fromGraph(new ActorRefSinkStage[T](ref, onCompleteMessage, t => Status.Failure(t)))
 
@@ -592,7 +592,7 @@ object Sink {
    * When the stream is completed with failure - result of `onFailureMessage(throwable)`
    * function will be sent to the destination actor.
    */
-  @deprecated("Use actorRefWithBackpressure accepting completion and failure matchers instead", "2.6.0")
+  @deprecated("Use actorRefWithBackpressure accepting completion and failure matchers instead", "Akka 2.6.0")
   def actorRefWithAck[T](
       ref: ActorRef,
       onInitMessage: Any,
@@ -650,7 +650,7 @@ object Sink {
    * sink fails then the `Future` is completed with the exception.
    * Otherwise the `Future` is completed with the materialized value of the internal sink.
    */
-  @deprecated("Use 'Sink.lazyFutureSink' in combination with 'Flow.prefixAndTail(1)' instead", "2.6.0")
+  @deprecated("Use 'Sink.lazyFutureSink' in combination with 'Flow.prefixAndTail(1)' instead", "Akka 2.6.0")
   def lazyInit[T, M](sinkFactory: T => Future[Sink[T, M]], fallback: () => M): Sink[T, Future[M]] =
     Sink
       .fromGraph(new LazySink[T, M](sinkFactory))
@@ -665,7 +665,7 @@ object Sink {
    * sink fails then the `Future` is completed with the exception.
    * Otherwise the `Future` is completed with the materialized value of the internal sink.
    */
-  @deprecated("Use 'Sink.lazyFutureSink' instead", "2.6.0")
+  @deprecated("Use 'Sink.lazyFutureSink' instead", "Akka 2.6.0")
   def lazyInitAsync[T, M](sinkFactory: () => Future[Sink[T, M]]): Sink[T, Future[Option[M]]] =
     Sink.fromGraph(new LazySink[T, M](_ => sinkFactory())).mapMaterializedValue { m =>
       implicit val ec = ExecutionContexts.parasitic

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Source.scala
@@ -238,7 +238,7 @@ final class Source[+Out, +Mat](
   /**
    * Combines several sources with fan-in strategy like `Merge` or `Concat` and returns `Source`.
    */
-  @deprecated("Use `Source.combine` on companion object instead", "2.5.5")
+  @deprecated("Use `Source.combine` on companion object instead", "Akka 2.5.5")
   def combine[T, U](first: Source[T, _], second: Source[T, _], rest: Source[T, _]*)(
       strategy: Int => Graph[UniformFanInShape[T, U], NotUsed]): Source[U, NotUsed] =
     Source.combine(first, second, rest: _*)(strategy)
@@ -341,7 +341,7 @@ object Source {
    * exposes [[ActorMaterializer]] which is going to be used during materialization and
    * [[Attributes]] of the [[Source]] returned by this method.
    */
-  @deprecated("Use 'fromMaterializer' instead", "2.6.0")
+  @deprecated("Use 'fromMaterializer' instead", "Akka 2.6.0")
   def setup[T, M](factory: (ActorMaterializer, Attributes) => Source[T, M]): Source[T, Future[M]] =
     Source.fromGraph(new SetupSourceStage((materializer, attributes) =>
       factory(ActorMaterializerHelper.downcast(materializer), attributes)))
@@ -364,7 +364,7 @@ object Source {
    * may happen before or after materializing the `Flow`.
    * The stream terminates with a failure if the `Future` is completed with a failure.
    */
-  @deprecated("Use 'Source.future' instead", "2.6.0")
+  @deprecated("Use 'Source.future' instead", "Akka 2.6.0")
   def fromFuture[T](future: Future[T]): Source[T, NotUsed] =
     fromGraph(new FutureSource(future))
 
@@ -374,7 +374,7 @@ object Source {
    * may happen before or after materializing the `Flow`.
    * The stream terminates with a failure if the `Future` is completed with a failure.
    */
-  @deprecated("Use 'Source.completionStage' instead", "2.6.0")
+  @deprecated("Use 'Source.completionStage' instead", "Akka 2.6.0")
   def fromCompletionStage[T](future: CompletionStage[T]): Source[T, NotUsed] =
     fromGraph(new FutureSource(future.toScala))
 
@@ -383,7 +383,7 @@ object Source {
    * If the [[Future]] fails the stream is failed with the exception from the future. If downstream cancels before the
    * stream completes the materialized `Future` will be failed with a [[StreamDetachedException]]
    */
-  @deprecated("Use 'Source.futureSource' (potentially together with `Source.fromGraph`) instead", "2.6.0")
+  @deprecated("Use 'Source.futureSource' (potentially together with `Source.fromGraph`) instead", "Akka 2.6.0")
   def fromFutureSource[T, M](future: Future[Graph[SourceShape[T], M]]): Source[T, Future[M]] =
     fromGraph(new FutureFlattenSource(future))
 
@@ -393,7 +393,7 @@ object Source {
    * If downstream cancels before the stream completes the materialized `Future` will be failed
    * with a [[StreamDetachedException]]
    */
-  @deprecated("Use scala-compat CompletionStage to future converter and 'Source.futureSource' instead", "2.6.0")
+  @deprecated("Use scala-compat CompletionStage to future converter and 'Source.futureSource' instead", "Akka 2.6.0")
   def fromSourceCompletionStage[T, M](
       completion: CompletionStage[_ <: Graph[SourceShape[T], M]]): Source[T, CompletionStage[M]] =
     fromFutureSource(completion.toScala).mapMaterializedValue(_.toJava)
@@ -489,7 +489,7 @@ object Source {
    * the materialized future is completed with its value, if downstream cancels or fails without any demand the
    * create factory is never called and the materialized `Future` is failed.
    */
-  @deprecated("Use 'Source.lazySource' instead", "2.6.0")
+  @deprecated("Use 'Source.lazySource' instead", "Akka 2.6.0")
   def lazily[T, M](create: () => Source[T, M]): Source[T, Future[M]] =
     Source.fromGraph(new LazySource[T, M](create))
 
@@ -500,7 +500,7 @@ object Source {
    *
    * @see [[Source.lazily]]
    */
-  @deprecated("Use 'Source.lazyFuture' instead", "2.6.0")
+  @deprecated("Use 'Source.lazyFuture' instead", "Akka 2.6.0")
   def lazilyAsync[T](create: () => Future[T]): Source[T, Future[NotUsed]] =
     lazily(() => fromFuture(create()))
 
@@ -689,7 +689,7 @@ object Source {
    * @param bufferSize The size of the buffer in element count
    * @param overflowStrategy Strategy that is used when incoming elements cannot fit inside the buffer
    */
-  @deprecated("Use variant accepting completion and failure matchers instead", "2.6.0")
+  @deprecated("Use variant accepting completion and failure matchers instead", "Akka 2.6.0")
   def actorRef[T](bufferSize: Int, overflowStrategy: OverflowStrategy): Source[T, ActorRef] =
     actorRef({
         case pekko.actor.Status.Success(s: CompletionStrategy) => s
@@ -748,7 +748,7 @@ object Source {
    * The actor will be stopped when the stream is completed, failed or canceled from downstream,
    * i.e. you can watch it to get notified when that happens.
    */
-  @deprecated("Use actorRefWithBackpressure accepting completion and failure matchers instead", "2.6.0")
+  @deprecated("Use actorRefWithBackpressure accepting completion and failure matchers instead", "Akka 2.6.0")
   def actorRefWithAck[T](ackMessage: Any): Source[T, ActorRef] =
     actorRefWithAck(None, ackMessage,
       {

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/TLS.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/TLS.scala
@@ -82,7 +82,8 @@ object TLS {
    * The SSLEngine may use this information e.g. when an endpoint identification algorithm was
    * configured using [[javax.net.ssl.SSLParameters.setEndpointIdentificationAlgorithm]].
    */
-  @deprecated("Use apply that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
+  @deprecated("Use apply that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.",
+    "Akka 2.6.0")
   def apply(
       sslContext: SSLContext,
       sslConfig: Option[PekkoSSLConfig],
@@ -160,7 +161,8 @@ object TLS {
    * The SSLEngine may use this information e.g. when an endpoint identification algorithm was
    * configured using [[javax.net.ssl.SSLParameters.setEndpointIdentificationAlgorithm]].
    */
-  @deprecated("Use apply that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
+  @deprecated("Use apply that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.",
+    "Akka 2.6.0")
   def apply(
       sslContext: SSLContext,
       firstSession: NegotiateNewSession,
@@ -179,7 +181,8 @@ object TLS {
    * that is not a requirement and depends entirely on the application
    * protocol.
    */
-  @deprecated("Use apply that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
+  @deprecated("Use apply that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.",
+    "Akka 2.6.0")
   def apply(
       sslContext: SSLContext,
       firstSession: NegotiateNewSession,

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/TLS.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/TLS.scala
@@ -82,7 +82,7 @@ object TLS {
    * The SSLEngine may use this information e.g. when an endpoint identification algorithm was
    * configured using [[javax.net.ssl.SSLParameters.setEndpointIdentificationAlgorithm]].
    */
-  @deprecated("Use apply that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "2.6.0")
+  @deprecated("Use apply that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
   def apply(
       sslContext: SSLContext,
       sslConfig: Option[PekkoSSLConfig],
@@ -160,7 +160,7 @@ object TLS {
    * The SSLEngine may use this information e.g. when an endpoint identification algorithm was
    * configured using [[javax.net.ssl.SSLParameters.setEndpointIdentificationAlgorithm]].
    */
-  @deprecated("Use apply that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "2.6.0")
+  @deprecated("Use apply that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
   def apply(
       sslContext: SSLContext,
       firstSession: NegotiateNewSession,
@@ -179,7 +179,7 @@ object TLS {
    * that is not a requirement and depends entirely on the application
    * protocol.
    */
-  @deprecated("Use apply that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "2.6.0")
+  @deprecated("Use apply that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "Akka 2.6.0")
   def apply(
       sslContext: SSLContext,
       firstSession: NegotiateNewSession,

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Tcp.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Tcp.scala
@@ -267,7 +267,7 @@ final class Tcp(system: ExtendedActorSystem) extends pekko.actor.Extension {
   @deprecated(
     "Use outgoingConnectionWithTls that takes a SSLEngine factory instead. " +
     "Setup the SSLEngine with needed parameters.",
-    "2.6.0")
+    "Akka 2.6.0")
   def outgoingTlsConnection(
       host: String,
       port: Int,
@@ -287,7 +287,7 @@ final class Tcp(system: ExtendedActorSystem) extends pekko.actor.Extension {
   @deprecated(
     "Use outgoingConnectionWithTls that takes a SSLEngine factory instead. " +
     "Setup the SSLEngine with needed parameters.",
-    "2.6.0")
+    "Akka 2.6.0")
   def outgoingTlsConnection(
       remoteAddress: InetSocketAddress,
       sslContext: SSLContext,
@@ -363,7 +363,7 @@ final class Tcp(system: ExtendedActorSystem) extends pekko.actor.Extension {
   @deprecated(
     "Use bindWithTls that takes a SSLEngine factory instead. " +
     "Setup the SSLEngine with needed parameters.",
-    "2.6.0")
+    "Akka 2.6.0")
   def bindTls(
       interface: String,
       port: Int,
@@ -496,7 +496,7 @@ final class Tcp(system: ExtendedActorSystem) extends pekko.actor.Extension {
   @deprecated(
     "Use bindAndHandleWithTls that takes a SSLEngine factory instead. " +
     "Setup the SSLEngine with needed parameters.",
-    "2.6.0")
+    "Akka 2.6.0")
   def bindAndHandleTls(
       handler: Flow[ByteString, ByteString, _],
       interface: String,


### PR DESCRIPTION
* because these versions do not relate to Pekko directly