### PR TITLE
remove refs to spanner persistence

### DIFF
--- a/docs/src/main/paradox/common/other-modules.md
+++ b/docs/src/main/paradox/common/other-modules.md
@@ -37,10 +37,6 @@ A Pekko Persistence journal and snapshot store for use with JDBC-compatible data
 
 A Pekko Persistence journal and snapshot store for use with R2DBC-compatible databases. This implementation relies on [R2DBC](https://r2dbc.io/).
 
-## [Google Cloud Spanner Plugin for Pekko Persistence]($pekko.doc.dns$/docs/pekko-persistence-spanner/current/)
-
-Use [Google Cloud Spanner](https://cloud.google.com/spanner/) as Pekko Persistence journal and snapshot store. This integration relies on [Pekko gRPC]($pekko.doc.dns$/docs/pekko-grpc/current/).
-
 
 ## Apache Pekko Management
 

--- a/docs/src/main/paradox/persistence-plugins.md
+++ b/docs/src/main/paradox/persistence-plugins.md
@@ -7,7 +7,7 @@ Plugins maintained within the Pekko organization are:
 * [pekko-persistence-cassandra]($pekko.doc.dns$/docs/pekko-persistence-cassandra/current/) (no Durable State support)
 * [pekko-persistence-jdbc]($pekko.doc.dns$/docs/pekko-persistence-jdbc/current/)
 * [pekko-persistence-r2dbc]($pekko.doc.dns$/docs/pekko-persistence-r2dbc/current/)
-* [pekko-persistence-r2dbc]($pekko.doc.dns$/docs/pekko-persistence-dynamodb/current/)
+* [pekko-persistence-dynamodb]($pekko.doc.dns$/docs/pekko-persistence-dynamodb/current/)
 
 Plugins can be selected either by "default" for all persistent actors,
 or "individually", when a persistent actor defines its own set of plugins.

--- a/docs/src/main/paradox/persistence-plugins.md
+++ b/docs/src/main/paradox/persistence-plugins.md
@@ -7,7 +7,7 @@ Plugins maintained within the Pekko organization are:
 * [pekko-persistence-cassandra]($pekko.doc.dns$/docs/pekko-persistence-cassandra/current/) (no Durable State support)
 * [pekko-persistence-jdbc]($pekko.doc.dns$/docs/pekko-persistence-jdbc/current/)
 * [pekko-persistence-r2dbc]($pekko.doc.dns$/docs/pekko-persistence-r2dbc/current/)
-* [pekko-persistence-spanner]($pekko.doc.dns$/docs/pekko-persistence-spanner/current/)
+* [pekko-persistence-r2dbc]($pekko.doc.dns$/docs/pekko-persistence-dynamodb/current/)
 
 Plugins can be selected either by "default" for all persistent actors,
 or "individually", when a persistent actor defines its own set of plugins.

--- a/docs/src/main/paradox/typed/replicated-eventsourcing.md
+++ b/docs/src/main/paradox/typed/replicated-eventsourcing.md
@@ -412,6 +412,5 @@ The @apidoc[SnapshotStoreSpec] in the Persistence TCK provides a capability flag
 
 The following plugins support Replicated Event Sourcing:
 
-* [Pekko Persistence Cassandra]($pekko.doc.dns$/docs/pekko-persistence-cassandra/current/index.html) versions 1.0.3+
-* [Pekko Persistence Spanner]($pekko.doc.dns$/docs/pekko-persistence-spanner/current/overview.html) versions 1.0.0-RC4+
-* [Pekko Persistence JDBC]($pekko.doc.dns$/docs/pekko-persistence-jdbc/current) versions 5.0.0+
+* [Pekko Persistence Cassandra]($pekko.doc.dns$/docs/pekko-persistence-cassandra/current/index.html)
+* [Pekko Persistence JDBC]($pekko.doc.dns$/docs/pekko-persistence-jdbc/current)


### PR DESCRIPTION
https://doc.akka.io/docs/akka-persistence-spanner/current/contributing.html was abandoned before it was ever fully released. There is no Pekko equivalent.