### PR TITLE
Add mapValues for Scala 2.12 collection compat

### DIFF
--- a/plugins/serialversion-remover-plugin/src/main/scala/org/apache/pekko/Plugin.scala
+++ b/plugins/serialversion-remover-plugin/src/main/scala/org/apache/pekko/Plugin.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) 2021-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 


### PR DESCRIPTION
This adds a `.mapValues` for `IterableView` which is a Scala 2.12 specific method that is necessary to get pekko-connectors-kafka to compile for 2.12. Note that the method has been taken from https://github.com/scala/scala-collection-compat/pull/220 which is where the other methods in this file come from (basically this exists to avoid adding scala-collection-compat as a dependency of Pekko).