### PR TITLE
Update sbt-apache-sonatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,6 @@ initialize := {
   initialize.value
 }
 
-PekkoBuild.buildSettings
 shellPrompt := { s =>
   Project.extract(s).currentProject.id + " > "
 }
@@ -587,7 +586,6 @@ lazy val billOfMaterials = Project("bill-of-materials", file("bill-of-materials"
   .enablePlugins(BillOfMaterialsPlugin)
   .disablePlugins(MimaPlugin, PekkoDisciplinePlugin)
   // buildSettings and defaultSettings configure organization name, licenses, etc...
-  .settings(PekkoBuild.buildSettings)
   .settings(PekkoBuild.defaultSettings)
   .settings(
     name := "pekko-bom",
@@ -612,7 +610,6 @@ def pekkoModule(moduleName: String): Project =
   Project(id = moduleName, base = file(moduleName))
     .enablePlugins(ReproducibleBuildsPlugin)
     .disablePlugins(WelcomePlugin)
-    .settings(PekkoBuild.buildSettings)
     .settings(PekkoBuild.defaultSettings)
     .settings(
       name := s"pekko-$moduleName")

--- a/project/PekkoBuild.scala
+++ b/project/PekkoBuild.scala
@@ -39,8 +39,6 @@ object PekkoBuild {
 
   val parallelExecutionByDefault = false // TODO: enable this once we're sure it does not break things
 
-  lazy val buildSettings = Def.settings(organization := "org.apache.pekko")
-
   lazy val rootSettings = Def.settings(
     commands += switchVersion,
     UnidocRoot.pekkoSettings,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,7 +20,7 @@ addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.30")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
 addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.2")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.5")
-addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.4")
+addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.5")
 addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.2.2")
 
 // allow access to snapshots for pekko-sbt-paradox


### PR DESCRIPTION
Updates the sbt-apache-sonatype plugin. Note that the new version of the plugin sets `organization` sbt setting automatically