### PR TITLE
update links to point to pekko sample docs

### DIFF
--- a/docs/src/main/paradox/additional/deploying.md
+++ b/docs/src/main/paradox/additional/deploying.md
@@ -14,7 +14,7 @@ To take advantage of running inside Kubernetes while forming a cluster,
 with the Kubernetes API or Kubernetes via DNS.  
 
 You can look at the
-@extref[Cluster with Kubernetes example project](samples:akka-sample-cluster-kubernetes-java)
+@extref[Cluster with Kubernetes example project](akka-samples:akka-sample-cluster-kubernetes-java)
 to see what this looks like in practice.
  
 ### Resource limits
@@ -28,8 +28,8 @@ that you will need to take special care with the network configuration when usin
 described here: @ref:[Pekko behind NAT or in a Docker container](../remoting-artery.md#remote-configuration-nat-artery)
 
 You can look at the
-@java[@extref[Cluster with docker-compse example project](samples:akka-sample-cluster-docker-compose-java)]
-@scala[@extref[Cluster with docker-compose example project](samples:akka-sample-cluster-docker-compose-scala)]
+@java[@extref[Cluster with docker-compse example project](akka-samples:akka-sample-cluster-docker-compose-java)]
+@scala[@extref[Cluster with docker-compose example project](akka-samples:akka-sample-cluster-docker-compose-scala)]
 to see what this looks like in practice.
 
 For the JVM to run well in a Docker container, there are some general (not Pekko specific) parameters that might need tuning:

--- a/docs/src/main/paradox/cluster-routing.md
+++ b/docs/src/main/paradox/cluster-routing.md
@@ -246,5 +246,5 @@ pekko.actor.deployment {
 }
 ```
 The easiest way to run **Router Example with Pool of Routees** example yourself is to try the
-@scala[@extref[Pekko Cluster Sample with Scala](samples:pekko-samples-cluster-scala)]@java[@extref[Pekko Cluster Sample with Java](samples:pekko-samples-cluster-java)].
+@scala[@extref[Pekko Cluster Sample with Scala](samples:pekko-sample-cluster-scala)]@java[@extref[Pekko Cluster Sample with Java](samples:pekko-sample-cluster-java)].
 It contains instructions on how to run the **Router Example with Pool of Routees** sample.

--- a/docs/src/main/paradox/multi-jvm-testing.md
+++ b/docs/src/main/paradox/multi-jvm-testing.md
@@ -214,7 +214,7 @@ described in that section.
 
 ## Example project
 
-@extref[Cluster example project](samples:pekko-samples-cluster-scala)
+@extref[Cluster example project](samples:pekko-sample-cluster-scala)
 is an example project that can be downloaded, and with instructions of how to run.
 
 This project illustrates Cluster features and also includes Multi JVM Testing with the `sbt-multi-jvm` plugin.

--- a/docs/src/main/paradox/project/examples.md
+++ b/docs/src/main/paradox/project/examples.md
@@ -52,8 +52,8 @@ This project contains a Shopping Cart sample illustrating how to use Pekko Persi
 
 ## Replicated Event Sourcing
 
-@java[@extref[Multi-DC Persistence example project](akka-samples:akka-samples-persistence-dc-java)]
-@scala[@extref[Multi-DC Persistence example project](akka-samples:akka-samples-persistence-dc-scala)]
+@java[[Multi-DC Persistence example project](https://github.com/apache/incubator-pekko-samples/tree/main/pekko-sample-persistence-dc-java)]
+@scala[[Multi-DC Persistence example project](https://github.com/apache/incubator-pekko-samples/tree/main/pekko-sample-persistence-dc-scala)]
 
 Illustrates how to use @ref:[Replicated Event Sourcing](../typed/replicated-eventsourcing.md) that supports
 active-active persistent entities across data centers.

--- a/docs/src/main/paradox/project/examples.md
+++ b/docs/src/main/paradox/project/examples.md
@@ -13,15 +13,15 @@ messages as well as how to use the test module and logging.
 
 ## FSM
 
-@java[@extref[FSM example project](samples:pekko-samples-fsm-java)]
-@scala[@extref[FSM example project](samples:pekko-samples-fsm-scala)]
+@java[@extref[FSM example project](samples:pekko-sample-fsm-java)]
+@scala[@extref[FSM example project](samples:pekko-sample-fsm-scala)]
 
 This project contains a Dining Hakkers sample illustrating how to model a Finite State Machine (FSM) with actors.
 
 ## Cluster
 
-@java[@extref[Cluster example project](samples:pekko-samples-cluster-java)]
-@scala[@extref[Cluster example project](samples:pekko-samples-cluster-scala)]
+@java[@extref[Cluster example project](samples:pekko-sample-cluster-java)]
+@scala[@extref[Cluster example project](samples:pekko-sample-cluster-scala)]
 
 This project contains samples illustrating different Cluster features, such as
 subscribing to cluster membership events, and sending messages to actors running on nodes in the cluster
@@ -31,55 +31,55 @@ It also includes Multi JVM Testing with the `sbt-multi-jvm` plugin.
 
 ## Distributed Data
 
-@java[@extref[Distributed Data example project](samples:pekko-samples-distributed-data-java)]
-@scala[@extref[Distributed Data example project](samples:pekko-samples-distributed-data-scala)]
+@java[@extref[Distributed Data example project](samples:pekko-sample-distributed-data-java)]
+@scala[@extref[Distributed Data example project](samples:pekko-sample-distributed-data-scala)]
 
 This project contains several samples illustrating how to use Distributed Data.
 
 ## Cluster Sharding
 
-@java[@extref[Sharding example project](samples:pekko-samples-cluster-sharding-java)]
-@scala[@extref[Sharding example project](samples:pekko-samples-cluster-sharding-scala)]
+@java[@extref[Sharding example project](samples:pekko-sample-cluster-sharding-java)]
+@scala[@extref[Sharding example project](samples:pekko-sample-cluster-sharding-scala)]
 
 This project contains a KillrWeather sample illustrating how to use Cluster Sharding.
 
 ## Persistence
 
-@java[@extref[Persistence example project](samples:pekko-samples-persistence-java)]
-@scala[@extref[Persistence example project](samples:pekko-samples-persistence-scala)]
+@java[@extref[Persistence example project](samples:pekko-sample-persistence-java)]
+@scala[@extref[Persistence example project](samples:pekko-sample-persistence-scala)]
 
 This project contains a Shopping Cart sample illustrating how to use Pekko Persistence.
 
 ## Replicated Event Sourcing
 
-@java[@extref[Multi-DC Persistence example project](samples:pekko-samples-persistence-dc-java)]
-@scala[@extref[Multi-DC Persistence example project](samples:pekko-samples-persistence-dc-scala)]
+@java[@extref[Multi-DC Persistence example project](akka-samples:akka-samples-persistence-dc-java)]
+@scala[@extref[Multi-DC Persistence example project](akka-samples:akka-samples-persistence-dc-scala)]
 
 Illustrates how to use @ref:[Replicated Event Sourcing](../typed/replicated-eventsourcing.md) that supports
 active-active persistent entities across data centers.
 
 ## Cluster with Docker
 
-@java[@extref[Cluster with docker-compose example project](samples:pekko-sample-cluster-docker-compose-java)]
-@scala[@extref[Cluster with docker-compose example project](samples:pekko-sample-cluster-docker-compose-scala)]
+@java[@extref[Cluster with docker-compose example project](akka-samples:akka-sample-cluster-docker-compose-java)]
+@scala[@extref[Cluster with docker-compose example project](akka-samples:akka-sample-cluster-docker-compose-scala)]
 
 Illustrates how to use Pekko Cluster with Docker compose.
 
 ## Cluster with Kubernetes
 
-@extref[Cluster with Kubernetes example project](samples:pekko-sample-cluster-kubernetes-java)
+@extref[Cluster with Kubernetes example project](akka-samples:akka-sample-cluster-kubernetes-java)
 
 This sample illustrates how to form a Pekko Cluster with Pekko Bootstrap when running in Kubernetes.
 
 ## Distributed workers
 
-@extref[Distributed workers example project](samples:pekko-samples-distributed-workers-scala)
+@extref[Distributed workers example project](samples:pekko-sample-distributed-workers-scala)
 
 This project demonstrates the work pulling pattern using Pekko Cluster.
 
 ## Kafka to Cluster Sharding 
 
-@extref[Kafka to Cluster Sharding example project](samples:pekko-samples-kafka-to-sharding)
+@extref[Kafka to Cluster Sharding example project](samples:pekko-sample-kafka-to-sharding)
 
 This project demonstrates how to use the External Shard Allocation strategy to co-locate the consumption of Kafka
 partitions with the shard that processes the messages.

--- a/docs/src/main/paradox/typed/cluster-sharding.md
+++ b/docs/src/main/paradox/typed/cluster-sharding.md
@@ -232,7 +232,7 @@ support a greater number of shards.
 
 #### Example project for external allocation strategy
 
-@extref[Kafka to Cluster Sharding](samples:pekko-samples-kafka-to-sharding)
+@extref[Kafka to Cluster Sharding](samples:pekko-sample-kafka-to-sharding)
 is an example project that can be downloaded, and with instructions of how to run, that demonstrates how to use
 external sharding to co-locate Kafka partition consumption with shards.
 
@@ -829,8 +829,8 @@ as described in @ref:[Shard allocation](#shard-allocation).
 
 ## Example project
 
-@java[@extref[Sharding example project](samples:pekko-samples-cluster-sharding-java)]
-@scala[@extref[Sharding example project](samples:pekko-samples-cluster-sharding-scala)]
+@java[@extref[Sharding example project](samples:pekko-sample-cluster-sharding-java)]
+@scala[@extref[Sharding example project](samples:pekko-sample-cluster-sharding-scala)]
 is an example project that can be downloaded, and with instructions of how to run.
 
 This project contains a KillrWeather sample illustrating how to use Cluster Sharding.

--- a/docs/src/main/paradox/typed/cluster.md
+++ b/docs/src/main/paradox/typed/cluster.md
@@ -455,8 +455,8 @@ See @ref:[Reliable Delivery](reliable-delivery.md)
 
 ## Example project
 
-@java[@extref[Cluster example project](samples:pekko-samples-cluster-java)]
-@scala[@extref[Cluster example project](samples:pekko-samples-cluster-scala)]
+@java[@extref[Cluster example project](samples:pekko-sample-cluster-java)]
+@scala[@extref[Cluster example project](samples:pekko-sample-cluster-scala)]
 is an example project that can be downloaded, and with instructions of how to run.
 
 This project contains samples illustrating different Cluster features, such as

--- a/docs/src/main/paradox/typed/distributed-data.md
+++ b/docs/src/main/paradox/typed/distributed-data.md
@@ -779,8 +779,8 @@ The `DistributedData` extension can be configured with the following properties:
 
 ## Example project
 
-@java[@extref[Distributed Data example project](samples:pekko-samples-distributed-data-java)]
-@scala[@extref[Distributed Data example project](samples:pekko-samples-distributed-data-scala)]
+@java[@extref[Distributed Data example project](samples:pekko-sample-distributed-data-java)]
+@scala[@extref[Distributed Data example project](samples:pekko-sample-distributed-data-scala)]
 is an example project that can be downloaded, and with instructions of how to run.
 
 This project contains several samples illustrating how to use Distributed Data.

--- a/docs/src/main/paradox/typed/fsm.md
+++ b/docs/src/main/paradox/typed/fsm.md
@@ -59,8 +59,8 @@ To set state timeouts use `Behaviors.withTimers` along with a `startSingleTimer`
 
 ## Example project
 
-@java[@extref[FSM example project](samples:pekko-samples-fsm-java)]
-@scala[@extref[FSM example project](samples:pekko-samples-fsm-scala)]
+@java[@extref[FSM example project](samples:pekko-sample-fsm-java)]
+@scala[@extref[FSM example project](samples:pekko-sample-fsm-scala)]
 is an example project that can be downloaded, and with instructions of how to run.
 
 This project contains a Dining Hakkers sample illustrating how to model a Finite State Machine (FSM) with actors.

--- a/docs/src/main/paradox/typed/persistence.md
+++ b/docs/src/main/paradox/typed/persistence.md
@@ -679,7 +679,7 @@ reference documentation of the chosen plugin.
 is an example project that can be downloaded, and with instructions of how to run.
 This project contains a Shopping Cart sample illustrating how to use Pekko Persistence.
 
-@java[@extref[Multi-DC Persistence example project](akka-samples:akka-samples-persistence-dc-java)]
-@scala[@extref[Multi-DC Persistence example project](akka-samples:akka-samples-persistence-dc-scala)]
+@java[[Multi-DC Persistence example project](https://github.com/apache/incubator-pekko-samples/tree/main/pekko-sample-persistence-dc-java)]
+@scala[[Multi-DC Persistence example project](https://github.com/apache/incubator-pekko-samples/tree/main/pekko-sample-persistence-dc-scala)]
 illustrates how to use @ref:[Replicated Event Sourcing](replicated-eventsourcing.md) that supports
 active-active persistent entities across data centers.

--- a/docs/src/main/paradox/typed/persistence.md
+++ b/docs/src/main/paradox/typed/persistence.md
@@ -674,12 +674,12 @@ reference documentation of the chosen plugin.
 
 ## Example project
 
-@java[@extref[Persistence example project](samples:pekko-samples-persistence-java)]
-@scala[@extref[Persistence example project](samples:pekko-samples-persistence-scala)]
+@java[@extref[Persistence example project](samples:pekko-sample-persistence-java)]
+@scala[@extref[Persistence example project](samples:pekko-sample-persistence-scala)]
 is an example project that can be downloaded, and with instructions of how to run.
 This project contains a Shopping Cart sample illustrating how to use Pekko Persistence.
 
-@java[@extref[Multi-DC Persistence example project](samples:pekko-samples-persistence-dc-java)]
-@scala[@extref[Multi-DC Persistence example project](samples:pekko-samples-persistence-dc-scala)]
+@java[@extref[Multi-DC Persistence example project](akka-samples:akka-samples-persistence-dc-java)]
+@scala[@extref[Multi-DC Persistence example project](akka-samples:akka-samples-persistence-dc-scala)]
 illustrates how to use @ref:[Replicated Event Sourcing](replicated-eventsourcing.md) that supports
 active-active persistent entities across data centers.

--- a/project/Paradox.scala
+++ b/project/Paradox.scala
@@ -35,8 +35,8 @@ object Paradox {
       "extref.platform-guide.base_url" -> "https://developer.lightbend.com/docs/akka-platform-guide/%s",
       "extref.wikipedia.base_url" -> "https://en.wikipedia.org/wiki/%s",
       "extref.github.base_url" -> (GitHub.url(version.value) + "/%s"), // for links to our sources
-      "extref.samples.base_url" -> "https://developer.lightbend.com/start/?group=akka&amp;project=%s",
-      "extref.ecs.base_url" -> "https://example.lightbend.com/v1/download/%s",
+      "extref.samples.base_url" -> s"$pekkoBaseURL/docs/pekko-samples/current/%s",
+      "extref.akka-samples.base_url" -> "https://developer.lightbend.com/start/?group=akka&amp;project=%s",
       "pekko.doc.dns" -> s"$pekkoBaseURL",
       "scaladoc.pekko.base_url" -> s"$pekkoBaseURL/api/pekko/current/org/apache",
       "scaladoc.pekko.http.base_url" -> s"$pekkoBaseURL/api/pekko-http/current/org/apache",


### PR DESCRIPTION
some samples that are referenced in pekko docs are not in https://github.com/apache/incubator-pekko-samples - so I have set those links up to work the old Akka docs way (and link to the Akka sample)

