### PR TITLE
Improve PR Workflow: Separate the validateCompile step from validatePullRequest

### DIFF
--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -33,6 +33,21 @@ jobs:
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts
 
+      - name: sbt validateCompile
+        run: |-
+          sbt \
+          -Dpekko.mima.enabled=false \
+          -Dpekko.test.multi-in-test=false \
+          -Dpekko.test.timefactor=2 \
+          -Dpekko.actor.testkit.typed.timefactor=2 \
+          -Dpekko.test.tags.exclude=gh-exclude,timing \
+          -Dpekko.cluster.assert=on \
+          -Dsbt.override.build.repos=false \
+          -Dpekko.test.multi-node=false \
+          -Dsbt.log.noformat=false \
+          -Dpekko.log.timestamps=true \
+          validateCompile
+
       - name: sbt validatePullRequest
         run: |-
           sbt \
@@ -46,4 +61,4 @@ jobs:
           -Dpekko.test.multi-node=false \
           -Dsbt.log.noformat=false \
           -Dpekko.log.timestamps=true \
-          validateCompile validatePullRequest
+          validatePullRequest


### PR DESCRIPTION
Currently the PR workflow 'Build / Test' job has a single step validatePullRequest that both compiles and then tests the changes. This takes 30 minutes and is very verbose -- it is difficult to see exactly where a failure is originating.

This PR separating compile and test: This will make the source of errors in steps clearer, without adding any extra pipeline time. (Steps in github jobs are dependent on one another, so the build files can be passed onto prValidation without the need for PR validation to compile again)

On the overall issue: I think next steps should be to extract test logs into their own short-lifetime artifact files and reduce the CI logs to only show failing tests. Will follow up with a PR on that if people think that's a good idea.

