### PR TITLE
=str Implement Source.never as a dedicated GraphStage.

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/GraphStages.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/GraphStages.scala
@@ -458,6 +458,21 @@ import pekko.stream.stage._
   }
 
   @InternalApi
+  private[pekko] object NeverSource extends GraphStage[SourceShape[Nothing]] {
+    private val out = Outlet[Nothing]("NeverSource.out")
+    val shape: SourceShape[Nothing] = SourceShape(out)
+
+    override def initialAttributes: Attributes = DefaultAttributes.neverSource
+
+    override def createLogic(inheritedAttributes: Attributes): GraphStageLogic with OutHandler =
+      new GraphStageLogic(shape) with OutHandler {
+        override def onPull(): Unit = ()
+
+        setHandler(out, this)
+      }
+  }
+
+  @InternalApi
   private[pekko] object NeverSink extends GraphStageWithMaterializedValue[SinkShape[Any], Future[Done]] {
     private val in = Inlet[Any]("NeverSink.in")
     val shape: SinkShape[Any] = SinkShape(in)

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Source.scala
@@ -293,7 +293,7 @@ object Source {
    */
   def fromJavaStream[T, S <: java.util.stream.BaseStream[T, S]](
       stream: () => java.util.stream.BaseStream[T, S]): Source[T, NotUsed] =
-    StreamConverters.fromJavaStream(stream);
+    StreamConverters.fromJavaStream(stream)
 
   /**
    * Creates [[Source]] that will continually produce given elements in specified order.
@@ -516,8 +516,7 @@ object Source {
    * This stream could be useful in tests.
    */
   def never[T]: Source[T, NotUsed] = _never
-  private[this] val _never: Source[Nothing, NotUsed] =
-    future(Future.never).withAttributes(DefaultAttributes.neverSource)
+  private[this] val _never: Source[Nothing, NotUsed] = fromGraph(GraphStages.NeverSource)
 
   /**
    * Emits a single value when the given `CompletionStage` is successfully completed and then completes the stream.


### PR DESCRIPTION
Using a more straightforward implementation will reduce the AsyncCallback in FutureSource.