### PR TITLE
Add ScalaTestWithActorTestKitBase trait to handle multiple extends

### DIFF
--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/ScalaTestWithActorTestKit.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/ScalaTestWithActorTestKit.scala
@@ -38,13 +38,9 @@ import pekko.actor.typed.ActorSystem
  * The application.conf of your project is not used in this case.
  * A specific configuration can be passed as constructor parameter.
  */
-abstract class ScalaTestWithActorTestKit(testKit: ActorTestKit)
+abstract class ScalaTestWithActorTestKit(override val testKit: ActorTestKit)
     extends ActorTestKitBase(testKit)
-    with TestSuite
-    with Matchers
-    with BeforeAndAfterAll
-    with ScalaFutures
-    with Eventually {
+    with ScalaTestWithActorTestKitBase {
 
   /**
    * Config loaded from `application-test.conf` if that exists, otherwise
@@ -74,6 +70,21 @@ abstract class ScalaTestWithActorTestKit(testKit: ActorTestKit)
    */
   def this(config: Config, settings: TestKitSettings) =
     this(ActorTestKit(ActorTestKitBase.testNameFromCallStack(), config, settings))
+}
+
+/**
+ * A ScalaTest base trait for the [[ActorTestKit]] which [[ScalaTestWithActorTestKit]] extends. If you find yourself in
+ * the situation where you need to extend the same test suite in different ways then you can implement your tests within
+ * a trait that extends [[ScalaTestWithActorTestKitBase]].
+ */
+trait ScalaTestWithActorTestKitBase
+    extends TestSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with ScalaFutures
+    with Eventually {
+
+  def testKit: ActorTestKit
 
   /**
    * `PatienceConfig` from [[pekko.actor.testkit.typed.TestKitSettings#DefaultTimeout]].

--- a/actor-testkit-typed/src/test/scala/docs/org/apache/pekko/actor/testkit/typed/scaladsl/ScalaTestIntegrationExampleSpec.scala
+++ b/actor-testkit-typed/src/test/scala/docs/org/apache/pekko/actor/testkit/typed/scaladsl/ScalaTestIntegrationExampleSpec.scala
@@ -15,16 +15,19 @@ package docs.org.apache.pekko.actor.testkit.typed.scaladsl
 
 import scala.annotation.nowarn
 import docs.org.apache.pekko.actor.testkit.typed.scaladsl.AsyncTestingExampleSpec.Echo
-
+//#extend-multiple-times
 //#log-capturing
 import org.apache.pekko
 import pekko.actor.testkit.typed.scaladsl.LogCapturing
 //#scalatest-integration
 import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import org.scalatest.wordspec.AnyWordSpecLike
-
 //#scalatest-integration
 //#log-capturing
+import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKitBase
+//#scalatest-integration
+import org.scalatest.wordspec.AnyWordSpecLike
+//#scalatest-integration
+//#extend-multiple-times
 
 @nowarn
 //#scalatest-integration
@@ -54,3 +57,23 @@ class LogCapturingExampleSpec extends ScalaTestWithActorTestKit with AnyWordSpec
   }
 }
 //#log-capturing
+
+//#extend-multiple-times
+
+trait ExtendTestMultipleTimes extends ScalaTestWithActorTestKitBase with AnyWordSpecLike with LogCapturing {
+  "ScalaTestWithActorTestKitBase" must {
+    "behave when extended in different ways" in {
+      val pinger = testKit.spawn(Echo(), "ping")
+      val probe = testKit.createTestProbe[Echo.Pong]()
+      val message = this.getClass.getSimpleName
+      pinger ! Echo.Ping(message, probe.ref)
+      val returnedMessage = probe.expectMessage(Echo.Pong(message))
+      returnedMessage.message.contains("ExtendTestMultipleTimes") shouldBe false
+    }
+  }
+
+}
+
+class TestWithOneImplementation extends ScalaTestWithActorTestKit with ExtendTestMultipleTimes
+class TestWithAnotherImplementation extends ScalaTestWithActorTestKit with ExtendTestMultipleTimes
+//#extend-multiple-times

--- a/docs/src/main/paradox/typed/testing-async.md
+++ b/docs/src/main/paradox/typed/testing-async.md
@@ -137,6 +137,17 @@ Scala
 Java
 :  @@snip [AsyncTestingExampleTest.java](/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/JunitIntegrationExampleTest.java) { #junit-integration }
 
+As you may have noticed @scaladoc[ScalaTestWithActorTestKit](pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit) is an abstract class
+which means its problematic if you want treat a given test suite as a value and extend it in multiple ways (i.e. as an example you happen to be using 
+[testcontainers-scala](https://github.com/testcontainers/testcontainers-scala) and hypothetically you want to extend the same test for each different type of database
+you support).
+
+If you find yourself in this situation you can instead define your tests within a trait that extends @scaladoc[ScalaTestWithActorTestKitBase](pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKitBase).
+Since this is a trait you can then have different classes which extend this along with @scaladoc[ScalaTestWithActorTestKit](pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit).
+
+Scala
+:  @@snip [AsyncTestingExampleSpec.scala](/actor-testkit-typed/src/test/scala/docs/org/apache/pekko/actor/testkit/typed/scaladsl/ScalaTestIntegrationExampleSpec.scala) { #extend-multiple-times }
+
 ### Configuration
 
 By default the `ActorTestKit` loads configuration from `application-test.conf` if that exists, otherwise


### PR DESCRIPTION
This PR's factors out the common logic of `ScalaTestWithActorTestKit` into a trait `ScalaTestWithActorTestKitBase` while keeping `ScalaTestWithActorTestKit` as is (i.e. an `abstract class`). The context behind this change is that I was looking at flaky tests within https://github.com/apache/incubator-pekko-persistence-r2dbc and I noticed that one of the reasons behind the flakiness is a hardcoded timeout value (see https://github.com/apache/incubator-pekko-persistence-r2dbc/blob/main/.github/workflows/build-test.yml#L75).

While there may be "easier" ways to solve this problem, a much more principled way is to use testcontainers/testcontainers-scala which already has logic (from community effort) that handles these problems so in reality it just works™. 

The easiest way to integrate testcontainers-scala with scalatest/testkit is to just define your test suites within a trait and then have a the different testcontainers extend those traits (as documented here https://github.com/testcontainers/testcontainers-scala/blob/master/docs/src/main/tut/usage.md#lifecycle). Unfortunately currently this is not really possible because `ScalaTestWithActorTestKitBase` is an abstract class and there is no equivalent version that is a trait (in stark contrast to `TestKitBase` which is a trait and not an `abstract class`).

With this feature, we can (for example) change https://github.com/apache/incubator-pekko-persistence-r2dbc/blob/ab3709fec338b2641ae00350e3b07512e2da4acf/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/CurrentPersistenceIdsQuerySpec.scala#L26 to a `trait CurrentPersistenceIdsQuerySpec` and then have an `PostGresCurrentPersistenceIdsQuerySpec` and `YugabyteCurrentPersistenceIdsQuerySpec` extend `CurrentPersistenceIdsQuerySpec`). This is also useful aside from `Testcontainers`, basically as documented whenever you need to abstract over your test suite you can use this trait.

This PR won't have any effect on behaviour (it just adds a new trait) and furthermore this is also not going to impact production code because we are dealing with testkit.