### PR TITLE
change default port number to 7355

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/actor/ActorPathSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/ActorPathSpec.scala
@@ -68,26 +68,26 @@ class ActorPathSpec extends AnyWordSpec with Matchers {
 
     "create correct toStringWithAddress" in {
       val local = Address("pekko", "mysys")
-      val a = local.copy(host = Some("aaa"), port = Some(2552))
+      val a = local.copy(host = Some("aaa"), port = Some(7355))
       val b = a.copy(host = Some("bb"))
       val c = a.copy(host = Some("cccc"))
       val root = RootActorPath(local)
-      root.toStringWithAddress(a) should ===("pekko://mysys@aaa:2552/")
-      (root / "user").toStringWithAddress(a) should ===("pekko://mysys@aaa:2552/user")
-      (root / "user" / "foo").toStringWithAddress(a) should ===("pekko://mysys@aaa:2552/user/foo")
+      root.toStringWithAddress(a) should ===("pekko://mysys@aaa:7355/")
+      (root / "user").toStringWithAddress(a) should ===("pekko://mysys@aaa:7355/user")
+      (root / "user" / "foo").toStringWithAddress(a) should ===("pekko://mysys@aaa:7355/user/foo")
 
-      //      root.toStringWithAddress(b) should ===("pekko://mysys@bb:2552/")
-      (root / "user").toStringWithAddress(b) should ===("pekko://mysys@bb:2552/user")
-      (root / "user" / "foo").toStringWithAddress(b) should ===("pekko://mysys@bb:2552/user/foo")
+      //      root.toStringWithAddress(b) should ===("pekko://mysys@bb:7355/")
+      (root / "user").toStringWithAddress(b) should ===("pekko://mysys@bb:7355/user")
+      (root / "user" / "foo").toStringWithAddress(b) should ===("pekko://mysys@bb:7355/user/foo")
 
-      root.toStringWithAddress(c) should ===("pekko://mysys@cccc:2552/")
-      (root / "user").toStringWithAddress(c) should ===("pekko://mysys@cccc:2552/user")
-      (root / "user" / "foo").toStringWithAddress(c) should ===("pekko://mysys@cccc:2552/user/foo")
+      root.toStringWithAddress(c) should ===("pekko://mysys@cccc:7355/")
+      (root / "user").toStringWithAddress(c) should ===("pekko://mysys@cccc:7355/user")
+      (root / "user" / "foo").toStringWithAddress(c) should ===("pekko://mysys@cccc:7355/user/foo")
 
       val rootA = RootActorPath(a)
-      rootA.toStringWithAddress(b) should ===("pekko://mysys@aaa:2552/")
-      (rootA / "user").toStringWithAddress(b) should ===("pekko://mysys@aaa:2552/user")
-      (rootA / "user" / "foo").toStringWithAddress(b) should ===("pekko://mysys@aaa:2552/user/foo")
+      rootA.toStringWithAddress(b) should ===("pekko://mysys@aaa:7355/")
+      (rootA / "user").toStringWithAddress(b) should ===("pekko://mysys@aaa:7355/user")
+      (rootA / "user" / "foo").toStringWithAddress(b) should ===("pekko://mysys@aaa:7355/user/foo")
     }
 
     "not allow path separators in RootActorPath's name" in {

--- a/actor-tests/src/test/scala/org/apache/pekko/actor/LocalActorRefProviderSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/LocalActorRefProviderSpec.scala
@@ -48,7 +48,7 @@ class LocalActorRefProviderSpec extends PekkoSpec(LocalActorRefProviderSpec.conf
   "An LocalActorRefProvider" must {
 
     "find child actor with URL encoded name" in {
-      val childName = "pekko%3A%2F%2FClusterSystem%40127.0.0.1%3A2552"
+      val childName = "pekko%3A%2F%2FClusterSystem%40127.0.0.1%3A7355"
       val a = system.actorOf(Props(new Actor {
         val child = context.actorOf(Props.empty, name = childName)
         def receive = {

--- a/actor-tests/src/test/scala/org/apache/pekko/actor/RelativeActorPathSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/RelativeActorPathSpec.scala
@@ -32,7 +32,7 @@ class RelativeActorPathSpec extends AnyWordSpec with Matchers {
       elements("foo/bar/baz") should ===(List("foo", "bar", "baz"))
     }
     "match url encoded name" in {
-      val name = URLEncoder.encode("pekko://ClusterSystem@127.0.0.1:2552", "UTF-8")
+      val name = URLEncoder.encode("pekko://ClusterSystem@127.0.0.1:7355", "UTF-8")
       elements(name) should ===(List(name))
     }
     "match path with uid fragment" in {

--- a/bench-jmh/src/main/scala/org/apache/pekko/cluster/ddata/ORSetMergeBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/cluster/ddata/ORSetMergeBenchmark.scala
@@ -43,7 +43,7 @@ class ORSetMergeBenchmark {
   @Param(Array("1", "10", "20", "100"))
   var set1Size = 0
 
-  val nodeA = UniqueAddress(Address("pekko", "Sys", "aaaa", 2552), 1L)
+  val nodeA = UniqueAddress(Address("pekko", "Sys", "aaaa", 7355), 1L)
   val nodeB = UniqueAddress(nodeA.address.copy(host = Some("bbbb")), 2L)
   val nodeC = UniqueAddress(nodeA.address.copy(host = Some("cccc")), 3L)
   val nodeD = UniqueAddress(nodeA.address.copy(host = Some("dddd")), 4L)

--- a/bench-jmh/src/main/scala/org/apache/pekko/cluster/ddata/VersionVectorBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/cluster/ddata/VersionVectorBenchmark.scala
@@ -43,7 +43,7 @@ class VersionVectorBenchmark {
   @Param(Array("1", "2", "5"))
   var size = 0
 
-  val nodeA = UniqueAddress(Address("pekko", "Sys", "aaaa", 2552), 1L)
+  val nodeA = UniqueAddress(Address("pekko", "Sys", "aaaa", 7355), 1L)
   val nodeB = UniqueAddress(nodeA.address.copy(host = Some("bbbb")), 2L)
   val nodeC = UniqueAddress(nodeA.address.copy(host = Some("cccc")), 3L)
   val nodeD = UniqueAddress(nodeA.address.copy(host = Some("dddd")), 4L)

--- a/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/ClusterMetricsRoutingSpec.scala
+++ b/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/ClusterMetricsRoutingSpec.scala
@@ -28,10 +28,10 @@ class MetricsSelectorSpec extends AnyWordSpec with Matchers {
     override def capacity(nodeMetrics: Set[NodeMetrics]): Map[Address, Double] = Map.empty
   }
 
-  val a1 = Address("pekko", "sys", "a1", 2551)
-  val b1 = Address("pekko", "sys", "b1", 2551)
-  val c1 = Address("pekko", "sys", "c1", 2551)
-  val d1 = Address("pekko", "sys", "d1", 2551)
+  val a1 = Address("pekko", "sys", "a1", 7354)
+  val b1 = Address("pekko", "sys", "b1", 7354)
+  val c1 = Address("pekko", "sys", "c1", 7354)
+  val d1 = Address("pekko", "sys", "d1", 7354)
 
   val decayFactor = Some(0.18)
 

--- a/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/MetricSpec.scala
+++ b/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/MetricSpec.scala
@@ -69,8 +69,8 @@ class MetricNumericConverterSpec extends AnyWordSpec with Matchers with MetricNu
 @nowarn
 class NodeMetricsSpec extends AnyWordSpec with Matchers {
 
-  val node1 = Address("pekko", "sys", "a", 2554)
-  val node2 = Address("pekko", "sys", "a", 2555)
+  val node1 = Address("pekko", "sys", "a", 7357)
+  val node2 = Address("pekko", "sys", "a", 7358)
 
   "NodeMetrics must" must {
 
@@ -162,8 +162,8 @@ class MetricsGossipSpec
 
   "A MetricsGossip" must {
     "add new NodeMetrics" in {
-      val m1 = NodeMetrics(Address("pekko", "sys", "a", 2554), newTimestamp, collector.sample().metrics)
-      val m2 = NodeMetrics(Address("pekko", "sys", "a", 2555), newTimestamp, collector.sample().metrics)
+      val m1 = NodeMetrics(Address("pekko", "sys", "a", 7357), newTimestamp, collector.sample().metrics)
+      val m2 = NodeMetrics(Address("pekko", "sys", "a", 7358), newTimestamp, collector.sample().metrics)
 
       m1.metrics.size should be > 3
       m2.metrics.size should be > 3
@@ -179,8 +179,8 @@ class MetricsGossipSpec
     }
 
     "merge peer metrics" in {
-      val m1 = NodeMetrics(Address("pekko", "sys", "a", 2554), newTimestamp, collector.sample().metrics)
-      val m2 = NodeMetrics(Address("pekko", "sys", "a", 2555), newTimestamp, collector.sample().metrics)
+      val m1 = NodeMetrics(Address("pekko", "sys", "a", 7357), newTimestamp, collector.sample().metrics)
+      val m2 = NodeMetrics(Address("pekko", "sys", "a", 7358), newTimestamp, collector.sample().metrics)
 
       val g1 = MetricsGossip.empty :+ m1 :+ m2
       g1.nodes.size should ===(2)
@@ -194,9 +194,9 @@ class MetricsGossipSpec
     }
 
     "merge an existing metric set for a node and update node ring" in {
-      val m1 = NodeMetrics(Address("pekko", "sys", "a", 2554), newTimestamp, collector.sample().metrics)
-      val m2 = NodeMetrics(Address("pekko", "sys", "a", 2555), newTimestamp, collector.sample().metrics)
-      val m3 = NodeMetrics(Address("pekko", "sys", "a", 2556), newTimestamp, collector.sample().metrics)
+      val m1 = NodeMetrics(Address("pekko", "sys", "a", 7357), newTimestamp, collector.sample().metrics)
+      val m2 = NodeMetrics(Address("pekko", "sys", "a", 7358), newTimestamp, collector.sample().metrics)
+      val m3 = NodeMetrics(Address("pekko", "sys", "a", 7359), newTimestamp, collector.sample().metrics)
       val m2Updated = m2.copy(metrics = newSample(m2.metrics), timestamp = m2.timestamp + 1000)
 
       val g1 = MetricsGossip.empty :+ m1 :+ m2
@@ -215,14 +215,14 @@ class MetricsGossipSpec
     }
 
     "get the current NodeMetrics if it exists in the local nodes" in {
-      val m1 = NodeMetrics(Address("pekko", "sys", "a", 2554), newTimestamp, collector.sample().metrics)
+      val m1 = NodeMetrics(Address("pekko", "sys", "a", 7357), newTimestamp, collector.sample().metrics)
       val g1 = MetricsGossip.empty :+ m1
       g1.nodeMetricsFor(m1.address).map(_.metrics) should ===(Some(m1.metrics))
     }
 
     "remove a node if it is no longer Up" in {
-      val m1 = NodeMetrics(Address("pekko", "sys", "a", 2554), newTimestamp, collector.sample().metrics)
-      val m2 = NodeMetrics(Address("pekko", "sys", "a", 2555), newTimestamp, collector.sample().metrics)
+      val m1 = NodeMetrics(Address("pekko", "sys", "a", 7357), newTimestamp, collector.sample().metrics)
+      val m2 = NodeMetrics(Address("pekko", "sys", "a", 7358), newTimestamp, collector.sample().metrics)
 
       val g1 = MetricsGossip.empty :+ m1 :+ m2
       g1.nodes.size should ===(2)
@@ -234,8 +234,8 @@ class MetricsGossipSpec
     }
 
     "filter nodes" in {
-      val m1 = NodeMetrics(Address("pekko", "sys", "a", 2554), newTimestamp, collector.sample().metrics)
-      val m2 = NodeMetrics(Address("pekko", "sys", "a", 2555), newTimestamp, collector.sample().metrics)
+      val m1 = NodeMetrics(Address("pekko", "sys", "a", 7357), newTimestamp, collector.sample().metrics)
+      val m2 = NodeMetrics(Address("pekko", "sys", "a", 7358), newTimestamp, collector.sample().metrics)
 
       val g1 = MetricsGossip.empty :+ m1 :+ m2
       g1.nodes.size should ===(2)
@@ -254,8 +254,8 @@ class MetricValuesSpec extends PekkoSpec(MetricsConfig.defaultEnabled) with Metr
 
   val collector = createMetricsCollector
 
-  val node1 = NodeMetrics(Address("pekko", "sys", "a", 2554), 1, collector.sample().metrics)
-  val node2 = NodeMetrics(Address("pekko", "sys", "a", 2555), 1, collector.sample().metrics)
+  val node1 = NodeMetrics(Address("pekko", "sys", "a", 7357), 1, collector.sample().metrics)
+  val node2 = NodeMetrics(Address("pekko", "sys", "a", 7358), 1, collector.sample().metrics)
 
   val nodes: Seq[NodeMetrics] = {
     (1 to 100).foldLeft(List(node1, node2)) { (nodes, _) =>

--- a/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/WeightedRouteesSpec.scala
+++ b/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/WeightedRouteesSpec.scala
@@ -35,10 +35,10 @@ class WeightedRouteesSpec extends PekkoSpec(ConfigFactory.parseString("""
     if (RARP(system).provider.remoteSettings.Artery.Enabled) "pekko"
     else "pekko.tcp"
 
-  val a1 = Address(protocol, "sys", "a1", 2551)
-  val b1 = Address(protocol, "sys", "b1", 2551)
-  val c1 = Address(protocol, "sys", "c1", 2551)
-  val d1 = Address(protocol, "sys", "d1", 2551)
+  val a1 = Address(protocol, "sys", "a1", 7354)
+  val b1 = Address(protocol, "sys", "b1", 7354)
+  val c1 = Address(protocol, "sys", "c1", 7354)
+  val d1 = Address(protocol, "sys", "d1", 7354)
 
   val routeeA = ActorSelectionRoutee(system.actorSelection(RootActorPath(a1) / "user" / "a"))
   val routeeB = ActorSelectionRoutee(system.actorSelection(RootActorPath(b1) / "user" / "b"))

--- a/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/protobuf/MessageSerializerSpec.scala
+++ b/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/protobuf/MessageSerializerSpec.scala
@@ -40,12 +40,12 @@ class MessageSerializerSpec extends PekkoSpec("""
 
   import MemberStatus._
 
-  val a1 = TestMember(Address("pekko", "sys", "a", 2552), Joining, Set.empty)
-  val b1 = TestMember(Address("pekko", "sys", "b", 2552), Up, Set("r1"))
-  val c1 = TestMember(Address("pekko", "sys", "c", 2552), Leaving, Set("r2"))
-  val d1 = TestMember(Address("pekko", "sys", "d", 2552), Exiting, Set("r1", "r2"))
-  val e1 = TestMember(Address("pekko", "sys", "e", 2552), Down, Set("r3"))
-  val f1 = TestMember(Address("pekko", "sys", "f", 2552), Removed, Set("r2", "r3"))
+  val a1 = TestMember(Address("pekko", "sys", "a", 7355), Joining, Set.empty)
+  val b1 = TestMember(Address("pekko", "sys", "b", 7355), Up, Set("r1"))
+  val c1 = TestMember(Address("pekko", "sys", "c", 7355), Leaving, Set("r2"))
+  val d1 = TestMember(Address("pekko", "sys", "d", 7355), Exiting, Set("r1", "r2"))
+  val e1 = TestMember(Address("pekko", "sys", "e", 7355), Down, Set("r3"))
+  val f1 = TestMember(Address("pekko", "sys", "f", 7355), Removed, Set("r2", "r3"))
 
   "ClusterMessages" must {
 

--- a/cluster-sharding-typed/src/test/java/jdocs/org/apache/pekko/cluster/sharding/typed/ExternalShardAllocationCompileOnlyTest.java
+++ b/cluster-sharding-typed/src/test/java/jdocs/org/apache/pekko/cluster/sharding/typed/ExternalShardAllocationCompileOnlyTest.java
@@ -46,7 +46,7 @@ public class ExternalShardAllocationCompileOnlyTest {
     ExternalShardAllocationClient client =
         ExternalShardAllocation.get(system).getClient(typeKey.name());
     CompletionStage<Done> done =
-        client.setShardLocation("shard-id-1", new Address("pekko", "system", "127.0.0.1", 2552));
+        client.setShardLocation("shard-id-1", new Address("pekko", "system", "127.0.0.1", 7355));
     // #client
 
   }

--- a/cluster-sharding-typed/src/test/scala/docs/org/apache/pekko/cluster/sharding/typed/ExternalShardAllocationCompileOnlySpec.scala
+++ b/cluster-sharding-typed/src/test/scala/docs/org/apache/pekko/cluster/sharding/typed/ExternalShardAllocationCompileOnlySpec.scala
@@ -46,7 +46,7 @@ class ExternalShardAllocationCompileOnlySpec {
 
   // #client
   val client: ExternalShardAllocationClient = ExternalShardAllocation(system).clientFor(TypeKey.name)
-  val done: Future[Done] = client.updateShardLocation("shard-id-1", Address("pekko", "system", "127.0.0.1", 2552))
+  val done: Future[Done] = client.updateShardLocation("shard-id-1", Address("pekko", "system", "127.0.0.1", 7355))
   // #client
 
 }

--- a/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/protobuf/ClusterShardingMessageSerializerSpec.scala
+++ b/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/protobuf/ClusterShardingMessageSerializerSpec.scala
@@ -121,15 +121,15 @@ class ClusterShardingMessageSerializerSpec extends PekkoSpec {
     "be able to serialize GetCurrentRegions" in {
       checkSerialization(ShardRegion.GetCurrentRegions)
       checkSerialization(
-        ShardRegion.CurrentRegions(Set(Address("pekko", "sys", "a", 2552), Address("pekko", "sys", "b", 2552))))
+        ShardRegion.CurrentRegions(Set(Address("pekko", "sys", "a", 7355), Address("pekko", "sys", "b", 7355))))
     }
 
     "be able to serialize GetClusterShardingStats" in {
       checkSerialization(ShardRegion.GetClusterShardingStats(3.seconds))
       checkSerialization(
         ShardRegion.ClusterShardingStats(Map(
-          Address("pekko", "sys", "a", 2552) -> ShardRegion.ShardRegionStats(Map[ShardId, Int]("a" -> 23), Set("b")),
-          Address("pekko", "sys", "b", 2552) -> ShardRegion.ShardRegionStats(Map[ShardId, Int]("a" -> 23), Set("b")))))
+          Address("pekko", "sys", "a", 7355) -> ShardRegion.ShardRegionStats(Map[ShardId, Int]("a" -> 23), Set("b")),
+          Address("pekko", "sys", "b", 7355) -> ShardRegion.ShardRegionStats(Map[ShardId, Int]("a" -> 23), Set("b")))))
     }
   }
 }

--- a/cluster-tools/src/multi-jvm/scala/org/apache/pekko/cluster/client/ClusterClientSpec.scala
+++ b/cluster-tools/src/multi-jvm/scala/org/apache/pekko/cluster/client/ClusterClientSpec.scala
@@ -205,8 +205,8 @@ class ClusterClientSpec extends MultiNodeSpec(ClusterClientSpec) with STMultiNod
   def docOnly = { // not used, only demo
     // #initialContacts
     val initialContacts = Set(
-      ActorPath.fromString("pekko://OtherSys@host1:2552/system/receptionist"),
-      ActorPath.fromString("pekko://OtherSys@host2:2552/system/receptionist"))
+      ActorPath.fromString("pekko://OtherSys@host1:7355/system/receptionist"),
+      ActorPath.fromString("pekko://OtherSys@host2:7355/system/receptionist"))
     val settings = ClusterClientSettings(system).withInitialContacts(initialContacts)
     // #initialContacts
 

--- a/cluster-tools/src/test/java/org/apache/pekko/cluster/client/ClusterClientTest.java
+++ b/cluster-tools/src/test/java/org/apache/pekko/cluster/client/ClusterClientTest.java
@@ -41,8 +41,8 @@ public class ClusterClientTest extends JUnitSuite {
   Set<ActorPath> initialContacts() {
     return new HashSet<ActorPath>(
         Arrays.asList(
-            ActorPaths.fromString("pekko://OtherSys@host1:2552/system/receptionist"),
-            ActorPaths.fromString("pekko://OtherSys@host2:2552/system/receptionist")));
+            ActorPaths.fromString("pekko://OtherSys@host1:7355/system/receptionist"),
+            ActorPaths.fromString("pekko://OtherSys@host2:7355/system/receptionist")));
   }
   // #initialContacts
 

--- a/cluster-tools/src/test/scala/org/apache/pekko/cluster/client/protobuf/ClusterClientMessageSerializerSpec.scala
+++ b/cluster-tools/src/test/scala/org/apache/pekko/cluster/client/protobuf/ClusterClientMessageSerializerSpec.scala
@@ -35,9 +35,9 @@ class ClusterClientMessageSerializerSpec extends PekkoSpec {
 
     "be serializable" in {
       val contactPoints = Vector(
-        "pekko://system@node-1:2552/system/receptionist",
-        "pekko://system@node-2:2552/system/receptionist",
-        "pekko://system@node-3:2552/system/receptionist")
+        "pekko://system@node-1:7355/system/receptionist",
+        "pekko://system@node-2:7355/system/receptionist",
+        "pekko://system@node-3:7355/system/receptionist")
       checkSerialization(Contacts(contactPoints))
       checkSerialization(GetContacts)
       checkSerialization(Heartbeat)

--- a/cluster-typed/src/test/java/jdocs/org/apache/pekko/cluster/typed/BasicClusterExampleTest.java
+++ b/cluster-typed/src/test/java/jdocs/org/apache/pekko/cluster/typed/BasicClusterExampleTest.java
@@ -132,7 +132,7 @@ public class BasicClusterExampleTest { // extends JUnitSuite {
     // #join-seed-nodes
     List<Address> seedNodes = new ArrayList<>();
     seedNodes.add(AddressFromURIString.parse("pekko://ClusterSystem@127.0.0.1:2551"));
-    seedNodes.add(AddressFromURIString.parse("pekko://ClusterSystem@127.0.0.1:2552"));
+    seedNodes.add(AddressFromURIString.parse("pekko://ClusterSystem@127.0.0.1:7355"));
 
     Cluster.get(system).manager().tell(new JoinSeedNodes(seedNodes));
     // #join-seed-nodes

--- a/cluster-typed/src/test/java/jdocs/org/apache/pekko/cluster/typed/BasicClusterExampleTest.java
+++ b/cluster-typed/src/test/java/jdocs/org/apache/pekko/cluster/typed/BasicClusterExampleTest.java
@@ -45,7 +45,7 @@ public class BasicClusterExampleTest { // extends JUnitSuite {
               + "  remote.artery { \n"
               + "    canonical { \n"
               + "      hostname = \"127.0.0.1\" \n"
-              + "      port = 2551 \n"
+              + "      port = 7354 \n"
               + "    } \n"
               + "  } \n"
               + "}  \n");
@@ -131,7 +131,7 @@ public class BasicClusterExampleTest { // extends JUnitSuite {
 
     // #join-seed-nodes
     List<Address> seedNodes = new ArrayList<>();
-    seedNodes.add(AddressFromURIString.parse("pekko://ClusterSystem@127.0.0.1:2551"));
+    seedNodes.add(AddressFromURIString.parse("pekko://ClusterSystem@127.0.0.1:7354"));
     seedNodes.add(AddressFromURIString.parse("pekko://ClusterSystem@127.0.0.1:7355"));
 
     Cluster.get(system).manager().tell(new JoinSeedNodes(seedNodes));

--- a/cluster-typed/src/test/scala/docs/org/apache/pekko/cluster/typed/BasicClusterExampleSpec.scala
+++ b/cluster-typed/src/test/scala/docs/org/apache/pekko/cluster/typed/BasicClusterExampleSpec.scala
@@ -53,7 +53,7 @@ pekko {
   cluster {
     seed-nodes = [
       "pekko://ClusterSystem@127.0.0.1:2551",
-      "pekko://ClusterSystem@127.0.0.1:2552"]
+      "pekko://ClusterSystem@127.0.0.1:7355"]
     
     downing-provider-class = "org.apache.pekko.cluster.sbr.SplitBrainResolverProvider"
   }
@@ -75,7 +75,7 @@ pekko {
     import pekko.cluster.typed.JoinSeedNodes
 
     val seedNodes: List[Address] =
-      List("pekko://ClusterSystem@127.0.0.1:2551", "pekko://ClusterSystem@127.0.0.1:2552").map(
+      List("pekko://ClusterSystem@127.0.0.1:2551", "pekko://ClusterSystem@127.0.0.1:7355").map(
         AddressFromURIString.parse)
     Cluster(system).manager ! JoinSeedNodes(seedNodes)
     // #join-seed-nodes

--- a/cluster-typed/src/test/scala/docs/org/apache/pekko/cluster/typed/BasicClusterExampleSpec.scala
+++ b/cluster-typed/src/test/scala/docs/org/apache/pekko/cluster/typed/BasicClusterExampleSpec.scala
@@ -46,13 +46,13 @@ pekko {
   remote.artery {
     canonical {
       hostname = "127.0.0.1"
-      port = 2551
+      port = 7354
     }
   }
 
   cluster {
     seed-nodes = [
-      "pekko://ClusterSystem@127.0.0.1:2551",
+      "pekko://ClusterSystem@127.0.0.1:7354",
       "pekko://ClusterSystem@127.0.0.1:7355"]
     
     downing-provider-class = "org.apache.pekko.cluster.sbr.SplitBrainResolverProvider"
@@ -75,7 +75,7 @@ pekko {
     import pekko.cluster.typed.JoinSeedNodes
 
     val seedNodes: List[Address] =
-      List("pekko://ClusterSystem@127.0.0.1:2551", "pekko://ClusterSystem@127.0.0.1:7355").map(
+      List("pekko://ClusterSystem@127.0.0.1:7354", "pekko://ClusterSystem@127.0.0.1:7355").map(
         AddressFromURIString.parse)
     Cluster(system).manager ! JoinSeedNodes(seedNodes)
     // #join-seed-nodes
@@ -163,7 +163,7 @@ pekko {
   remote.artery {
     canonical {
       hostname = "127.0.0.1"
-      port = 2551
+      port = 7354
     }
   }
 }

--- a/cluster/jmx-client/pekko-cluster
+++ b/cluster/jmx-client/pekko-cluster
@@ -217,10 +217,10 @@ do
         printf "Where the <node-url> should be on the format of 'pekko.tcp://actor-system-name@hostname:port'\n"
         printf "\n"
         printf "Examples: $0 localhost 9999 is-available\n"
-        printf "          $0 localhost 9999 join pekko.tcp://MySystem@darkstar:2552\n"
+        printf "          $0 localhost 9999 join pekko.tcp://MySystem@darkstar:7355\n"
         printf "          $0 localhost 9999 cluster-status\n"
         printf "          $0 localhost 9999 -p 2551 is-available\n"
-        printf "          $0 localhost 9999 -p 2551 join pekko.tcp://MySystem@darkstar:2552\n"
+        printf "          $0 localhost 9999 -p 2551 join pekko.tcp://MySystem@darkstar:7355\n"
         printf "          $0 localhost 9999 -p 2551 cluster-status\n"
         exit 1
         ;;

--- a/cluster/jmx-client/pekko-cluster
+++ b/cluster/jmx-client/pekko-cluster
@@ -219,9 +219,9 @@ do
         printf "Examples: $0 localhost 9999 is-available\n"
         printf "          $0 localhost 9999 join pekko.tcp://MySystem@darkstar:7355\n"
         printf "          $0 localhost 9999 cluster-status\n"
-        printf "          $0 localhost 9999 -p 2551 is-available\n"
-        printf "          $0 localhost 9999 -p 2551 join pekko.tcp://MySystem@darkstar:7355\n"
-        printf "          $0 localhost 9999 -p 2551 cluster-status\n"
+        printf "          $0 localhost 9999 -p 7354 is-available\n"
+        printf "          $0 localhost 9999 -p 7354 join pekko.tcp://MySystem@darkstar:7355\n"
+        printf "          $0 localhost 9999 -p 7354 cluster-status\n"
         exit 1
         ;;
 esac

--- a/cluster/src/main/scala/org/apache/pekko/cluster/ClusterJmx.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/ClusterJmx.scala
@@ -49,10 +49,10 @@ trait ClusterNodeMBean {
    * JSON format of the status of all nodes in the cluster as follows:
    * {{{
    * {
-   *   "self-address": "pekko://system@host1:2552",
+   *   "self-address": "pekko://system@host1:7355",
    *   "members": [
    *     {
-   *       "address": "pekko://system@host1:2552",
+   *       "address": "pekko://system@host1:7355",
    *       "status": "Up",
    *       "app-version": "1.0.0",
    *       "roles": [
@@ -60,7 +60,7 @@ trait ClusterNodeMBean {
    *       ]
    *     },
    *     {
-   *       "address": "pekko://system@host2:2552",
+   *       "address": "pekko://system@host2:7355",
    *       "status": "Up",
    *       "app-version": "1.0.0",
    *       "roles": [
@@ -68,7 +68,7 @@ trait ClusterNodeMBean {
    *       ]
    *     },
    *     {
-   *       "address": "pekko://system@host3:2552",
+   *       "address": "pekko://system@host3:7355",
    *       "status": "Down",
    *       "app-version": "1.0.0",
    *       "roles": [
@@ -76,7 +76,7 @@ trait ClusterNodeMBean {
    *       ]
    *     },
    *     {
-   *       "address": "pekko://system@host4:2552",
+   *       "address": "pekko://system@host4:7355",
    *       "status": "Joining",
    *       "app-version": "1.1.0",
    *       "roles": [
@@ -86,17 +86,17 @@ trait ClusterNodeMBean {
    *   ],
    *   "unreachable": [
    *     {
-   *       "node": "pekko://system@host2:2552",
+   *       "node": "pekko://system@host2:7355",
    *       "observed-by": [
-   *         "pekko://system@host1:2552",
-   *         "pekko://system@host3:2552"
+   *         "pekko://system@host1:7355",
+   *         "pekko://system@host3:7355"
    *       ]
    *     },
    *     {
-   *       "node": "pekko://system@host3:2552",
+   *       "node": "pekko://system@host3:7355",
    *       "observed-by": [
-   *         "pekko://system@host1:2552",
-   *         "pekko://system@host2:2552"
+   *         "pekko://system@host1:7355",
+   *         "pekko://system@host2:7355"
    *       ]
    *     }
    *   ]

--- a/cluster/src/test/scala/org/apache/pekko/cluster/ClusterDomainEventPublisherSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/ClusterDomainEventPublisherSpec.scala
@@ -52,18 +52,18 @@ class ClusterDomainEventPublisherSpec
 
   final val OtherDataCenter = "dc2"
 
-  val aUp = TestMember(Address(protocol, "sys", "a", 2552), Up)
+  val aUp = TestMember(Address(protocol, "sys", "a", 7355), Up)
   val aLeaving = aUp.copy(status = Leaving)
   val aExiting = aLeaving.copy(status = Exiting)
   val aRemoved = aExiting.copy(status = Removed)
-  val bExiting = TestMember(Address(protocol, "sys", "b", 2552), Exiting)
+  val bExiting = TestMember(Address(protocol, "sys", "b", 7355), Exiting)
   val bRemoved = bExiting.copy(status = Removed)
-  val cJoining = TestMember(Address(protocol, "sys", "c", 2552), Joining, Set("GRP"))
+  val cJoining = TestMember(Address(protocol, "sys", "c", 7355), Joining, Set("GRP"))
   val cUp = cJoining.copy(status = Up)
   val cRemoved = cUp.copy(status = Removed)
   val a51Up = TestMember(Address(protocol, "sys", "a", 2551), Up)
-  val dUp = TestMember(Address(protocol, "sys", "d", 2552), Up, Set("GRP"))
-  val eUp = TestMember(Address(protocol, "sys", "e", 2552), Up, Set("GRP"), OtherDataCenter)
+  val dUp = TestMember(Address(protocol, "sys", "d", 7355), Up, Set("GRP"))
+  val eUp = TestMember(Address(protocol, "sys", "e", 7355), Up, Set("GRP"), OtherDataCenter)
 
   private def state(gossip: Gossip, self: UniqueAddress) =
     MembershipState(gossip, self, DefaultDataCenter, crossDcConnections = 5)

--- a/cluster/src/test/scala/org/apache/pekko/cluster/ClusterDomainEventPublisherSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/ClusterDomainEventPublisherSpec.scala
@@ -61,7 +61,7 @@ class ClusterDomainEventPublisherSpec
   val cJoining = TestMember(Address(protocol, "sys", "c", 7355), Joining, Set("GRP"))
   val cUp = cJoining.copy(status = Up)
   val cRemoved = cUp.copy(status = Removed)
-  val a51Up = TestMember(Address(protocol, "sys", "a", 2551), Up)
+  val a51Up = TestMember(Address(protocol, "sys", "a", 7354), Up)
   val dUp = TestMember(Address(protocol, "sys", "d", 7355), Up, Set("GRP"))
   val eUp = TestMember(Address(protocol, "sys", "e", 7355), Up, Set("GRP"), OtherDataCenter)
 

--- a/cluster/src/test/scala/org/apache/pekko/cluster/ClusterDomainEventSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/ClusterDomainEventSpec.scala
@@ -25,25 +25,25 @@ class ClusterDomainEventSpec extends AnyWordSpec with Matchers with BeforeAndAft
   import MemberStatus._
 
   val aRoles = Set("AA", "AB")
-  val aJoining = TestMember(Address("pekko", "sys", "a", 2552), Joining, aRoles)
-  val aUp = TestMember(Address("pekko", "sys", "a", 2552), Up, aRoles)
-  val aRemoved = TestMember(Address("pekko", "sys", "a", 2552), Removed, aRoles)
+  val aJoining = TestMember(Address("pekko", "sys", "a", 7355), Joining, aRoles)
+  val aUp = TestMember(Address("pekko", "sys", "a", 7355), Up, aRoles)
+  val aRemoved = TestMember(Address("pekko", "sys", "a", 7355), Removed, aRoles)
   val bRoles = Set("AB", "BB")
-  val bUp = TestMember(Address("pekko", "sys", "b", 2552), Up, bRoles)
-  val bDown = TestMember(Address("pekko", "sys", "b", 2552), Down, bRoles)
-  val bRemoved = TestMember(Address("pekko", "sys", "b", 2552), Removed, bRoles)
+  val bUp = TestMember(Address("pekko", "sys", "b", 7355), Up, bRoles)
+  val bDown = TestMember(Address("pekko", "sys", "b", 7355), Down, bRoles)
+  val bRemoved = TestMember(Address("pekko", "sys", "b", 7355), Removed, bRoles)
   val cRoles = Set.empty[String]
-  val cUp = TestMember(Address("pekko", "sys", "c", 2552), Up, cRoles)
-  val cLeaving = TestMember(Address("pekko", "sys", "c", 2552), Leaving, cRoles)
+  val cUp = TestMember(Address("pekko", "sys", "c", 7355), Up, cRoles)
+  val cLeaving = TestMember(Address("pekko", "sys", "c", 7355), Leaving, cRoles)
   val dRoles = Set("DD", "DE")
-  val dLeaving = TestMember(Address("pekko", "sys", "d", 2552), Leaving, dRoles)
-  val dExiting = TestMember(Address("pekko", "sys", "d", 2552), Exiting, dRoles)
-  val dRemoved = TestMember(Address("pekko", "sys", "d", 2552), Removed, dRoles)
+  val dLeaving = TestMember(Address("pekko", "sys", "d", 7355), Leaving, dRoles)
+  val dExiting = TestMember(Address("pekko", "sys", "d", 7355), Exiting, dRoles)
+  val dRemoved = TestMember(Address("pekko", "sys", "d", 7355), Removed, dRoles)
   val eRoles = Set("EE", "DE")
-  val eJoining = TestMember(Address("pekko", "sys", "e", 2552), Joining, eRoles)
-  val eUp = TestMember(Address("pekko", "sys", "e", 2552), Up, eRoles)
-  val eDown = TestMember(Address("pekko", "sys", "e", 2552), Down, eRoles)
-  val selfDummyAddress = UniqueAddress(Address("pekko", "sys", "selfDummy", 2552), 17L)
+  val eJoining = TestMember(Address("pekko", "sys", "e", 7355), Joining, eRoles)
+  val eUp = TestMember(Address("pekko", "sys", "e", 7355), Up, eRoles)
+  val eDown = TestMember(Address("pekko", "sys", "e", 7355), Down, eRoles)
+  val selfDummyAddress = UniqueAddress(Address("pekko", "sys", "selfDummy", 7355), 17L)
 
   private val originalClusterAssert = sys.props.get("pekko.cluster.assert").getOrElse("false")
   override protected def beforeAll(): Unit = {
@@ -109,12 +109,12 @@ class ClusterDomainEventSpec extends AnyWordSpec with Matchers with BeforeAndAft
     }
 
     "be produced for reachability observations between data centers" in {
-      val dc2AMemberUp = TestMember(Address("pekko", "sys", "dc2A", 2552), Up, Set.empty[String], "dc2")
-      val dc2AMemberDown = TestMember(Address("pekko", "sys", "dc2A", 2552), Down, Set.empty[String], "dc2")
-      val dc2BMemberUp = TestMember(Address("pekko", "sys", "dc2B", 2552), Up, Set.empty[String], "dc2")
+      val dc2AMemberUp = TestMember(Address("pekko", "sys", "dc2A", 7355), Up, Set.empty[String], "dc2")
+      val dc2AMemberDown = TestMember(Address("pekko", "sys", "dc2A", 7355), Down, Set.empty[String], "dc2")
+      val dc2BMemberUp = TestMember(Address("pekko", "sys", "dc2B", 7355), Up, Set.empty[String], "dc2")
 
-      val dc3AMemberUp = TestMember(Address("pekko", "sys", "dc3A", 2552), Up, Set.empty[String], "dc3")
-      val dc3BMemberUp = TestMember(Address("pekko", "sys", "dc3B", 2552), Up, Set.empty[String], "dc3")
+      val dc3AMemberUp = TestMember(Address("pekko", "sys", "dc3A", 7355), Up, Set.empty[String], "dc3")
+      val dc3BMemberUp = TestMember(Address("pekko", "sys", "dc3B", 7355), Up, Set.empty[String], "dc3")
 
       val reachability1 = Reachability.empty
       val g1 = Gossip(
@@ -146,8 +146,8 @@ class ClusterDomainEventSpec extends AnyWordSpec with Matchers with BeforeAndAft
     }
 
     "not be produced for same reachability observations between data centers" in {
-      val dc2AMemberUp = TestMember(Address("pekko", "sys", "dc2A", 2552), Up, Set.empty[String], "dc2")
-      val dc2AMemberDown = TestMember(Address("pekko", "sys", "dc2A", 2552), Down, Set.empty[String], "dc2")
+      val dc2AMemberUp = TestMember(Address("pekko", "sys", "dc2A", 7355), Up, Set.empty[String], "dc2")
+      val dc2AMemberDown = TestMember(Address("pekko", "sys", "dc2A", 7355), Down, Set.empty[String], "dc2")
 
       val reachability1 = Reachability.empty
       val g1 = Gossip(members = SortedSet(aUp, dc2AMemberUp), overview = GossipOverview(reachability = reachability1))
@@ -181,9 +181,9 @@ class ClusterDomainEventSpec extends AnyWordSpec with Matchers with BeforeAndAft
       // - empty
       // - B --unreachable--> C
 
-      val dc1MemberA = TestMember(Address("pekko", "sys", "dc2A", 2552), Up, Set.empty[String], "dc2")
-      val dc1MemberB = TestMember(Address("pekko", "sys", "dc2B", 2552), Up, Set.empty[String], "dc2")
-      val dc2MemberC = TestMember(Address("pekko", "sys", "dc3A", 2552), Up, Set.empty[String], "dc3")
+      val dc1MemberA = TestMember(Address("pekko", "sys", "dc2A", 7355), Up, Set.empty[String], "dc2")
+      val dc1MemberB = TestMember(Address("pekko", "sys", "dc2B", 7355), Up, Set.empty[String], "dc2")
+      val dc2MemberC = TestMember(Address("pekko", "sys", "dc3A", 7355), Up, Set.empty[String], "dc3")
 
       val members = SortedSet(dc1MemberA, dc1MemberB, dc2MemberC)
 

--- a/cluster/src/test/scala/org/apache/pekko/cluster/ClusterHeartbeatSenderStateSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/ClusterHeartbeatSenderStateSpec.scala
@@ -52,11 +52,11 @@ object ClusterHeartbeatSenderStateSpec {
 class ClusterHeartbeatSenderStateSpec extends AnyWordSpec with Matchers {
   import ClusterHeartbeatSenderStateSpec._
 
-  val aa = UniqueAddress(Address("pekko", "sys", "aa", 2552), 1L)
-  val bb = UniqueAddress(Address("pekko", "sys", "bb", 2552), 2L)
-  val cc = UniqueAddress(Address("pekko", "sys", "cc", 2552), 3L)
-  val dd = UniqueAddress(Address("pekko", "sys", "dd", 2552), 4L)
-  val ee = UniqueAddress(Address("pekko", "sys", "ee", 2552), 5L)
+  val aa = UniqueAddress(Address("pekko", "sys", "aa", 7355), 1L)
+  val bb = UniqueAddress(Address("pekko", "sys", "bb", 7355), 2L)
+  val cc = UniqueAddress(Address("pekko", "sys", "cc", 7355), 3L)
+  val dd = UniqueAddress(Address("pekko", "sys", "dd", 7355), 4L)
+  val ee = UniqueAddress(Address("pekko", "sys", "ee", 7355), 5L)
 
   private def emptyState: ClusterHeartbeatSenderState = emptyState(aa)
 
@@ -164,7 +164,7 @@ class ClusterHeartbeatSenderStateSpec extends AnyWordSpec with Matchers {
     "behave correctly for random operations" in {
       val rnd = ThreadLocalRandom.current
       val nodes =
-        (1 to rnd.nextInt(10, 200)).map(n => UniqueAddress(Address("pekko", "sys", "n" + n, 2552), n.toLong)).toVector
+        (1 to rnd.nextInt(10, 200)).map(n => UniqueAddress(Address("pekko", "sys", "n" + n, 7355), n.toLong)).toVector
       def rndNode() = nodes(rnd.nextInt(0, nodes.size))
       val selfUniqueAddress = rndNode()
       var state = emptyState(selfUniqueAddress)

--- a/cluster/src/test/scala/org/apache/pekko/cluster/ClusterSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/ClusterSpec.scala
@@ -358,7 +358,7 @@ class ClusterSpec extends PekkoSpec(ClusterSpec.config) with ImplicitSender {
           """).withFallback(ConfigFactory.parseString(ClusterSpec.config))
 
       val sys1 = ActorSystem("ClusterSpec4", getConfig(7355))
-      val sys2 = ActorSystem("ClusterSpec4", getConfig(2553))
+      val sys2 = ActorSystem("ClusterSpec4", getConfig(7356))
 
       try {
         Cluster(sys1)
@@ -369,7 +369,7 @@ class ClusterSpec extends PekkoSpec(ClusterSpec.config) with ImplicitSender {
         info1.getAttributes.length should be > 0
         info1.getOperations.length should be > 0
 
-        val name2 = new ObjectName(s"pekko:type=Cluster,port=2553")
+        val name2 = new ObjectName(s"pekko:type=Cluster,port=7356")
         val info2 = ManagementFactory.getPlatformMBeanServer.getMBeanInfo(name2)
         info2.getAttributes.length should be > 0
         info2.getOperations.length should be > 0

--- a/cluster/src/test/scala/org/apache/pekko/cluster/ClusterSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/ClusterSpec.scala
@@ -357,14 +357,14 @@ class ClusterSpec extends PekkoSpec(ClusterSpec.config) with ImplicitSender {
              pekko.remote.artery.canonical.port = ${port}
           """).withFallback(ConfigFactory.parseString(ClusterSpec.config))
 
-      val sys1 = ActorSystem("ClusterSpec4", getConfig(2552))
+      val sys1 = ActorSystem("ClusterSpec4", getConfig(7355))
       val sys2 = ActorSystem("ClusterSpec4", getConfig(2553))
 
       try {
         Cluster(sys1)
         Cluster(sys2)
 
-        val name1 = new ObjectName(s"pekko:type=Cluster,port=2552")
+        val name1 = new ObjectName(s"pekko:type=Cluster,port=7355")
         val info1 = ManagementFactory.getPlatformMBeanServer.getMBeanInfo(name1)
         info1.getAttributes.length should be > 0
         info1.getOperations.length should be > 0

--- a/cluster/src/test/scala/org/apache/pekko/cluster/GossipSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/GossipSpec.scala
@@ -27,23 +27,23 @@ class GossipSpec extends AnyWordSpec with Matchers {
 
   import MemberStatus._
 
-  val a1 = TestMember(Address("pekko", "sys", "a", 2552), Up)
+  val a1 = TestMember(Address("pekko", "sys", "a", 7355), Up)
   val a2 = TestMember(a1.address, Joining)
-  val b1 = TestMember(Address("pekko", "sys", "b", 2552), Up)
+  val b1 = TestMember(Address("pekko", "sys", "b", 7355), Up)
   val b2 = TestMember(b1.address, Removed)
-  val c1 = TestMember(Address("pekko", "sys", "c", 2552), Leaving)
+  val c1 = TestMember(Address("pekko", "sys", "c", 7355), Leaving)
   val c2 = TestMember(c1.address, Up)
   val c3 = TestMember(c1.address, Exiting)
-  val d1 = TestMember(Address("pekko", "sys", "d", 2552), Leaving)
-  val e1 = TestMember(Address("pekko", "sys", "e", 2552), Joining)
+  val d1 = TestMember(Address("pekko", "sys", "d", 7355), Leaving)
+  val e1 = TestMember(Address("pekko", "sys", "e", 7355), Joining)
   val e2 = TestMember(e1.address, Up)
   val e3 = TestMember(e1.address, Down)
-  val f1 = TestMember(Address("pekko", "sys", "f", 2552), Joining)
+  val f1 = TestMember(Address("pekko", "sys", "f", 7355), Joining)
 
-  val dc1a1 = TestMember(Address("pekko", "sys", "a", 2552), Up, Set.empty, dataCenter = "dc1")
-  val dc1b1 = TestMember(Address("pekko", "sys", "b", 2552), Up, Set.empty, dataCenter = "dc1")
-  val dc2c1 = TestMember(Address("pekko", "sys", "c", 2552), Up, Set.empty, dataCenter = "dc2")
-  val dc2d1 = TestMember(Address("pekko", "sys", "d", 2552), Up, Set.empty, dataCenter = "dc2")
+  val dc1a1 = TestMember(Address("pekko", "sys", "a", 7355), Up, Set.empty, dataCenter = "dc1")
+  val dc1b1 = TestMember(Address("pekko", "sys", "b", 7355), Up, Set.empty, dataCenter = "dc1")
+  val dc2c1 = TestMember(Address("pekko", "sys", "c", 7355), Up, Set.empty, dataCenter = "dc2")
+  val dc2d1 = TestMember(Address("pekko", "sys", "d", 7355), Up, Set.empty, dataCenter = "dc2")
   val dc2d2 = TestMember(dc2d1.address, status = Down, roles = Set.empty, dataCenter = dc2d1.dataCenter)
   // restarted with another uid
   val dc2d3 =
@@ -533,7 +533,7 @@ class GossipSpec extends AnyWordSpec with Matchers {
     }
 
     "update members" in {
-      val joining = TestMember(Address("pekko", "sys", "d", 2552), Joining, Set.empty, dataCenter = "dc2")
+      val joining = TestMember(Address("pekko", "sys", "d", 7355), Joining, Set.empty, dataCenter = "dc2")
       val g = Gossip(members = SortedSet(dc1a1, joining))
 
       g.member(joining.uniqueAddress).status should ===(Joining)

--- a/cluster/src/test/scala/org/apache/pekko/cluster/GossipTargetSelectorSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/GossipTargetSelectorSpec.scala
@@ -25,17 +25,17 @@ import pekko.cluster.MemberStatus.Up
 
 class GossipTargetSelectorSpec extends AnyWordSpec with Matchers {
 
-  val aDc1 = TestMember(Address("pekko", "sys", "a", 2552), Up, Set.empty, dataCenter = "dc1")
-  val bDc1 = TestMember(Address("pekko", "sys", "b", 2552), Up, Set.empty, dataCenter = "dc1")
-  val cDc1 = TestMember(Address("pekko", "sys", "c", 2552), Up, Set.empty, dataCenter = "dc1")
+  val aDc1 = TestMember(Address("pekko", "sys", "a", 7355), Up, Set.empty, dataCenter = "dc1")
+  val bDc1 = TestMember(Address("pekko", "sys", "b", 7355), Up, Set.empty, dataCenter = "dc1")
+  val cDc1 = TestMember(Address("pekko", "sys", "c", 7355), Up, Set.empty, dataCenter = "dc1")
 
-  val eDc2 = TestMember(Address("pekko", "sys", "e", 2552), Up, Set.empty, dataCenter = "dc2")
-  val fDc2 = TestMember(Address("pekko", "sys", "f", 2552), Up, Set.empty, dataCenter = "dc2")
+  val eDc2 = TestMember(Address("pekko", "sys", "e", 7355), Up, Set.empty, dataCenter = "dc2")
+  val fDc2 = TestMember(Address("pekko", "sys", "f", 7355), Up, Set.empty, dataCenter = "dc2")
 
-  val gDc3 = TestMember(Address("pekko", "sys", "g", 2552), Up, Set.empty, dataCenter = "dc3")
-  val hDc3 = TestMember(Address("pekko", "sys", "h", 2552), Up, Set.empty, dataCenter = "dc3")
+  val gDc3 = TestMember(Address("pekko", "sys", "g", 7355), Up, Set.empty, dataCenter = "dc3")
+  val hDc3 = TestMember(Address("pekko", "sys", "h", 7355), Up, Set.empty, dataCenter = "dc3")
 
-  val iDc4 = TestMember(Address("pekko", "sys", "i", 2552), Up, Set.empty, dataCenter = "dc4")
+  val iDc4 = TestMember(Address("pekko", "sys", "i", 7355), Up, Set.empty, dataCenter = "dc4")
 
   val defaultSelector =
     new GossipTargetSelector(reduceGossipDifferentViewProbability = 400, crossDcGossipProbability = 0.2)

--- a/cluster/src/test/scala/org/apache/pekko/cluster/HeartbeatNodeRingPerfSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/HeartbeatNodeRingPerfSpec.scala
@@ -26,7 +26,7 @@ class HeartbeatNodeRingPerfSpec extends AnyWordSpec with Matchers {
     sys.props.get("org.apache.pekko.cluster.HeartbeatNodeRingPerfSpec.iterations").getOrElse("1000").toInt
 
   def createHeartbeatNodeRingOfSize(size: Int): HeartbeatNodeRing = {
-    val nodes = (1 to size).map(n => UniqueAddress(Address("pekko", "sys", "node-" + n, 2552), n.toLong))
+    val nodes = (1 to size).map(n => UniqueAddress(Address("pekko", "sys", "node-" + n, 7355), n.toLong))
     val selfAddress = nodes(size / 2)
     HeartbeatNodeRing(selfAddress, nodes.toSet, Set.empty, 5)
   }

--- a/cluster/src/test/scala/org/apache/pekko/cluster/HeartbeatNodeRingSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/HeartbeatNodeRingSpec.scala
@@ -20,12 +20,12 @@ import org.apache.pekko.actor.Address
 
 class HeartbeatNodeRingSpec extends AnyWordSpec with Matchers {
 
-  val aa = UniqueAddress(Address("pekko", "sys", "aa", 2552), 1L)
-  val bb = UniqueAddress(Address("pekko", "sys", "bb", 2552), 2L)
-  val cc = UniqueAddress(Address("pekko", "sys", "cc", 2552), 3L)
-  val dd = UniqueAddress(Address("pekko", "sys", "dd", 2552), 4L)
-  val ee = UniqueAddress(Address("pekko", "sys", "ee", 2552), 5L)
-  val ff = UniqueAddress(Address("pekko", "sys", "ff", 2552), 6L)
+  val aa = UniqueAddress(Address("pekko", "sys", "aa", 7355), 1L)
+  val bb = UniqueAddress(Address("pekko", "sys", "bb", 7355), 2L)
+  val cc = UniqueAddress(Address("pekko", "sys", "cc", 7355), 3L)
+  val dd = UniqueAddress(Address("pekko", "sys", "dd", 7355), 4L)
+  val ee = UniqueAddress(Address("pekko", "sys", "ee", 7355), 5L)
+  val ff = UniqueAddress(Address("pekko", "sys", "ff", 7355), 6L)
 
   val nodes = Set(aa, bb, cc, dd, ee, ff)
 

--- a/cluster/src/test/scala/org/apache/pekko/cluster/MembershipStateSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/MembershipStateSpec.scala
@@ -24,18 +24,18 @@ import pekko.cluster.MemberStatus.Up
 
 class MembershipStateSpec extends AnyWordSpec with Matchers {
   // DC-a is in reverse age order
-  val a1 = TestMember(Address("pekko", "sys", "a4", 2552), Up, 1, "dc-a")
-  val a2 = TestMember(Address("pekko", "sys", "a3", 2552), Up, 2, "dc-a")
-  val a3 = TestMember(Address("pekko", "sys", "a2", 2552), Up, 3, "dc-a")
-  val a4 = TestMember(Address("pekko", "sys", "a1", 2552), Up, 4, "dc-a")
+  val a1 = TestMember(Address("pekko", "sys", "a4", 7355), Up, 1, "dc-a")
+  val a2 = TestMember(Address("pekko", "sys", "a3", 7355), Up, 2, "dc-a")
+  val a3 = TestMember(Address("pekko", "sys", "a2", 7355), Up, 3, "dc-a")
+  val a4 = TestMember(Address("pekko", "sys", "a1", 7355), Up, 4, "dc-a")
 
   // DC-b it is the first and the last that are the oldest
-  val b1 = TestMember(Address("pekko", "sys", "b3", 2552), Up, 1, "dc-b")
-  val b3 = TestMember(Address("pekko", "sys", "b2", 2552), Up, 3, "dc-b")
+  val b1 = TestMember(Address("pekko", "sys", "b3", 7355), Up, 1, "dc-b")
+  val b3 = TestMember(Address("pekko", "sys", "b2", 7355), Up, 3, "dc-b")
   // Won't be replaced by b3
-  val b2 = TestMember(Address("pekko", "sys", "b1", 2552), Up, 2, "dc-b")
+  val b2 = TestMember(Address("pekko", "sys", "b1", 7355), Up, 2, "dc-b")
   // for the case that we don't replace it ever
-  val bOldest = TestMember(Address("pekko", "sys", "b0", 2552), Up, 0, "dc-b")
+  val bOldest = TestMember(Address("pekko", "sys", "b0", 7355), Up, 0, "dc-b")
 
   "Membership state" must {
     "sort by upNumber for oldest top members" in {
@@ -64,43 +64,43 @@ class MembershipStateSpec extends AnyWordSpec with Matchers {
 
     "find two oldest per role as targets for Exiting change" in {
       val a5 = TestMember(
-        Address("pekko", "sys", "a5", 2552),
+        Address("pekko", "sys", "a5", 7355),
         MemberStatus.Exiting,
         roles = Set("role1", "role2"),
         upNumber = 5,
         dataCenter = "dc-a")
       val a6 = TestMember(
-        Address("pekko", "sys", "a6", 2552),
+        Address("pekko", "sys", "a6", 7355),
         MemberStatus.Exiting,
         roles = Set("role1", "role3"),
         upNumber = 6,
         dataCenter = "dc-a")
       val a7 = TestMember(
-        Address("pekko", "sys", "a7", 2552),
+        Address("pekko", "sys", "a7", 7355),
         MemberStatus.Exiting,
         roles = Set("role1"),
         upNumber = 7,
         dataCenter = "dc-a")
       val a8 = TestMember(
-        Address("pekko", "sys", "a8", 2552),
+        Address("pekko", "sys", "a8", 7355),
         MemberStatus.Exiting,
         roles = Set("role1"),
         upNumber = 8,
         dataCenter = "dc-a")
       val a9 = TestMember(
-        Address("pekko", "sys", "a9", 2552),
+        Address("pekko", "sys", "a9", 7355),
         MemberStatus.Exiting,
         roles = Set("role2"),
         upNumber = 9,
         dataCenter = "dc-a")
       val b5 = TestMember(
-        Address("pekko", "sys", "b5", 2552),
+        Address("pekko", "sys", "b5", 7355),
         MemberStatus.Exiting,
         roles = Set("role1"),
         upNumber = 5,
         dataCenter = "dc-b")
       val b6 = TestMember(
-        Address("pekko", "sys", "b6", 2552),
+        Address("pekko", "sys", "b6", 7355),
         MemberStatus.Exiting,
         roles = Set("role2"),
         upNumber = 6,

--- a/cluster/src/test/scala/org/apache/pekko/cluster/ReachabilityPerfSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/ReachabilityPerfSpec.scala
@@ -25,8 +25,8 @@ class ReachabilityPerfSpec extends AnyWordSpec with Matchers {
   // increase for serious measurements
   val iterations = sys.props.get("org.apache.pekko.cluster.ReachabilityPerfSpec.iterations").getOrElse("100").toInt
 
-  val address = Address("pekko", "sys", "a", 2552)
-  val node = Address("pekko", "sys", "a", 2552)
+  val address = Address("pekko", "sys", "a", 7355)
+  val node = Address("pekko", "sys", "a", 7355)
 
   private def createReachabilityOfSize(base: Reachability, size: Int): Reachability =
     (1 to size).foldLeft(base) {

--- a/cluster/src/test/scala/org/apache/pekko/cluster/ReachabilitySpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/ReachabilitySpec.scala
@@ -22,11 +22,11 @@ class ReachabilitySpec extends AnyWordSpec with Matchers {
 
   import Reachability.{ Reachable, Record, Terminated, Unreachable }
 
-  val nodeA = UniqueAddress(Address("pekko", "sys", "a", 2552), 1L)
-  val nodeB = UniqueAddress(Address("pekko", "sys", "b", 2552), 2L)
-  val nodeC = UniqueAddress(Address("pekko", "sys", "c", 2552), 3L)
-  val nodeD = UniqueAddress(Address("pekko", "sys", "d", 2552), 4L)
-  val nodeE = UniqueAddress(Address("pekko", "sys", "e", 2552), 5L)
+  val nodeA = UniqueAddress(Address("pekko", "sys", "a", 7355), 1L)
+  val nodeB = UniqueAddress(Address("pekko", "sys", "b", 7355), 2L)
+  val nodeC = UniqueAddress(Address("pekko", "sys", "c", 7355), 3L)
+  val nodeD = UniqueAddress(Address("pekko", "sys", "d", 7355), 4L)
+  val nodeE = UniqueAddress(Address("pekko", "sys", "e", 7355), 5L)
 
   "Reachability table" must {
 

--- a/cluster/src/test/scala/org/apache/pekko/cluster/protobuf/ClusterMessageSerializerSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/protobuf/ClusterMessageSerializerSpec.scala
@@ -81,13 +81,13 @@ class ClusterMessageSerializerSpec extends PekkoSpec("pekko.actor.provider = clu
   import MemberStatus._
 
   val a1 =
-    TestMember(Address("pekko", "sys", "a", 2552), Joining, Set.empty[String], appVersion = Version("1.0.0"))
-  val b1 = TestMember(Address("pekko", "sys", "b", 2552), Up, Set("r1"), appVersion = Version("1.1.0"))
+    TestMember(Address("pekko", "sys", "a", 7355), Joining, Set.empty[String], appVersion = Version("1.0.0"))
+  val b1 = TestMember(Address("pekko", "sys", "b", 7355), Up, Set("r1"), appVersion = Version("1.1.0"))
   val c1 =
-    TestMember(Address("pekko", "sys", "c", 2552), Leaving, Set.empty[String], "foo", appVersion = Version("1.1.0"))
-  val d1 = TestMember(Address("pekko", "sys", "d", 2552), Exiting, Set("r1"), "foo")
-  val e1 = TestMember(Address("pekko", "sys", "e", 2552), Down, Set("r3"))
-  val f1 = TestMember(Address("pekko", "sys", "f", 2552), Removed, Set("r3"), "foo")
+    TestMember(Address("pekko", "sys", "c", 7355), Leaving, Set.empty[String], "foo", appVersion = Version("1.1.0"))
+  val d1 = TestMember(Address("pekko", "sys", "d", 7355), Exiting, Set("r1"), "foo")
+  val e1 = TestMember(Address("pekko", "sys", "e", 7355), Down, Set("r3"))
+  val f1 = TestMember(Address("pekko", "sys", "f", 7355), Removed, Set("r3"), "foo")
 
   "ClusterMessages" must {
 

--- a/cluster/src/test/scala/org/apache/pekko/cluster/sbr/TestAddresses.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/sbr/TestAddresses.scala
@@ -32,7 +32,7 @@ object TestAddresses {
   val defaultDataCenter = ClusterSettings.DefaultDataCenter
   private def defaultDcRole = dcRole(defaultDataCenter)
 
-  val addressA = Address("pekko.tcp", "sys", "a", 2552)
+  val addressA = Address("pekko.tcp", "sys", "a", 7355)
   val memberA = new Member(UniqueAddress(addressA, 0L), 5, Up, Set("role3", defaultDcRole), Version.Zero)
   val memberB =
     new Member(

--- a/cluster/src/test/scala/org/apache/pekko/cluster/testkit/AutoDownSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/testkit/AutoDownSpec.scala
@@ -58,9 +58,9 @@ class AutoDownSpec extends PekkoSpec("""
     if (RARP(system).provider.remoteSettings.Artery.Enabled) "pekko"
     else "pekko.tcp"
 
-  val memberA = TestMember(Address(protocol, "sys", "a", 2552), Up)
-  val memberB = TestMember(Address(protocol, "sys", "b", 2552), Up)
-  val memberC = TestMember(Address(protocol, "sys", "c", 2552), Up)
+  val memberA = TestMember(Address(protocol, "sys", "a", 7355), Up)
+  val memberB = TestMember(Address(protocol, "sys", "b", 7355), Up)
+  val memberC = TestMember(Address(protocol, "sys", "c", 7355), Up)
 
   def autoDownActor(autoDownUnreachableAfter: FiniteDuration): ActorRef =
     system.actorOf(Props(classOf[AutoDownTestActor], memberA, autoDownUnreachableAfter, testActor))

--- a/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/protobuf/ReplicatorMessageSerializer.scala
+++ b/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/protobuf/ReplicatorMessageSerializer.scala
@@ -175,7 +175,7 @@ class ReplicatorMessageSerializer(val system: ExtendedActorSystem)
   }(system.dispatchers.internalDispatcher)
 
   private val writeAckBytes = dm.Empty.getDefaultInstance.toByteArray
-  private val dummyAddress = UniqueAddress(Address("a", "b", "c", 2552), 1L)
+  private val dummyAddress = UniqueAddress(Address("a", "b", "c", 7355), 1L)
 
   val GetManifest = "A"
   val GetSuccessManifest = "B"

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/DataEnvelopeSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/DataEnvelopeSpec.scala
@@ -24,7 +24,7 @@ import pekko.cluster.ddata.Replicator.Internal.DataEnvelope
 class DataEnvelopeSpec extends AnyWordSpec with Matchers {
   import PruningState._
 
-  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 7354), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
   val node3 = UniqueAddress(node1.address.copy(port = Some(7356)), 3L)
   val node4 = UniqueAddress(node1.address.copy(port = Some(7357)), 4L)

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/DataEnvelopeSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/DataEnvelopeSpec.scala
@@ -25,7 +25,7 @@ class DataEnvelopeSpec extends AnyWordSpec with Matchers {
   import PruningState._
 
   val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
-  val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
+  val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
   val node3 = UniqueAddress(node1.address.copy(port = Some(2553)), 3L)
   val node4 = UniqueAddress(node1.address.copy(port = Some(2554)), 4L)
   val obsoleteTimeInFuture = System.currentTimeMillis() + 3600 * 1000

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/DataEnvelopeSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/DataEnvelopeSpec.scala
@@ -26,8 +26,8 @@ class DataEnvelopeSpec extends AnyWordSpec with Matchers {
 
   val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
-  val node3 = UniqueAddress(node1.address.copy(port = Some(2553)), 3L)
-  val node4 = UniqueAddress(node1.address.copy(port = Some(2554)), 4L)
+  val node3 = UniqueAddress(node1.address.copy(port = Some(7356)), 3L)
+  val node4 = UniqueAddress(node1.address.copy(port = Some(7357)), 4L)
   val obsoleteTimeInFuture = System.currentTimeMillis() + 3600 * 1000
   val oldObsoleteTime = System.currentTimeMillis() - 3600 * 1000
 

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/GCounterSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/GCounterSpec.scala
@@ -23,7 +23,7 @@ import pekko.cluster.ddata.Replicator.Changed
 
 class GCounterSpec extends AnyWordSpec with Matchers {
   val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
-  val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
+  val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
   val node3 = UniqueAddress(node1.address.copy(port = Some(2553)), 3L)
 
   "A GCounter" must {

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/GCounterSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/GCounterSpec.scala
@@ -24,7 +24,7 @@ import pekko.cluster.ddata.Replicator.Changed
 class GCounterSpec extends AnyWordSpec with Matchers {
   val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
-  val node3 = UniqueAddress(node1.address.copy(port = Some(2553)), 3L)
+  val node3 = UniqueAddress(node1.address.copy(port = Some(7356)), 3L)
 
   "A GCounter" must {
 

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/GCounterSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/GCounterSpec.scala
@@ -22,7 +22,7 @@ import pekko.cluster.UniqueAddress
 import pekko.cluster.ddata.Replicator.Changed
 
 class GCounterSpec extends AnyWordSpec with Matchers {
-  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 7354), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
   val node3 = UniqueAddress(node1.address.copy(port = Some(7356)), 3L)
 

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/LWWMapSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/LWWMapSpec.scala
@@ -25,7 +25,7 @@ class LWWMapSpec extends AnyWordSpec with Matchers {
   import LWWRegister.defaultClock
 
   val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
-  val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
+  val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
 
   "A LWWMap" must {
 

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/LWWMapSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/LWWMapSpec.scala
@@ -24,7 +24,7 @@ import pekko.cluster.ddata.Replicator.Changed
 class LWWMapSpec extends AnyWordSpec with Matchers {
   import LWWRegister.defaultClock
 
-  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 7354), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
 
   "A LWWMap" must {

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/LWWRegisterSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/LWWRegisterSpec.scala
@@ -24,7 +24,7 @@ import pekko.cluster.ddata.Replicator.Changed
 class LWWRegisterSpec extends AnyWordSpec with Matchers {
   import LWWRegister.defaultClock
 
-  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 7354), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
 
   "A LWWRegister" must {

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/LWWRegisterSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/LWWRegisterSpec.scala
@@ -25,7 +25,7 @@ class LWWRegisterSpec extends AnyWordSpec with Matchers {
   import LWWRegister.defaultClock
 
   val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
-  val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
+  val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
 
   "A LWWRegister" must {
     "use latest of successive assignments" in {

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/LotsOfDataBot.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/LotsOfDataBot.scala
@@ -33,7 +33,7 @@ object LotsOfDataBot {
 
   def main(args: Array[String]): Unit = {
     if (args.isEmpty)
-      startup(Seq("2551", "2552", "0"))
+      startup(Seq("2551", "7355", "0"))
     else
       startup(args.toIndexedSeq)
   }
@@ -58,7 +58,7 @@ object LotsOfDataBot {
             pekko.cluster {
               seed-nodes = [
                 "pekko://ClusterSystem@127.0.0.1:2551",
-                "pekko://ClusterSystem@127.0.0.1:2552"]
+                "pekko://ClusterSystem@127.0.0.1:7355"]
 
               downing-provider-class = org.apache.pekko.cluster.testkit.AutoDowning
               testkit.auto-down-unreachable-after = 10s

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/LotsOfDataBot.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/LotsOfDataBot.scala
@@ -33,7 +33,7 @@ object LotsOfDataBot {
 
   def main(args: Array[String]): Unit = {
     if (args.isEmpty)
-      startup(Seq("2551", "7355", "0"))
+      startup(Seq("7354", "7355", "0"))
     else
       startup(args.toIndexedSeq)
   }
@@ -57,7 +57,7 @@ object LotsOfDataBot {
 
             pekko.cluster {
               seed-nodes = [
-                "pekko://ClusterSystem@127.0.0.1:2551",
+                "pekko://ClusterSystem@127.0.0.1:7354",
                 "pekko://ClusterSystem@127.0.0.1:7355"]
 
               downing-provider-class = org.apache.pekko.cluster.testkit.AutoDowning

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/ORMapSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/ORMapSpec.scala
@@ -25,7 +25,7 @@ import pekko.cluster.ddata.Replicator.Changed
 class ORMapSpec extends AnyWordSpec with Matchers {
 
   val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
-  val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
+  val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
 
   "A ORMap" must {
 

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/ORMapSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/ORMapSpec.scala
@@ -24,7 +24,7 @@ import pekko.cluster.ddata.Replicator.Changed
 
 class ORMapSpec extends AnyWordSpec with Matchers {
 
-  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 7354), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
 
   "A ORMap" must {

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/ORMultiMapSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/ORMultiMapSpec.scala
@@ -24,7 +24,7 @@ import pekko.cluster.ddata.Replicator.Changed
 class ORMultiMapSpec extends AnyWordSpec with Matchers {
 
   val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
-  val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
+  val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
 
   "A ORMultiMap" must {
 

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/ORMultiMapSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/ORMultiMapSpec.scala
@@ -23,7 +23,7 @@ import pekko.cluster.ddata.Replicator.Changed
 
 class ORMultiMapSpec extends AnyWordSpec with Matchers {
 
-  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 7354), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
 
   "A ORMultiMap" must {

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/ORSetSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/ORSetSpec.scala
@@ -26,10 +26,10 @@ import pekko.cluster.ddata.Replicator.Changed
 class ORSetSpec extends AnyWordSpec with Matchers {
 
   val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
-  val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
+  val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
   val node3 = UniqueAddress(node1.address.copy(port = Some(2553)), 3L)
 
-  val nodeA = UniqueAddress(Address("pekko", "Sys", "a", 2552), 1L)
+  val nodeA = UniqueAddress(Address("pekko", "Sys", "a", 7355), 1L)
   val nodeB = UniqueAddress(nodeA.address.copy(host = Some("b")), 2L)
   val nodeC = UniqueAddress(nodeA.address.copy(host = Some("c")), 3L)
   val nodeD = UniqueAddress(nodeA.address.copy(host = Some("d")), 4L)

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/ORSetSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/ORSetSpec.scala
@@ -27,7 +27,7 @@ class ORSetSpec extends AnyWordSpec with Matchers {
 
   val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
-  val node3 = UniqueAddress(node1.address.copy(port = Some(2553)), 3L)
+  val node3 = UniqueAddress(node1.address.copy(port = Some(7356)), 3L)
 
   val nodeA = UniqueAddress(Address("pekko", "Sys", "a", 7355), 1L)
   val nodeB = UniqueAddress(nodeA.address.copy(host = Some("b")), 2L)

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/ORSetSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/ORSetSpec.scala
@@ -25,7 +25,7 @@ import pekko.cluster.ddata.Replicator.Changed
 
 class ORSetSpec extends AnyWordSpec with Matchers {
 
-  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 7354), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
   val node3 = UniqueAddress(node1.address.copy(port = Some(7356)), 3L)
 

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/PNCounterMapSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/PNCounterMapSpec.scala
@@ -24,7 +24,7 @@ import pekko.cluster.ddata.Replicator.Changed
 class PNCounterMapSpec extends AnyWordSpec with Matchers {
 
   val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
-  val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
+  val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
 
   "A PNCounterMap" must {
 

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/PNCounterMapSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/PNCounterMapSpec.scala
@@ -23,7 +23,7 @@ import pekko.cluster.ddata.Replicator.Changed
 
 class PNCounterMapSpec extends AnyWordSpec with Matchers {
 
-  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 7354), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
 
   "A PNCounterMap" must {

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/PNCounterSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/PNCounterSpec.scala
@@ -23,7 +23,7 @@ import pekko.cluster.ddata.Replicator.Changed
 
 class PNCounterSpec extends AnyWordSpec with Matchers {
   val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
-  val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
+  val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
 
   "A PNCounter" must {
 

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/PNCounterSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/PNCounterSpec.scala
@@ -22,7 +22,7 @@ import pekko.cluster.UniqueAddress
 import pekko.cluster.ddata.Replicator.Changed
 
 class PNCounterSpec extends AnyWordSpec with Matchers {
-  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 7354), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
 
   "A PNCounter" must {

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/PruningStateSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/PruningStateSpec.scala
@@ -24,7 +24,7 @@ class PruningStateSpec extends AnyWordSpec with Matchers {
   import PruningState._
 
   val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
-  val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
+  val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
   val node3 = UniqueAddress(node1.address.copy(port = Some(2553)), 3L)
   val node4 = UniqueAddress(node1.address.copy(port = Some(2554)), 4L)
 

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/PruningStateSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/PruningStateSpec.scala
@@ -25,8 +25,8 @@ class PruningStateSpec extends AnyWordSpec with Matchers {
 
   val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
-  val node3 = UniqueAddress(node1.address.copy(port = Some(2553)), 3L)
-  val node4 = UniqueAddress(node1.address.copy(port = Some(2554)), 4L)
+  val node3 = UniqueAddress(node1.address.copy(port = Some(7356)), 3L)
+  val node4 = UniqueAddress(node1.address.copy(port = Some(7357)), 4L)
 
   "Pruning state" must {
 

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/PruningStateSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/PruningStateSpec.scala
@@ -23,7 +23,7 @@ import pekko.cluster.UniqueAddress
 class PruningStateSpec extends AnyWordSpec with Matchers {
   import PruningState._
 
-  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 7354), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
   val node3 = UniqueAddress(node1.address.copy(port = Some(7356)), 3L)
   val node4 = UniqueAddress(node1.address.copy(port = Some(7357)), 4L)

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/VersionVectorSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/VersionVectorSpec.scala
@@ -31,8 +31,8 @@ class VersionVectorSpec
 
   val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
-  val node3 = UniqueAddress(node1.address.copy(port = Some(2553)), 3L)
-  val node4 = UniqueAddress(node1.address.copy(port = Some(2554)), 4L)
+  val node3 = UniqueAddress(node1.address.copy(port = Some(7356)), 3L)
+  val node4 = UniqueAddress(node1.address.copy(port = Some(7357)), 4L)
 
   override def afterAll(): Unit = {
     shutdown()

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/VersionVectorSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/VersionVectorSpec.scala
@@ -30,7 +30,7 @@ class VersionVectorSpec
     with BeforeAndAfterAll {
 
   val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
-  val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
+  val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
   val node3 = UniqueAddress(node1.address.copy(port = Some(2553)), 3L)
   val node4 = UniqueAddress(node1.address.copy(port = Some(2554)), 4L)
 

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/VersionVectorSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/VersionVectorSpec.scala
@@ -29,7 +29,7 @@ class VersionVectorSpec
     with Matchers
     with BeforeAndAfterAll {
 
-  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("pekko", "Sys", "localhost", 7354), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(7355)), 2L)
   val node3 = UniqueAddress(node1.address.copy(port = Some(7356)), 3L)
   val node4 = UniqueAddress(node1.address.copy(port = Some(7357)), 4L)

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/WriteAggregatorSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/WriteAggregatorSpec.scala
@@ -153,10 +153,10 @@ class WriteAggregatorSpec extends PekkoSpec(s"""
     if (RARP(system).provider.remoteSettings.Artery.Enabled) "pekko"
     else "pekko.tcp"
 
-  val nodeA = UniqueAddress(Address(protocol, "Sys", "a", 2552), 17L)
-  val nodeB = UniqueAddress(Address(protocol, "Sys", "b", 2552), 17L)
-  val nodeC = UniqueAddress(Address(protocol, "Sys", "c", 2552), 17L)
-  val nodeD = UniqueAddress(Address(protocol, "Sys", "d", 2552), 17L)
+  val nodeA = UniqueAddress(Address(protocol, "Sys", "a", 7355), 17L)
+  val nodeB = UniqueAddress(Address(protocol, "Sys", "b", 7355), 17L)
+  val nodeC = UniqueAddress(Address(protocol, "Sys", "c", 7355), 17L)
+  val nodeD = UniqueAddress(Address(protocol, "Sys", "d", 7355), 17L)
   // 4 replicas + the local => 5
   val nodes = Vector(nodeA, nodeB, nodeC, nodeD)
 

--- a/docs/src/main/paradox/cluster-usage.md
+++ b/docs/src/main/paradox/cluster-usage.md
@@ -412,7 +412,7 @@ Where the <node-url> should be on the format of
   'pekko.<protocol>://<actor-system-name>@<hostname>:<port>'
 
 Examples: ./pekko-cluster localhost 9999 is-available
-          ./pekko-cluster localhost 9999 join pekko://MySystem@darkstar:2552
+          ./pekko-cluster localhost 9999 join pekko://MySystem@darkstar:7355
           ./pekko-cluster localhost 9999 cluster-status
 ```
 

--- a/docs/src/main/paradox/project/migration-guides.md
+++ b/docs/src/main/paradox/project/migration-guides.md
@@ -16,11 +16,15 @@ This is just stub documentation. It will be improved.
 * Pekko packages start with "org.apache.pekko" instead of "akka" - e.g. `import org.apache.pekko.actor` instead of `import akka.actor`
 * Where class names have "Akka" in the name, the Pekko ones have "Pekko" - e.g. PekkoException instead of AkkaException
 * Configs in `application.conf` use "pekko" prefix instead of "akka"
+* We have changed the default ports used by the pekko-remote module.
+* With @ref:[Classic Remoting](../remoting.md), Akka defaults to 2552, while Pekko defaults to 7355.
+* With @ref:[Artery Remoting](../remoting-artery.md), Akka defaults to 25520, while Pekko defaults to 17355.
 
 We are still investigating the effects of how the package name changes affect the @ref:[Persistence](../persistence.md)
 and @ref:[Cluster](../cluster-usage.md) modules.
-Data persisted with "akka-persistence" may not yet be usable with "pekko-persistence" (or vice versa).
-Akka and Pekko nodes may not be able to form a cluster or messages may not be recognised if passed between nodes
-of different types.
+
+It appears that data persisted with "akka-persistence" is usable with "pekko-persistence" (and vice versa).
+
+We currently do not expect that Akka and Pekko nodes will be able to form a cluster.
 
 We may be able to provide [Scalafix](https://scalacenter.github.io/scalafix/) scripts to help with migrations.

--- a/docs/src/main/paradox/remoting-artery.md
+++ b/docs/src/main/paradox/remoting-artery.md
@@ -58,7 +58,7 @@ pekko {
     artery {
       transport = tcp # See Selecting a transport below
       canonical.hostname = "127.0.0.1"
-      canonical.port = 73550
+      canonical.port = 17355
     }
   }
 }
@@ -189,13 +189,13 @@ In the next sections the two alternatives are described in detail.
 Scala
 :   ```
     val selection =
-      context.actorSelection("pekko://actorSystemName@10.0.0.1:73550/user/actorName")
+      context.actorSelection("pekko://actorSystemName@10.0.0.1:17355/user/actorName")
     ```
     
 Java
 :   ```
     ActorSelection selection =
-      context.actorSelection("pekko://actorSystemName@10.0.0.1:73550/user/actorName");
+      context.actorSelection("pekko://actorSystemName@10.0.0.1:17355/user/actorName");
     ```
     
 
@@ -850,7 +850,7 @@ pekko {
       canonical.port = 8000                   # external (logical) port
 
       bind.hostname = local.address # internal (bind) hostname
-      bind.port = 73550              # internal (bind) port
+      bind.port = 17355              # internal (bind) port
     }
  }
 }

--- a/docs/src/main/paradox/remoting-artery.md
+++ b/docs/src/main/paradox/remoting-artery.md
@@ -58,7 +58,7 @@ pekko {
     artery {
       transport = tcp # See Selecting a transport below
       canonical.hostname = "127.0.0.1"
-      canonical.port = 25520
+      canonical.port = 73550
     }
   }
 }
@@ -189,13 +189,13 @@ In the next sections the two alternatives are described in detail.
 Scala
 :   ```
     val selection =
-      context.actorSelection("pekko://actorSystemName@10.0.0.1:25520/user/actorName")
+      context.actorSelection("pekko://actorSystemName@10.0.0.1:73550/user/actorName")
     ```
     
 Java
 :   ```
     ActorSelection selection =
-      context.actorSelection("pekko://actorSystemName@10.0.0.1:25520/user/actorName");
+      context.actorSelection("pekko://actorSystemName@10.0.0.1:73550/user/actorName");
     ```
     
 
@@ -850,7 +850,7 @@ pekko {
       canonical.port = 8000                   # external (logical) port
 
       bind.hostname = local.address # internal (bind) hostname
-      bind.port = 25520              # internal (bind) port
+      bind.port = 73550              # internal (bind) port
     }
  }
 }

--- a/docs/src/main/paradox/remoting.md
+++ b/docs/src/main/paradox/remoting.md
@@ -190,7 +190,7 @@ pekko {
   actor {
     deployment {
       /sampleActor {
-        remote = "pekko.tcp://sampleActorSystem@127.0.0.1:2553"
+        remote = "pekko.tcp://sampleActorSystem@127.0.0.1:7356"
       }
     }
   }
@@ -200,7 +200,7 @@ pekko {
 The configuration above instructs Pekko to react when an actor with path `/sampleActor` is created, i.e.
 using @scala[`system.actorOf(Props(...), "sampleActor")`]@java[`system.actorOf(new Props(...), "sampleActor")`]. This specific actor will not be directly instantiated,
 but instead the remote daemon of the remote system will be asked to create the actor,
-which in this sample corresponds to `sampleActorSystem@127.0.0.1:2553`.
+which in this sample corresponds to `sampleActorSystem@127.0.0.1:7356`.
 
 Once you have configured the properties above you would do the following in code:
 

--- a/docs/src/main/paradox/remoting.md
+++ b/docs/src/main/paradox/remoting.md
@@ -60,7 +60,7 @@ pekko {
     enabled-transports = ["pekko.remote.classic.netty.tcp"]
     netty.tcp {
       hostname = "127.0.0.1"
-      port = 2552
+      port = 7355
     }
  }
 }
@@ -126,13 +126,13 @@ In the next sections the two alternatives are described in detail.
 Scala
 :   ```
 val selection =
-  context.actorSelection("pekko.tcp://actorSystemName@10.0.0.1:2552/user/actorName")
+  context.actorSelection("pekko.tcp://actorSystemName@10.0.0.1:7355/user/actorName")
 ```
 
 Java
 :   ```
 ActorSelection selection =
-  context.actorSelection("pekko.tcp://app@10.0.0.1:2552/user/serviceA/worker");
+  context.actorSelection("pekko.tcp://app@10.0.0.1:7355/user/serviceA/worker");
 ```
 
 As you can see from the example above the following pattern is used to find an actor on a remote node:
@@ -609,7 +609,7 @@ pekko.remote.classic.netty.tcp {
       port = 8000                   # external (logical) port
 
       bind-hostname = local.address # internal (bind) hostname
-      bind-port = 2552              # internal (bind) port
+      bind-port = 7355              # internal (bind) port
 }
 ```
 

--- a/docs/src/main/paradox/typed/cluster.md
+++ b/docs/src/main/paradox/typed/cluster.md
@@ -155,15 +155,15 @@ You can define the seed nodes in the @ref:[configuration](#configuration) file (
 
 ```
 pekko.cluster.seed-nodes = [
-  "pekko://ClusterSystem@host1:2552",
-  "pekko://ClusterSystem@host2:2552"]
+  "pekko://ClusterSystem@host1:7355",
+  "pekko://ClusterSystem@host2:7355"]
 ```
 
 This can also be defined as Java system properties when starting the JVM using the following syntax:
 
 ```
--Dpekko.cluster.seed-nodes.0=pekko://ClusterSystem@host1:2552
--Dpekko.cluster.seed-nodes.1=pekko://ClusterSystem@host2:2552
+-Dpekko.cluster.seed-nodes.0=pekko://ClusterSystem@host1:7355
+-Dpekko.cluster.seed-nodes.1=pekko://ClusterSystem@host2:7355
 ```
 
 

--- a/docs/src/test/java/jdocs/cluster/StatsSampleOneMasterMain.java
+++ b/docs/src/test/java/jdocs/cluster/StatsSampleOneMasterMain.java
@@ -28,7 +28,7 @@ public class StatsSampleOneMasterMain {
 
   public static void main(String[] args) {
     if (args.length == 0) {
-      startup(new String[] {"2551", "2552", "0"});
+      startup(new String[] {"2551", "7355", "0"});
       StatsSampleOneMasterClientMain.main(new String[0]);
     } else {
       startup(args);

--- a/docs/src/test/java/jdocs/cluster/StatsSampleOneMasterMain.java
+++ b/docs/src/test/java/jdocs/cluster/StatsSampleOneMasterMain.java
@@ -28,7 +28,7 @@ public class StatsSampleOneMasterMain {
 
   public static void main(String[] args) {
     if (args.length == 0) {
-      startup(new String[] {"2551", "7355", "0"});
+      startup(new String[] {"7354", "7355", "0"});
       StatsSampleOneMasterClientMain.main(new String[0]);
     } else {
       startup(args);

--- a/docs/src/test/java/jdocs/persistence/LambdaPersistencePluginDocTest.java
+++ b/docs/src/test/java/jdocs/persistence/LambdaPersistencePluginDocTest.java
@@ -53,7 +53,7 @@ public class LambdaPersistencePluginDocTest {
         class SharedStorageUsage extends AbstractActor {
           @Override
           public void preStart() throws Exception {
-            String path = "pekko://example@127.0.0.1:2552/user/store";
+            String path = "pekko://example@127.0.0.1:7355/user/store";
             ActorSelection selection = getContext().actorSelection(path);
             selection.tell(new Identify(1), getSelf());
           }

--- a/docs/src/test/scala/docs/config/ConfigDocSpec.scala
+++ b/docs/src/test/scala/docs/config/ConfigDocSpec.scala
@@ -78,7 +78,7 @@ class ConfigDocSpec extends AnyWordSpec with Matchers {
   
     # '/user/actorA/actorB' is a remote deployed actor
     /actorA/actorB {
-      remote = "pekko://sampleActorSystem@127.0.0.1:2553"
+      remote = "pekko://sampleActorSystem@127.0.0.1:7356"
     }
     
     # all direct children of '/user/actorC' have a dedicated dispatcher 

--- a/docs/src/test/scala/docs/persistence/PersistencePluginDocSpec.scala
+++ b/docs/src/test/scala/docs/persistence/PersistencePluginDocSpec.scala
@@ -138,7 +138,7 @@ object SharedLeveldbPluginDocSpec {
   // #shared-store-usage
   trait SharedStoreUsage extends Actor {
     override def preStart(): Unit = {
-      context.actorSelection("pekko://example@127.0.0.1:2552/user/store") ! Identify(1)
+      context.actorSelection("pekko://example@127.0.0.1:7355/user/store") ! Identify(1)
     }
 
     def receive = {

--- a/docs/src/test/scala/docs/routing/RouterDocSpec.scala
+++ b/docs/src/test/scala/docs/routing/RouterDocSpec.scala
@@ -219,7 +219,7 @@ pekko.actor.deployment {
   /parent/remotePool {
     router = round-robin-pool
     nr-of-instances = 10
-    target.nodes = ["pekko://app@10.0.0.2:2552", "pekko://app@10.0.0.3:2552"]
+    target.nodes = ["pekko://app@10.0.0.2:7355", "pekko://app@10.0.0.3:7355"]
   }
 }
 #//#config-remote-round-robin-pool
@@ -229,7 +229,7 @@ pekko.actor.deployment {
   /parent/remotePool {
     router = round-robin-pool
     nr-of-instances = 10
-    target.nodes = ["tcp://app@10.0.0.2:2552", "pekko://app@10.0.0.3:2552"]
+    target.nodes = ["tcp://app@10.0.0.2:7355", "pekko://app@10.0.0.3:7355"]
   }
 }
 #//#config-remote-round-robin-pool-artery
@@ -239,9 +239,9 @@ pekko.actor.deployment {
   /parent/remoteGroup {
     router = round-robin-group
     routees.paths = [
-      "pekko://app@10.0.0.1:2552/user/workers/w1",
-      "pekko://app@10.0.0.2:2552/user/workers/w1",
-      "pekko://app@10.0.0.3:2552/user/workers/w1"]
+      "pekko://app@10.0.0.1:7355/user/workers/w1",
+      "pekko://app@10.0.0.2:7355/user/workers/w1",
+      "pekko://app@10.0.0.3:7355/user/workers/w1"]
   }
 }
 #//#config-remote-round-robin-group
@@ -251,9 +251,9 @@ pekko.actor.deployment {
   /parent/remoteGroup2 {
     router = round-robin-group
     routees.paths = [
-      "pekko://app@10.0.0.1:2552/user/workers/w1",
-      "pekko://app@10.0.0.2:2552/user/workers/w1",
-      "pekko://app@10.0.0.3:2552/user/workers/w1"]
+      "pekko://app@10.0.0.1:7355/user/workers/w1",
+      "pekko://app@10.0.0.2:7355/user/workers/w1",
+      "pekko://app@10.0.0.3:7355/user/workers/w1"]
   }
 }
 #//#config-remote-round-robin-group-artery

--- a/remote/src/main/resources/reference.conf
+++ b/remote/src/main/resources/reference.conf
@@ -513,8 +513,8 @@ pekko {
         # Use 0 if you want a random available port. Examples:
         #
         # pekko.remote.classic.netty.tcp.port = 7355
-        # pekko.remote.classic.netty.tcp.bind-port = 2553
-        # Network interface will be bound to the 2553 port, but remoting protocol will
+        # pekko.remote.classic.netty.tcp.bind-port = 7356
+        # Network interface will be bound to the 7356 port, but remoting protocol will
         # expect messages sent to port 7355.
         #
         # pekko.remote.classic.netty.tcp.port = 0
@@ -528,8 +528,8 @@ pekko {
         # expect messages sent to port 7355.
         #
         # pekko.remote.classic.netty.tcp.port = 0
-        # pekko.remote.classic.netty.tcp.bind-port = 2553
-        # Network interface will be bound to the 2553 port, and remoting protocol will
+        # pekko.remote.classic.netty.tcp.bind-port = 7356
+        # Network interface will be bound to the 7356 port, and remoting protocol will
         # expect messages sent to the bound port.
         #
         # pekko.remote.classic.netty.tcp.port = 7355

--- a/remote/src/main/resources/reference.conf
+++ b/remote/src/main/resources/reference.conf
@@ -499,9 +499,9 @@ pekko {
         applied-adapters = []
 
         # The default remote server port clients should connect to.
-        # Default is 2552 (AKKA), use 0 if you want a random available port
+        # Default is 7355 (AKKA), use 0 if you want a random available port
         # This port needs to be unique for each actor system on the same machine.
-        port = 2552
+        port = 7355
 
         # The hostname or ip clients should connect to.
         # InetAddress.getLocalHost.getHostAddress is used if empty
@@ -512,29 +512,29 @@ pekko {
         # when running pekko nodes in a separated networks (under NATs or docker containers).
         # Use 0 if you want a random available port. Examples:
         #
-        # pekko.remote.classic.netty.tcp.port = 2552
+        # pekko.remote.classic.netty.tcp.port = 7355
         # pekko.remote.classic.netty.tcp.bind-port = 2553
         # Network interface will be bound to the 2553 port, but remoting protocol will
-        # expect messages sent to port 2552.
+        # expect messages sent to port 7355.
         #
         # pekko.remote.classic.netty.tcp.port = 0
         # pekko.remote.classic.netty.tcp.bind-port = 0
         # Network interface will be bound to a random port, and remoting protocol will
         # expect messages sent to the bound port.
         #
-        # pekko.remote.classic.netty.tcp.port = 2552
+        # pekko.remote.classic.netty.tcp.port = 7355
         # pekko.remote.classic.netty.tcp.bind-port = 0
         # Network interface will be bound to a random port, but remoting protocol will
-        # expect messages sent to port 2552.
+        # expect messages sent to port 7355.
         #
         # pekko.remote.classic.netty.tcp.port = 0
         # pekko.remote.classic.netty.tcp.bind-port = 2553
         # Network interface will be bound to the 2553 port, and remoting protocol will
         # expect messages sent to the bound port.
         #
-        # pekko.remote.classic.netty.tcp.port = 2552
+        # pekko.remote.classic.netty.tcp.port = 7355
         # pekko.remote.classic.netty.tcp.bind-port = ""
-        # Network interface will be bound to the 2552 port, and remoting protocol will
+        # Network interface will be bound to the 7355 port, and remoting protocol will
         # expect messages sent to the bound port.
         #
         # pekko.remote.classic.netty.tcp.port if empty
@@ -760,9 +760,9 @@ pekko {
       canonical {
 
         # The default remote server port clients should connect to.
-        # Default is 25520, use 0 if you want a random available port
+        # Default is 73550, use 0 if you want a random available port
         # This port needs to be unique for each actor system on the same machine.
-        port = 25520
+        port = 73550
 
         # Hostname clients should connect to. Can be set to an ip, hostname
         # or one of the following special values:

--- a/remote/src/main/resources/reference.conf
+++ b/remote/src/main/resources/reference.conf
@@ -760,9 +760,9 @@ pekko {
       canonical {
 
         # The default remote server port clients should connect to.
-        # Default is 73550, use 0 if you want a random available port
+        # Default is 17355, use 0 if you want a random available port
         # This port needs to be unique for each actor system on the same machine.
-        port = 73550
+        port = 17355
 
         # Hostname clients should connect to. Can be set to an ip, hostname
         # or one of the following special values:

--- a/remote/src/test/scala/org/apache/pekko/remote/RemoteConsistentHashingRouterSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/RemoteConsistentHashingRouterSpec.scala
@@ -29,11 +29,11 @@ class RemoteConsistentHashingRouterSpec
 
     "use same hash ring independent of self address" in {
       // simulating running router on two different nodes (a1, a2) with target routees on 3 other nodes (s1, s2, s3)
-      val a1 = Address("pekko", "Sys", "client1", 2552)
-      val a2 = Address("pekko", "Sys", "client2", 2552)
-      val s1 = ActorSelectionRoutee(system.actorSelection("pekko://Sys@server1:2552/user/a/b"))
-      val s2 = ActorSelectionRoutee(system.actorSelection("pekko://Sys@server2:2552/user/a/b"))
-      val s3 = ActorSelectionRoutee(system.actorSelection("pekko://Sys@server3:2552/user/a/b"))
+      val a1 = Address("pekko", "Sys", "client1", 7355)
+      val a2 = Address("pekko", "Sys", "client2", 7355)
+      val s1 = ActorSelectionRoutee(system.actorSelection("pekko://Sys@server1:7355/user/a/b"))
+      val s2 = ActorSelectionRoutee(system.actorSelection("pekko://Sys@server2:7355/user/a/b"))
+      val s3 = ActorSelectionRoutee(system.actorSelection("pekko://Sys@server3:7355/user/a/b"))
       val nodes1 = List(ConsistentRoutee(s1, a1), ConsistentRoutee(s2, a1), ConsistentRoutee(s3, a1))
       val nodes2 = List(ConsistentRoutee(s1, a2), ConsistentRoutee(s2, a2), ConsistentRoutee(s3, a2))
       val consistentHash1 = ConsistentHash(nodes1, 10)

--- a/remote/src/test/scala/org/apache/pekko/remote/RemoteDeployerSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/RemoteDeployerSpec.scala
@@ -29,7 +29,7 @@ object RemoteDeployerSpec {
         /service2 {
           router = round-robin-pool
           nr-of-instances = 3
-          remote = "pekko://sys@wallace:2552"
+          remote = "pekko://sys@wallace:7355"
           dispatcher = mydispatcher
         }
       }
@@ -57,7 +57,7 @@ class RemoteDeployerSpec extends PekkoSpec(RemoteDeployerSpec.deployerConf) {
             service,
             deployment.get.config,
             RoundRobinPool(3),
-            RemoteScope(Address("pekko", "sys", "wallace", 2552)),
+            RemoteScope(Address("pekko", "sys", "wallace", 7355)),
             "mydispatcher")))
     }
 

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/RemoteDeathWatchSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/RemoteDeathWatchSpec.scala
@@ -94,7 +94,7 @@ class RemoteDeathWatchSpec
   }
 
   "receive Terminated when watched node is unknown host" in {
-    val path = RootActorPath(Address("pekko", system.name, "unknownhost", 2552)) / "user" / "subject"
+    val path = RootActorPath(Address("pekko", system.name, "unknownhost", 7355)) / "user" / "subject"
 
     system.actorOf(Props(new Actor {
         @nowarn
@@ -114,7 +114,7 @@ class RemoteDeathWatchSpec
     // immediately in constructor from aeron.addPublication when UnknownHostException. That will trigger
     // this immediately. With TCP it will trigger after handshake timeout. Can we see the UnknownHostException
     // reason somehow and fail the stream immediately for that case?
-    val path = RootActorPath(Address("pekko", system.name, "unknownhost2", 2552)) / "user" / "subject"
+    val path = RootActorPath(Address("pekko", system.name, "unknownhost2", 7355)) / "user" / "subject"
     system.actorSelection(path) ! Identify(path.toString)
     expectMsg(60.seconds, ActorIdentity(path.toString, None))
   }

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/RemoteDeployerSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/RemoteDeployerSpec.scala
@@ -28,7 +28,7 @@ object RemoteDeployerSpec {
         /service2 {
           router = round-robin-pool
           nr-of-instances = 3
-          remote = "pekko://sys@wallace:2552"
+          remote = "pekko://sys@wallace:7355"
           dispatcher = mydispatcher
         }
       }
@@ -54,7 +54,7 @@ class RemoteDeployerSpec extends PekkoSpec(RemoteDeployerSpec.deployerConf) {
             service,
             deployment.get.config,
             RoundRobinPool(3),
-            RemoteScope(Address("pekko", "sys", "wallace", 2552)),
+            RemoteScope(Address("pekko", "sys", "wallace", 7355)),
             "mydispatcher")))
     }
 

--- a/remote/src/test/scala/org/apache/pekko/remote/classic/ActorsLeakSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/classic/ActorsLeakSpec.scala
@@ -124,7 +124,7 @@ class ActorsLeakSpec extends PekkoSpec(ActorsLeakSpec.config) with ImplicitSende
             "remote",
             ConfigFactory.parseString("""
                 pekko.remote.artery.enabled = false
-                pekko.remote.classic.netty.tcp.port = 2553
+                pekko.remote.classic.netty.tcp.port = 7356
               """.stripMargin).withFallback(config))
 
         try {

--- a/remote/src/test/scala/org/apache/pekko/remote/classic/RemoteDeathWatchSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/classic/RemoteDeathWatchSpec.scala
@@ -101,7 +101,7 @@ pekko.actor.warn-about-java-serializer-usage = off
   }
 
   "receive Terminated when watched node is unknown host" in {
-    val path = RootActorPath(Address(protocol, system.name, "unknownhost", 2552)) / "user" / "subject"
+    val path = RootActorPath(Address(protocol, system.name, "unknownhost", 7355)) / "user" / "subject"
 
     system.actorOf(Props(new Actor {
         @nowarn
@@ -117,7 +117,7 @@ pekko.actor.warn-about-java-serializer-usage = off
   }
 
   "receive ActorIdentity(None) when identified node is unknown host" in {
-    val path = RootActorPath(Address(protocol, system.name, "unknownhost2", 2552)) / "user" / "subject"
+    val path = RootActorPath(Address(protocol, system.name, "unknownhost2", 7355)) / "user" / "subject"
     system.actorSelection(path) ! Identify(path)
     expectMsg(60.seconds, ActorIdentity(path, None))
   }

--- a/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonSerializerSpec.scala
+++ b/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonSerializerSpec.scala
@@ -856,7 +856,7 @@ abstract class JacksonSerializerSpec(serializerName: String)
     }
 
     "serialize with Address" in {
-      val address = Address("pekko", "sys", "localhost", 2552)
+      val address = Address("pekko", "sys", "localhost", 7355)
       checkSerialization(new CommandWithAddress("echo", address))
     }
 
@@ -1082,7 +1082,7 @@ abstract class JacksonSerializerSpec(serializerName: String)
     }
 
     "serialize with Address" in {
-      val address = Address("pekko", "sys", "localhost", 2552)
+      val address = Address("pekko", "sys", "localhost", 7355)
       checkSerialization(CommandWithAddress("echo", address))
     }
 


### PR DESCRIPTION
relates to #208 

* old akka port default 2552 becomes 7355 (PEKK on a telephone keypad)
* old akka artery default of 25520 becomes 17355 (73550 > 65535 - max port value) 