### PR TITLE
Fix Xlint options

### DIFF
--- a/project/PekkoDisciplinePlugin.scala
+++ b/project/PekkoDisciplinePlugin.scala
@@ -129,7 +129,8 @@ object PekkoDisciplinePlugin extends AutoPlugin {
               "-Ywarn-nullary-override",
               "-Ywarn-nullary-unit",
               "-Ypartial-unification",
-              "-Yno-adapted-args")
+              "-Yno-adapted-args") ++ Set(
+              "-Xlint:-strict-unsealed-patmat")
           case Some((2, 12)) =>
             disciplineScalacOptions
           case _ =>
@@ -164,6 +165,7 @@ object PekkoDisciplinePlugin extends AutoPlugin {
     "-Ywarn-numeric-widen",
     "-Yno-adapted-args",
     "-deprecation",
+    "-Xlint",
     "-Xlint:-infer-any",
     "-Ywarn-dead-code",
     "-Ywarn-inaccessible",


### PR DESCRIPTION
As pointed out in https://github.com/apache/incubator-pekko/pull/258#pullrequestreview-1351557344 I got the `Xlint` options wrong in that pull request. This PR fixes that, but in the process of fixing it the Scala compiler for 2.13 specifically found some warnings related to unsealed checking of pattern matches such as 

```
[error] /Users/mdedetrich/github/incubator-pekko/docs/src/test/scala/typed/tutorial_4/DeviceGroup.scala:51:5: match may not be exhaustive.
[error] It would fail on the following input: (x: typed.tutorial_4.DeviceGroup.Command forSome x not in (typed.tutorial_4.DeviceGroup.DeviceTerminated, typed.tutorial_4.DeviceManager.RequestDeviceList, typed.tutorial_4.DeviceManager.RequestTrackDevice))
[error]     msg match {
```

This is the reason behind adding `-Xlint:-strict-unsealed-patmat` specifically for 2.13. I will make an issue to have a look into this because it does seem we might be able to legitimately fix this in the code.