### PR TITLE
Add headers to github actions status check

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -35,12 +35,6 @@ github:
         # contexts are the names of checks that must pass
         contexts:
           - Code is formatted
-    temp:
-      required_status_checks:
-        # strict means "Require branches to be up to date before merging".
-        strict: false
-        # contexts are the names of checks that must pass
-        contexts:
           - Check headers
 
 notifications:


### PR DESCRIPTION
This PR adds a github status check to make sure source files have the appropriate headers before a PR can be merged. This feature has already been tested on the `temp` branch to make sure that it works, see 

https://github.com/apache/incubator-pekko/pull/218

I have also tested the negative case in (i.e. I deliberately broke a header for a source file and to verify that you cannot merge the PR).

![image](https://user-images.githubusercontent.com/2337269/221423493-0d84fd05-5df3-4911-82ca-5f28fd5f7e9b.png)

Note that there is some concern about adding this check before the all of the headers have been added to the source files (see https://github.com/apache/incubator-pekko/pull/218#discussion_r1118091218). Technically speaking this is a non concern because sbt-header allows you to precisely control which files get checked (see the `headerSources` sbt setting key, i.e. https://github.com/apache/incubator-pekko/search?q=headerSources). As it stands now even if we do add headers to specific different types of files (i.e. `*.conf` or `*.md`), they won't be checked until we add them using `headerSources`. If a PR is created that does somehow manage to break the sbt-header check then, I doubt it would be merged into main because in that case we would have a constantly failing header check which we would have to tell people to ignore all of the time. In the ultimate worst case scenario, one can always revert the change in this PR or even just comment out the sbt-header check at https://github.com/apache/incubator-pekko/blob/main/.github/workflows/headers.yml#L25-L30 which will make the github action always pass.

Nevertheless if its still a big concern we can suspend merging this PR until the other header work has been done.