### PR TITLE
=act Use lambda instead of BiConsumer.

### DIFF
--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/ActorContextImpl.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/ActorContextImpl.scala
@@ -284,7 +284,7 @@ import scala.util.Success
   def pipeToSelf[Value](
       future: CompletionStage[Value],
       applyToResult: pekko.japi.function.Function2[Value, Throwable, T]): Unit = {
-    future.whenComplete { (value, ex) =>
+    future.handle { (value, ex) =>
       if (ex != null)
         self.unsafeUpcast ! AdaptMessage(ex, applyToResult.apply(null.asInstanceOf[Value], _: Throwable))
       else self.unsafeUpcast ! AdaptMessage(value, applyToResult.apply(_: Value, null))

--- a/actor/src/main/scala/org/apache/pekko/pattern/FutureTimeoutSupport.scala
+++ b/actor/src/main/scala/org/apache/pekko/pattern/FutureTimeoutSupport.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.pattern
 
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
-import java.util.function.BiConsumer
 
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.concurrent.duration.FiniteDuration
@@ -78,11 +77,9 @@ trait FutureTimeoutSupport {
       using.scheduleOnce(duration) {
         try {
           val future = value
-          future.whenComplete(new BiConsumer[T, Throwable] {
-            override def accept(t: T, ex: Throwable): Unit = {
-              if (t != null) p.complete(t)
-              if (ex != null) p.completeExceptionally(ex)
-            }
+          future.handle((t: T, ex: Throwable) => {
+            if (t != null) p.complete(t)
+            if (ex != null) p.completeExceptionally(ex)
           })
         } catch {
           case NonFatal(ex) => p.completeExceptionally(ex)

--- a/actor/src/main/scala/org/apache/pekko/pattern/PipeToSupport.scala
+++ b/actor/src/main/scala/org/apache/pekko/pattern/PipeToSupport.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.pattern
 
 import java.util.concurrent.CompletionStage
-import java.util.function.BiConsumer
 
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success }
@@ -53,22 +52,17 @@ trait PipeToSupport {
     }
   }
 
-  final class PipeableCompletionStage[T](val future: CompletionStage[T])(
-      implicit @unused executionContext: ExecutionContext) {
+  final class PipeableCompletionStage[T](val future: CompletionStage[T]) {
     def pipeTo(recipient: ActorRef)(implicit sender: ActorRef = Actor.noSender): CompletionStage[T] = {
-      future.whenComplete(new BiConsumer[T, Throwable] {
-        override def accept(t: T, ex: Throwable): Unit = {
-          if (t != null) recipient ! t
-          if (ex != null) recipient ! Status.Failure(ex)
-        }
+      future.whenComplete((t: T, ex: Throwable) => {
+        if (t != null) recipient ! t
+        if (ex != null) recipient ! Status.Failure(ex)
       })
     }
     def pipeToSelection(recipient: ActorSelection)(implicit sender: ActorRef = Actor.noSender): CompletionStage[T] = {
-      future.whenComplete(new BiConsumer[T, Throwable] {
-        override def accept(t: T, ex: Throwable): Unit = {
-          if (t != null) recipient ! t
-          if (ex != null) recipient ! Status.Failure(ex)
-        }
+      future.whenComplete((t: T, ex: Throwable) => {
+        if (t != null) recipient ! t
+        if (ex != null) recipient ! Status.Failure(ex)
       })
     }
     def to(recipient: ActorRef): PipeableCompletionStage[T] = to(recipient, Actor.noSender)
@@ -123,5 +117,6 @@ trait PipeToSupport {
    * the failure is sent in a [[pekko.actor.Status.Failure]] to the recipient.
    */
   implicit def pipeCompletionStage[T](future: CompletionStage[T])(
-      implicit executionContext: ExecutionContext): PipeableCompletionStage[T] = new PipeableCompletionStage(future)
+      implicit @unused executionContext: ExecutionContext): PipeableCompletionStage[T] =
+    new PipeableCompletionStage(future)
 }


### PR DESCRIPTION
Some Code cleans up:
1. CompletionStage#handle instead as no returning result is required and better performance
2. Use a lambda instead of `BiConsumer`
3. Drop the additional executionContext in `PipeableCompletionStage`'s contractor, and make it an AnyVal