### PR TITLE
Add filterKeys for Scala 2.12 collection compat

### DIFF
--- a/actor/src/main/scala-2.12/org/apache/pekko/util/ccompat/package.scala
+++ b/actor/src/main/scala-2.12/org/apache/pekko/util/ccompat/package.scala
@@ -110,4 +110,7 @@ class MapViewExtensionMethods[K, V, C <: scala.collection.Map[K, V]](
     private val self: IterableView[(K, V), C]) extends AnyVal {
   def mapValues[W, That](f: V => W)(implicit bf: CanBuildFrom[IterableView[(K, V), C], (K, W), That]): That =
     self.map[(K, W), That] { case (k, v) => (k, f(v)) }
+
+  def filterKeys(p: K => Boolean): IterableView[(K, V), C] =
+    self.filter { case (k, _) => p(k) }
 }


### PR DESCRIPTION
Same deal as https://github.com/apache/incubator-pekko/pull/251 but with another method (`filterKeys`) which is also used by pekko-connectors-kafka.

Equivalent source is here https://github.com/scala/scala-collection-compat/blob/0737983fded4dada1c9ad20ae34d2a98b0b3083f/compat/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala#L634-L635