### PR TITLE
Add sbt-dependency-check

### DIFF
--- a/dependency-check/suppression.xml
+++ b/dependency-check/suppression.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+</suppressions>

--- a/docs/src/main/paradox/security/index.md
+++ b/docs/src/main/paradox/security/index.md
@@ -1,5 +1,13 @@
 # Security Announcements
 
+@@toc { depth=2 }
+
+@@@ index
+
+* [dependency-check-report](dependency-check-report.md)
+
+@@@
+
 ## Receiving Security Advisories
 
 The best way to receive any and all security announcements is to subscribe to the [Apache Announce Mailing List](https://lists.apache.org/list.html?announce@apache.org).
@@ -16,6 +24,15 @@ Please follow the [guidelines](https://www.apache.org/security/) laid down by th
 
 Ideally, any issues affecting Apache Pekko and Akka should be reported to Apache team first. We will share the
 report with the Lightbend Akka team.
+
+## Dependency check scanner
+
+This project uses [sbt-dependency-check](https://github.com/albuch/sbt-dependency-check) in order to scan the
+projects dependencies against [OWASP](https://owasp.org/) to create a @ref:[dependency-check-report](dependency-check-report.md)
+of any potential security issues.
+
+If you want to suppress the checking of some dependencies then there is a [supression](github:dependency-check/suppression.xml)
+file. The format of this file is documented [here](https://jeremylong.github.io/DependencyCheck/general/suppression.html).
 
 ## Security Related Documentation
 

--- a/project/DependencyCheck.scala
+++ b/project/DependencyCheck.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+import net.vonbuchholtz.sbt.dependencycheck.DependencyCheckPlugin
+import sbt.AutoPlugin
+import sbt.Keys.baseDirectory
+import sbt.Keys._
+import sbt._
+import net.vonbuchholtz.sbt.dependencycheck.DependencyCheckPlugin.autoImport._
+
+object DependencyCheck extends AutoPlugin {
+  override lazy val buildSettings = Seq(
+    LocalRootProject / dependencyCheckSuppressionFile := Some(
+      baseDirectory.value / "dependency-check" / "suppression.xml"))
+
+  override def requires = plugins.JvmPlugin && DependencyCheckPlugin
+
+  override def trigger = allRequirements
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,6 +22,7 @@ addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.2")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.5")
 addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.6")
 addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.2.2")
+addSbtPlugin("net.vonbuchholtz" % "sbt-dependency-check" % "5.1.0")
 
 // allow access to snapshots for pekko-sbt-paradox
 resolvers += Resolver.ApacheMavenSnapshotsRepo


### PR DESCRIPTION
This PR adds sbt-dependency-check which scans the entire dependency tree of Pekko against OWASP to scan for any potential CVE's. This PR does a pretty basic addition of the plugin but there is future room for improvement, i.e. since this is a standard sbt plugin its possible to run `dependencyCheckAggregate` along with `sourceDistGenerate` when making a release. Another notable setting is `dependencyCheckFailBuildOnCVSS` which would cause the project to automatically fail if it finds a dependency with a certain security level.

The contents of both the generated report and the surpression file are located in the `dependency` folder (this can be renamed if needed). This also means that the report will be contained in the source dist distribution.

Note that the report has actually picked up `CRITICAL` CVE's from our dependency list which we should look into, i.e. 
![image](https://user-images.githubusercontent.com/2337269/232207685-2a4806b6-90a7-4584-8aee-165612a15aaf.png)
