### PR TITLE
Add Scala 2.12 equivalent Iterator apply method for ByteString

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -814,6 +814,13 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
         }
       }
 
+      "created from iterator" in {
+        check { (a: ByteString) =>
+          val asIterator = a.iterator
+          ByteString(asIterator) == a
+        }
+      }
+
       "compacting" in {
         check { (a: ByteString) =>
           val wasCompact = a.isCompact

--- a/actor/src/main/scala-2.12/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala-2.12/org/apache/pekko/util/ByteString.scala
@@ -40,6 +40,11 @@ object ByteString {
   def apply(bytes: Byte*): ByteString = CompactByteString(bytes: _*)
 
   /**
+   * Creates a new ByteString by iterating over bytes.
+   */
+  def apply(bytes: Iterator[Byte]): ByteString = CompactByteString(bytes)
+
+  /**
    * Creates a new ByteString by converting from integral numbers to bytes.
    */
   def apply[T](bytes: T*)(implicit num: Integral[T]): ByteString =
@@ -943,6 +948,14 @@ object CompactByteString {
       bytes.copyToArray(ar)
       ByteString.ByteString1C(ar)
     }
+  }
+
+  /**
+   * Creates a new CompactByteString by traversing bytes.
+   */
+  def apply(bytes: Iterator[Byte]): CompactByteString = {
+    if (bytes.isEmpty) empty
+    else ByteString.ByteString1C(bytes.toArray)
   }
 
   /**


### PR DESCRIPTION
While working on https://github.com/apache/incubator-pekko-connectors/pull/74#pullrequestreview-1350324353 I noticed that while there is an `IterableOnce[Byte]` apply method in `ByteString` for Scala 2.13, there isn't the Scala 2.12 `Iterable[Byte]` equivalent apply method. Note that the already existing Scala 2.13 variant can be found at https://github.com/apache/incubator-pekko/blob/main/actor/src/main/scala-2.13/org/apache/pekko/util/ByteString.scala#L1002-L1009 and https://github.com/apache/incubator-pekko/blob/main/actor/src/main/scala-2.13/org/apache/pekko/util/ByteString.scala#L40-L43.

This change can be considered safe because if you look at the implementation either for the already existing Scala 2.13 or the Scala 2.12 variant being added in this PR, in both cases it internally converts to an array.