### PR TITLE
Move header check into its own github action

### DIFF
--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -11,35 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-headers:
-    name: Check / Headers
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
-          fetch-depth: 0
-
-      - name: Setup Java 8
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 8
-
-      - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
-
-      - name: Enable jvm-opts
-        run: cp .jvmopts-ci .jvmopts
-
-      - name: Check headers
-        run: |-
-          sbt \
-          -Dsbt.override.build.repos=false \
-          -Dsbt.log.noformat=false \
-          +headerCheckAll
-
   pull-request-validation:
     name: Check / Tests
     runs-on: ubuntu-20.04

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -1,0 +1,30 @@
+name: Headers
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  check-headers:
+    name: Check headers
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Java 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 8
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Check headers
+        run: |-
+          sbt \
+          -Dsbt.override.build.repos=false \
+          -Dsbt.log.noformat=false \
+          +headerCheckAll

--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko
 
-import org.apache.pekko.PekkoValidatePullRequest.additionalTasks
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
 import de.heikoseeberger.sbtheader.{ CommentCreator, HeaderPlugin, NewLine }
 import com.typesafe.sbt.MultiJvmPlugin.MultiJvmKeys._
@@ -38,7 +37,7 @@ trait CopyrightHeader extends AutoPlugin {
             HeaderFileType("template") -> cStyleComment)))
     }
 
-  override def projectSettings: Seq[Def.Setting[_]] = Def.settings(headerMappingSettings, additional)
+  override def projectSettings: Seq[Def.Setting[_]] = headerMappingSettings
 
   def additional: Seq[Def.Setting[_]] =
     Def.settings(Compile / compile := {
@@ -105,8 +104,4 @@ trait CopyrightHeader extends AutoPlugin {
 
 object CopyrightHeader extends CopyrightHeader
 
-object CopyrightHeaderInPr extends CopyrightHeader {
-
-  override val additional =
-    Def.settings(additionalTasks += Compile / headerCheck, additionalTasks += Test / headerCheck)
-}
+object CopyrightHeaderInPr extends CopyrightHeader


### PR DESCRIPTION
Similar to https://github.com/apache/incubator-pekko-http/pull/77, moves the header check into its own github workflow. Note that there are some slight differences compared to pekko-http, but this is due to bespoke pekko core differences (which can be seen in the code removed from `build-test-prValidation.yml`).