### PR TITLE
update pekko notice used in jars

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -211,7 +211,7 @@ Copyright (c) 2003-2011, LAMP/EPFL
 ---------------
 
 pekko-actor contains code from scala-collection-compat in the `org.apache.pekko.util.ccompat` package
-which has written by the Scala-Lang team under an Apache 2.0 license.
+which has released under an Apache 2.0 license.
 Copyright (c) 2002-2023 EPFL
 Copyright (c) 2011-2023 Lightbend, Inc.
 

--- a/NOTICE
+++ b/NOTICE
@@ -23,8 +23,7 @@ Lightbend, Inc. (https://www.lightbend.com/).
 
 ---------------
 
-pekko-actor contains code from scala-collection-compat which has changes made by the Scala-Lang team
-under an Apache 2.0 license.
+pekko-actor contains code from scala-collection-compat which was released under an Apache 2.0 license.
 
 scala-collection-compat
 Copyright (c) 2002-2023 EPFL

--- a/legal/PekkoNotice.txt
+++ b/legal/PekkoNotice.txt
@@ -1,0 +1,11 @@
+Apache Pekko
+Copyright 2022, 2023 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+This product contains significant parts that were originally based on software from Lightbend (Akka <https://akka.io/>).
+Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
+
+Apache Pekko is derived from Akka 2.6.x, the last version that was distributed under the
+Apache License, Version 2.0 License.

--- a/legal/pekko-actor-jar-license.txt
+++ b/legal/pekko-actor-jar-license.txt
@@ -211,7 +211,7 @@ Copyright (c) 2003-2011, LAMP/EPFL
 ---------------
 
 pekko-actor contains code from scala-collection-compat in the `org.apache.pekko.util.ccompat` package
-which has written by the Scala-Lang team under an Apache 2.0 license.
+which has released under an Apache 2.0 license.
 Copyright (c) 2002-2023 EPFL
 Copyright (c) 2011-2023 Lightbend, Inc.
 

--- a/project/AddMetaInfLicenseFiles.scala
+++ b/project/AddMetaInfLicenseFiles.scala
@@ -21,6 +21,7 @@ object AddMetaInfLicenseFiles extends AutoPlugin {
 
   override lazy val projectSettings = Seq(
     apacheSonatypeLicenseFile := baseDir.value / "legal" / "StandardLicense.txt",
+    apacheSonatypeNoticeFile := baseDir.value / "legal" / "PekkoNotice.txt",
     apacheSonatypeDisclaimerFile := Some(baseDir.value / "DISCLAIMER"))
 
   /**


### PR DESCRIPTION
Applies changes similar to ones already in https://github.com/apache/incubator-pekko-http

* at the jar level, most jars only need the vanilla Pekko Notice - not the source repo 'NOTICE' file that has a fair few amendments that are specific to just a few jars
* tidy up text about scala-collection-compat license and notice to not specifically mention Scala-Lang team
* https://github.com/apache/incubator-pekko/issues/241