### PR TITLE
temporarily remove refs to platform guide

### DIFF
--- a/docs/src/main/paradox/persistence-query.md
+++ b/docs/src/main/paradox/persistence-query.md
@@ -33,9 +33,6 @@ recommend (in the spirit of CQRS) of splitting up the write/read sides into sepa
 For a similar implementation of query interface to @ref:[Durable State Behaviors](typed/durable-state/persistence.md)
 please refer to @ref:[Persistence Query using Durable State](durable-state/persistence-query.md).
 
-The @extref[Microservices with Pekko tutorial](platform-guide:microservices-tutorial/) explains how to
-implement an Event Sourced CQRS application with Pekko Persistence and Pekko Projections.
-
 ## Design overview
 
 Pekko persistence query is purposely designed to be a very loosely specified API.
@@ -333,8 +330,3 @@ resilience is important so that if a node crashes the persistent queries are qui
 resume operations @ref:[Cluster Sharding](cluster-sharding.md) together with event tagging is an excellent fit to 
 shard events over a cluster.
 
-## Example project
-
-The @extref[Microservices with Pekko tutorial](platform-guide:microservices-tutorial/) explains how to
-use Event Sourcing and Projections together. The events are tagged to be consumed by even processors to build
-other representations from the events, or publish the events to other services.

--- a/docs/src/main/paradox/project/examples.md
+++ b/docs/src/main/paradox/project/examples.md
@@ -50,13 +50,6 @@ This project contains a KillrWeather sample illustrating how to use Cluster Shar
 
 This project contains a Shopping Cart sample illustrating how to use Pekko Persistence.
 
-## CQRS
-
-The @extref[Microservices with Pekko tutorial](platform-guide:microservices-tutorial/) contains a
-Shopping Cart sample illustrating how to use Event Sourcing and Projections together. The events are
-tagged to be consumed by even processors to build other representations from the events, or publish the events
-to other services.
-
 ## Replicated Event Sourcing
 
 @java[@extref[Multi-DC Persistence example project](samples:pekko-samples-persistence-dc-java)]

--- a/docs/src/main/paradox/typed/choosing-cluster.md
+++ b/docs/src/main/paradox/typed/choosing-cluster.md
@@ -17,8 +17,6 @@ In a microservices architecture, you should consider communication within a serv
 In general we recommend against using Pekko Cluster and actor messaging between _different_ services because that
 would result in a too tight code coupling between the services and difficulties deploying these independent of
 each other, which is one of the main reasons for using a microservices architecture.
-See the discussion on @extref[Internal and External Communication](platform-guide:concepts/internal-and-external-communication.html)
-for some background on this.
 
 Nodes of a single service (collectively called a cluster) require less decoupling. They share the same code and
 are deployed together, as a set, by a single team or individual. There might be two versions running concurrently

--- a/docs/src/main/paradox/typed/cqrs.md
+++ b/docs/src/main/paradox/typed/cqrs.md
@@ -1,6 +1,5 @@
 # CQRS
 
 @ref:[EventSourcedBehavior](persistence.md)s along with [Pekko Projections]($pekko.doc.dns$/docs/pekko-projection/current/)
-can be used to implement Command Query Responsibility Segregation (CQRS). The @extref[Microservices with Pekko tutorial](platform-guide:microservices-tutorial/)
-explains how to use Event Sourcing and Projections together. For implementing CQRS using @ref:[DurableStateBehavior](durable-state/persistence.md), please take a look at the corresponding @ref:[CQRS](durable-state/cqrs.md) documentation.
- 
+can be used to implement Command Query Responsibility Segregation (CQRS).
+For implementing CQRS using @ref:[DurableStateBehavior](durable-state/persistence.md), please take a look at the corresponding @ref:[CQRS](durable-state/cqrs.md) documentation. 

--- a/docs/src/main/paradox/typed/guide/tutorial_5.md
+++ b/docs/src/main/paradox/typed/guide/tutorial_5.md
@@ -233,5 +233,4 @@ To continue your journey with Pekko, we recommend:
 
 To get from this guide to a complete application you would likely need to provide either an UI or an API. For this we recommend that you look at the following technologies and see what fits you:
 
- * @extref[Microservices with Pekko tutorial](platform-guide:microservices-tutorial/) illustrates how to implement an Event Sourced CQRS application with Pekko Persistence and Pekko Projections 
  * [Pekko HTTP]($pekko.doc.dns$/docs/pekko-http/current/introduction.html) is a HTTP server and client library, making it possible to publish and consume HTTP endpoints

--- a/docs/src/main/paradox/typed/persistence-testing.md
+++ b/docs/src/main/paradox/typed/persistence-testing.md
@@ -189,8 +189,6 @@ For tests that involve more than one Cluster node you have to use another journa
 While it's possible to use the @ref:[Persistence Plugin Proxy](../persistence-plugins.md#persistence-plugin-proxy)
 it's often better and more realistic to use a real database.
 
-The @ref:[CQRS example](../project/examples.md#cqrs) includes tests that are using Pekko Persistence Cassandra.
-
 ### Plugin initialization
 
 Some Persistence plugins create tables automatically, but has the limitation that it can't be done concurrently

--- a/docs/src/main/paradox/typed/persistence.md
+++ b/docs/src/main/paradox/typed/persistence.md
@@ -39,9 +39,7 @@ or starting from a checkpoint in a snapshot, which can dramatically reduce recov
 
 Pekko Persistence also supports @ref:[Durable State Behaviors](durable-state/persistence.md), which is based on 
 persistence of the latest state of the actor. In this implementation, the _latest_ state is persisted, instead of events. 
-Hence this is more similar to CRUD based applications.
-
-The @extref[Microservices with Pekko tutorial](platform-guide:microservices-tutorial/) illustrates how to implement an Event Sourced CQRS application with Pekko Persistence and Pekko Projections.
+Hence, this is more similar to CRUD based applications.
 
 @@@ note
 
@@ -680,10 +678,6 @@ reference documentation of the chosen plugin.
 @scala[@extref[Persistence example project](samples:pekko-samples-persistence-scala)]
 is an example project that can be downloaded, and with instructions of how to run.
 This project contains a Shopping Cart sample illustrating how to use Pekko Persistence.
-
-The Shopping Cart sample is expanded further in the @extref[Microservices with Pekko tutorial](platform-guide:microservices-tutorial/).
-In that sample the events are tagged to be consumed by even processors to build other representations
-from the events, or publish the events to other services.
 
 @java[@extref[Multi-DC Persistence example project](samples:pekko-samples-persistence-dc-java)]
 @scala[@extref[Multi-DC Persistence example project](samples:pekko-samples-persistence-dc-scala)]


### PR DESCRIPTION
* relates to https://github.com/apache/incubator-pekko/issues/244
* can add these doc points back when we actually have a Pekko Platform Guide to look at