### PR TITLE
scaladoc/javadoc links broken in docs

### DIFF
--- a/project/Paradox.scala
+++ b/project/Paradox.scala
@@ -105,7 +105,7 @@ object Paradox {
       resolvers += Resolver.jcenterRepo,
       ApidocPlugin.autoImport.apidocRootPackage := "org.apache.pekko",
       publishRsyncArtifacts += {
-        val releaseVersion = if (isSnapshot.value) "snapshot" else version.value
+        val releaseVersion = if (isSnapshot.value) "current" else version.value
         (Compile / paradox).value -> s"www/docs/pekko/$releaseVersion"
       })
 }

--- a/project/Paradox.scala
+++ b/project/Paradox.scala
@@ -105,7 +105,7 @@ object Paradox {
       resolvers += Resolver.jcenterRepo,
       ApidocPlugin.autoImport.apidocRootPackage := "org.apache.pekko",
       publishRsyncArtifacts += {
-        val releaseVersion = if (isSnapshot.value) "current" else version.value
+        val releaseVersion = if (isSnapshot.value) "snapshot" else version.value
         (Compile / paradox).value -> s"www/docs/pekko/$releaseVersion"
       })
 }

--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -1,7 +1,7 @@
 project-info {
   version: "current"
-  scaladoc: "https://pekko.apache.org/api/pekko/"${project-info.version}"/pekko/"
-  javadoc: "https://pekko.apache.org/japi/pekko/"${project-info.version}"/pekko/"
+  scaladoc: "https://pekko.apache.org/api/pekko/current/org/apache/pekko/"
+  javadoc: "https://pekko.apache.org/japi/pekko/current/org/apache/pekko/"
   shared-info {
     jdk-versions: ["OpenJDK 8", "OpenJDK 11", "OpenJDK 17"]
     snapshots: {
@@ -14,12 +14,14 @@ project-info {
       text: "Github issues"
     }
     release-notes: {
-      # TODO: Correct url needs to be provided
-      url: "https://akka.io/blog/news-archive.html"
-      text: "akka.io blog"
-      new-tab: false
+      url: "https://github.com/apache/incubator-pekko/releases"
+      text: "GitHub releases"
     }
     forums: [
+      {
+        text: "Apache Pekko User mailing list"
+        url: "https://lists.apache.org/list.html?user@pekko.apache.org"
+      }
       {
         text: "Apache Pekko Dev mailing list"
         url: "https://lists.apache.org/list.html?dev@pekko.apache.org"

--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -1,7 +1,7 @@
 project-info {
   version: "current"
-  scaladoc: "https://pekko.apache.org/api/pekko/current/org/apache/pekko/"
-  javadoc: "https://pekko.apache.org/japi/pekko/current/org/apache/pekko/"
+  scaladoc: "https://pekko.apache.org/api/pekko/"${project-info.version}"/org/apache/pekko/"
+  javadoc: "https://pekko.apache.org/japi/pekko/"${project-info.version}"/org/apache/pekko/"
   shared-info {
     jdk-versions: ["OpenJDK 8", "OpenJDK 11", "OpenJDK 17"]
     snapshots: {


### PR DESCRIPTION
2 problems:
* the `{project-info.version}` token incorrectly evaluates to `snapshot` instead of the value that we need - `current` - see https://nightlies.apache.org/pekko/docs/pekko/main-snapshot/docs/discovery/index.html#module-info
* we need `org.apache` in the package names