### PR TITLE
Scala 3.3 support

### DIFF
--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/InteractionPatternsSpec.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/InteractionPatternsSpec.scala
@@ -36,6 +36,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 // #per-session-child
 // dummy data types just for this sample
 case class Keys()
+
 case class Wallet()
 
 // #per-session-child

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,7 +41,7 @@ object Dependencies {
   val scala213Version = "2.13.10"
   // To get the fix for https://github.com/lampepfl/dotty/issues/13106
   // and restored static forwarders
-  val scala3Version = "3.3.0-RC5"
+  val scala3Version = "3.3.0-RC6"
   val allScalaVersions = Seq(scala213Version, scala212Version, scala3Version)
 
   val reactiveStreamsVersion = "1.0.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,7 +39,9 @@ object Dependencies {
 
   val scala212Version = "2.12.17"
   val scala213Version = "2.13.10"
-  val scala3Version = "3.2.2"
+  // To get the fix for https://github.com/lampepfl/dotty/issues/13106
+  // and restored static forwarders
+  val scala3Version = "3.3.0-RC3"
   val allScalaVersions = Seq(scala213Version, scala212Version, scala3Version)
 
   val reactiveStreamsVersion = "1.0.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,7 +41,7 @@ object Dependencies {
   val scala213Version = "2.13.10"
   // To get the fix for https://github.com/lampepfl/dotty/issues/13106
   // and restored static forwarders
-  val scala3Version = "3.3.0-RC3"
+  val scala3Version = "3.3.0-RC4"
   val allScalaVersions = Seq(scala213Version, scala212Version, scala3Version)
 
   val reactiveStreamsVersion = "1.0.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,7 +41,7 @@ object Dependencies {
   val scala213Version = "2.13.10"
   // To get the fix for https://github.com/lampepfl/dotty/issues/13106
   // and restored static forwarders
-  val scala3Version = "3.3.0-RC4"
+  val scala3Version = "3.3.0-RC5"
   val allScalaVersions = Seq(scala213Version, scala212Version, scala3Version)
 
   val reactiveStreamsVersion = "1.0.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,7 +41,7 @@ object Dependencies {
   val scala213Version = "2.13.10"
   // To get the fix for https://github.com/lampepfl/dotty/issues/13106
   // and restored static forwarders
-  val scala3Version = "3.3.0-RC6"
+  val scala3Version = "3.3.0"
   val allScalaVersions = Seq(scala213Version, scala212Version, scala3Version)
 
   val reactiveStreamsVersion = "1.0.4"


### PR DESCRIPTION
Preliminary support for Scala 3.3 (currently based on RC3). Aside from one case (noted below), there hasn't been any non trivial change in sources. Most of the source changes were due to update in Scala 3.3 checking more cases and hence producing more warnings (which isn't that different from latest Scala 2.13 or Scala 2.12).