### PR TITLE
Update project-info JDKs

### DIFF
--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -3,7 +3,7 @@ project-info {
   scaladoc: "https://pekko.apache.org/api/pekko/"${project-info.version}"/pekko/"
   javadoc: "https://pekko.apache.org/japi/pekko/"${project-info.version}"/pekko/"
   shared-info {
-    jdk-versions: ["Adopt OpenJDK 8", "Adopt OpenJDK 11"]
+    jdk-versions: ["Temurin OpenJDK 8", "Temurin OpenJDK 11", "Temurin OpenJDK 17"]
     snapshots: {
       url: "https://pekko.apache.org/docs/pekko/current/project/links.html#snapshots-repository"
       text: "Snapshots are available"

--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -3,7 +3,7 @@ project-info {
   scaladoc: "https://pekko.apache.org/api/pekko/"${project-info.version}"/pekko/"
   javadoc: "https://pekko.apache.org/japi/pekko/"${project-info.version}"/pekko/"
   shared-info {
-    jdk-versions: ["Temurin OpenJDK 8", "Temurin OpenJDK 11", "Temurin OpenJDK 17"]
+    jdk-versions: ["OpenJDK 8", "OpenJDK 11", "OpenJDK 17"]
     snapshots: {
       url: "https://pekko.apache.org/docs/pekko/current/project/links.html#snapshots-repository"
       text: "Snapshots are available"


### PR DESCRIPTION
We test with Temurin OpenJDK 8, 11 and 17. Adopt OpenJDK is no longer supported and Adoptium have taken over and name their JDKs as Temurin.

Relates to https://github.com/apache/incubator-pekko/issues/247