### PR TITLE
upgrade to jackson 2.14.2

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/pattern/AskSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/pattern/AskSpec.scala
@@ -237,7 +237,7 @@ class AskSpec extends PekkoSpec("""
       }))
 
       val f = (act ? "ask").mapTo[String]
-      val (promiseActorRef, "ask") = p.expectMsgType[(ActorRef, String)]
+      val (promiseActorRef, "ask") = p.expectMsgType[(ActorRef, String)]: @unchecked
 
       watch(promiseActorRef)
       promiseActorRef ! "complete"
@@ -258,12 +258,12 @@ class AskSpec extends PekkoSpec("""
         }), "myName")
 
       (act ? "ask").mapTo[String]
-      val (promiseActorRef, "ask") = p.expectMsgType[(ActorRef, String)]
+      val (promiseActorRef, "ask") = p.expectMsgType[(ActorRef, String)]: @unchecked
 
       promiseActorRef.path.name should startWith("myName")
 
       (system.actorSelection("/user/myName") ? "ask").mapTo[String]
-      val (promiseActorRefForSelection, "ask") = p.expectMsgType[(ActorRef, String)]
+      val (promiseActorRefForSelection, "ask") = p.expectMsgType[(ActorRef, String)]: @unchecked
       promiseActorRefForSelection.path.name should startWith("_user_myName")
     }
   }

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/InteractionPatternsSpec.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/InteractionPatternsSpec.scala
@@ -36,7 +36,6 @@ import org.scalatest.wordspec.AnyWordSpecLike
 // #per-session-child
 // dummy data types just for this sample
 case class Keys()
-
 case class Wallet()
 
 // #per-session-child

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/InteractionPatternsSpec.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/InteractionPatternsSpec.scala
@@ -33,6 +33,14 @@ import pekko.actor.typed.scaladsl.TimerScheduler
 import pekko.pattern.StatusReply
 import org.scalatest.wordspec.AnyWordSpecLike
 
+// #per-session-child
+// dummy data types just for this sample
+case class Keys()
+
+case class Wallet()
+
+// #per-session-child
+
 class InteractionPatternsSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
 
   "The interaction patterns docs" must {
@@ -359,12 +367,6 @@ class InteractionPatternsSpec extends ScalaTestWithActorTestKit with AnyWordSpec
   }
 
   "contain a sample for per session child" in {
-    // #per-session-child
-    // dummy data types just for this sample
-    case class Keys()
-    case class Wallet()
-
-    // #per-session-child
 
     object KeyCabinet {
       case class GetKeys(whoseKeys: String, replyTo: ActorRef[Keys])

--- a/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/MetricSpec.scala
+++ b/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/MetricSpec.scala
@@ -40,7 +40,7 @@ class MetricNumericConverterSpec extends AnyWordSpec with Matchers with MetricNu
     }
 
     "define a new metric" in {
-      val Some(metric) = Metric.create(HeapMemoryUsed, 256L, decayFactor = Some(0.18))
+      val Some(metric) = Metric.create(HeapMemoryUsed, 256L, decayFactor = Some(0.18)): @unchecked
       metric.name should ===(HeapMemoryUsed)
       metric.value should ===(256L)
       metric.isSmooth should ===(true)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,21 +34,8 @@ object Dependencies {
   val protobufJavaVersion = "3.16.1"
   val logbackVersion = "1.2.11"
 
-  val jacksonCoreVersion = Def.setting {
-    if (scalaVersion.value.startsWith("3.")) {
-      "2.13.2"
-    } else {
-      "2.11.4"
-    }
-  }
-
-  val jacksonDatabindVersion = Def.setting {
-    if (scalaVersion.value.startsWith("3.")) {
-      "2.13.2.2"
-    } else {
-      jacksonCoreVersion.value
-    }
-  }
+  val jacksonCoreVersion = "2.14.2"
+  val jacksonDatabindVersion = jacksonCoreVersion
 
   val scala212Version = "2.12.17"
   val scala213Version = "2.13.10"
@@ -138,28 +125,28 @@ object Dependencies {
     val asnOne = ("com.hierynomus" % "asn-one" % "0.5.0").exclude("org.slf4j", "slf4j-api") // ApacheV2
 
     val jacksonCore = Def.setting {
-      "com.fasterxml.jackson.core" % "jackson-core" % jacksonCoreVersion.value
+      "com.fasterxml.jackson.core" % "jackson-core" % jacksonCoreVersion
     } // ApacheV2
     val jacksonAnnotations = Def.setting {
-      "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonCoreVersion.value
+      "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonCoreVersion
     } // ApacheV2
     val jacksonDatabind = Def.setting {
-      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion.value
+      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
     } // ApacheV2
     val jacksonJdk8 = Def.setting {
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonCoreVersion.value
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonCoreVersion
     } // ApacheV2
     val jacksonJsr310 = Def.setting {
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonCoreVersion.value
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonCoreVersion
     } // ApacheV2
     val jacksonScala = Def.setting {
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonCoreVersion.value
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonCoreVersion
     } // ApacheV2
     val jacksonParameterNames = Def.setting {
-      "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % jacksonCoreVersion.value
+      "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % jacksonCoreVersion
     } // ApacheV2
     val jacksonCbor = Def.setting {
-      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonCoreVersion.value
+      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonCoreVersion
     } // ApacheV2
     val lz4Java = "org.lz4" % "lz4-java" % "1.8.0" // ApacheV2
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,9 +39,7 @@ object Dependencies {
 
   val scala212Version = "2.12.17"
   val scala213Version = "2.13.10"
-  // To get the fix for https://github.com/lampepfl/dotty/issues/13106
-  // and restored static forwarders
-  val scala3Version = "3.1.2"
+  val scala3Version = "3.2.2" // Needed for Jackson 2.14.2
   val allScalaVersions = Seq(scala213Version, scala212Version, scala3Version)
 
   val reactiveStreamsVersion = "1.0.3"

--- a/project/PekkoDisciplinePlugin.scala
+++ b/project/PekkoDisciplinePlugin.scala
@@ -134,7 +134,7 @@ object PekkoDisciplinePlugin extends AutoPlugin {
           case Some((2, 12)) =>
             disciplineScalacOptions
           case _ =>
-            Nil
+            Seq("-Wconf:cat=deprecation:s")
         }).toSeq,
         Compile / scalacOptions --=
           (if (looseProjects.contains(name.value)) undisciplineScalacOptions.toSeq

--- a/project/PekkoDisciplinePlugin.scala
+++ b/project/PekkoDisciplinePlugin.scala
@@ -48,6 +48,8 @@ object PekkoDisciplinePlugin extends AutoPlugin {
     // references to deprecated PARSER fields in generated message formats?
     "pekko-persistence-query",
     "pekko-docs",
+    // references to deprecated Jackson methods that would involve a significant refactor to avoid
+    "pekko-serialization-jackson",
     // use varargs of `Graph` in alsoTo and etc operators
     "pekko-stream-tests")
 

--- a/remote/src/test/scala/org/apache/pekko/remote/AccrualFailureDetectorSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/AccrualFailureDetectorSpec.scala
@@ -63,8 +63,8 @@ class AccrualFailureDetectorSpec extends PekkoSpec("pekko.loglevel = INFO") {
       cdf(fd.phi(35L, 0, 10)) should ===(0.99977 +- 0.001)
       cdf(fd.phi(40L, 0, 10)) should ===(0.99997 +- 0.0001)
 
-      for (x :: y :: Nil <- (0 to 40).toList.sliding(2)) {
-        fd.phi(x, 0, 10) should be < (fd.phi(y, 0, 10))
+      for (case x :: y :: Nil <- (0 to 40).toList.sliding(2)) {
+        fd.phi(x, 0, 10) should be < fd.phi(y, 0, 10)
       }
 
       cdf(fd.phi(22, 20.0, 3)) should ===(0.7475 +- 0.001)

--- a/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonObjectMapperProvider.scala
+++ b/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonObjectMapperProvider.scala
@@ -15,12 +15,10 @@ package org.apache.pekko.serialization.jackson
 
 import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
-
 import scala.collection.immutable
 import scala.compat.java8.OptionConverters._
 import scala.util.Failure
 import scala.util.Success
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.PropertyAccessor
@@ -40,7 +38,6 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule
 import com.typesafe.config.Config
-
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.actor.ClassicActorSystemProvider
@@ -54,6 +51,8 @@ import pekko.annotation.InternalStableApi
 import pekko.event.Logging
 import pekko.event.LoggingAdapter
 import pekko.util.unused
+
+import scala.annotation.nowarn
 
 object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvider] with ExtensionIdProvider {
   override def get(system: ActorSystem): JacksonObjectMapperProvider = super.get(system)
@@ -136,6 +135,7 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
     jsonFactory
   }
 
+  @nowarn("msg=deprecated")
   private def configureObjectMapperFeatures(
       bindingName: String,
       objectMapper: ObjectMapper,

--- a/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonObjectMapperProvider.scala
+++ b/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonObjectMapperProvider.scala
@@ -15,10 +15,12 @@ package org.apache.pekko.serialization.jackson
 
 import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
+import scala.annotation.nowarn
 import scala.collection.immutable
 import scala.compat.java8.OptionConverters._
 import scala.util.Failure
 import scala.util.Success
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.PropertyAccessor
@@ -51,8 +53,6 @@ import pekko.annotation.InternalStableApi
 import pekko.event.Logging
 import pekko.event.LoggingAdapter
 import pekko.util.unused
-
-import scala.annotation.nowarn
 
 object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvider] with ExtensionIdProvider {
   override def get(system: ActorSystem): JacksonObjectMapperProvider = super.get(system)

--- a/serialization-jackson/src/test/scala/doc/org/apache/pekko/serialization/jackson/v2a/CustomerMigration.scala
+++ b/serialization-jackson/src/test/scala/doc/org/apache/pekko/serialization/jackson/v2a/CustomerMigration.scala
@@ -18,10 +18,13 @@ import org.apache.pekko.serialization.jackson.JacksonMigration
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 
+import scala.annotation.nowarn
+
 class CustomerMigration extends JacksonMigration {
 
   override def currentVersion: Int = 2
 
+  @nowarn("msg=deprecated")
   override def transform(fromVersion: Int, json: JsonNode): JsonNode = {
     val root = json.asInstanceOf[ObjectNode]
     if (fromVersion <= 1) {

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/ActorMaterializerSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/ActorMaterializerSpec.scala
@@ -152,7 +152,7 @@ class ActorMaterializerSpec extends StreamSpec with ImplicitSender {
 
       p.expectMsg("hello")
       a ! PoisonPill
-      val Failure(_) = p.expectMsgType[Try[Done]]
+      val Failure(_) = p.expectMsgType[Try[Done]]: @unchecked
     }
 
     "report correctly if it has been shut down from the side" in {


### PR DESCRIPTION
https://github.com/apache/incubator-pekko/issues/7

* Jackson 2.14.2 for Scala 3 - supports only Scala 3.2 - so we'll need to upgrade Scala
* There is a deprecation warning - a Jackson method that we use that has now been deprecated.
* The deprecated method needs a large scale rewrite to do things the preferred Jackson 2.14 way
* Jackson is heading towards making ObjectMapper immutable and the preferred approach is to use `JsonMapper.builder()...` to create a configured MapperBuilder and to create JsonMapper/ObjectMapper instances from it
* In short term, we are probably bestter off not moving off the deprecated method - it won't be removed for ages

```
[error] /home/runner/work/incubator-pekko/incubator-pekko/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonObjectMapperProvider.scala:170:45: method configure in class ObjectMapper is deprecated
[error]       case (feature, value) => objectMapper.configure(feature, value)
[error]                                             ^
[error] one error found
```