### PR TITLE
Fixing #246: update signature and fiddle properties in project/Paradox.scala

### DIFF
--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/IntroSpec.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/IntroSpec.scala
@@ -109,7 +109,7 @@ object IntroSpec {
   }
   //#hello-world-main
 
-  // This is run by ScalaFiddle
+  // Entry point for the execution
   HelloWorldMain.main(Array.empty)
   //#fiddle_code
   //format: ON

--- a/docs/src/main/paradox/_template/projectSpecificFooter.st
+++ b/docs/src/main/paradox/_template/projectSpecificFooter.st
@@ -1,2 +1,1 @@
 <script type="text/javascript" src="$page.base$assets/js/warnOldDocs.js"></script>
-<script type="text/javascript" src="$page.base$assets/js/scalafiddle.js"></script>

--- a/docs/src/main/paradox/actors.md
+++ b/docs/src/main/paradox/actors.md
@@ -95,9 +95,9 @@ construction.
 
 @@@ div { .group-scala }
 
-#### Here is another example that you can edit and run in the browser:
+#### Here is another example:
 
-@@fiddle [ActorDocSpec.scala](/docs/src/test/scala/docs/actor/ActorDocSpec.scala) { #fiddle_code template="Pekko" layout="v75" minheight="400px" }
+@@snip [ActorDocSpec.scala](/docs/src/test/scala/docs/actor/ActorDocSpec.scala) { #fiddle_code template="Pekko" layout="v75" minheight="400px" }
 
 @@@
 

--- a/docs/src/main/paradox/assets/js/scalafiddle.js
+++ b/docs/src/main/paradox/assets/js/scalafiddle.js
@@ -1,8 +1,8 @@
 window.scalaFiddleTemplates = {
   "Pekko": {
-    pre: "// $FiddleDependency org.pekko-js %%% pekkojsactor % 2.2.6.1 \n" +
-    "// $FiddleDependency org.pekko-js %%% pekkojsactorstream % 2.2.6.1 \n" +
-    "// $FiddleDependency org.pekko-js %%% pekkojsactortyped % 2.2.6.1 \n",
+    pre: "// $FiddleDependency org.akka-js %%% akkajsactor % 2.2.6.1 \n" +
+    "// $FiddleDependency org.akka-js %%% akkajsactorstream % 2.2.6.1 \n" +
+    "// $FiddleDependency org.akka-js %%% akkajsactortyped % 2.2.6.1 \n",
     post: ""
   }
 }

--- a/docs/src/main/paradox/assets/js/scalafiddle.js
+++ b/docs/src/main/paradox/assets/js/scalafiddle.js
@@ -1,8 +1,0 @@
-window.scalaFiddleTemplates = {
-  "Pekko": {
-    pre: "// $FiddleDependency org.akka-js %%% akkajsactor % 2.2.6.1 \n" +
-    "// $FiddleDependency org.akka-js %%% akkajsactorstream % 2.2.6.1 \n" +
-    "// $FiddleDependency org.akka-js %%% akkajsactortyped % 2.2.6.1 \n",
-    post: ""
-  }
-}

--- a/docs/src/main/paradox/stream/operators/Source/mergePrioritizedN.md
+++ b/docs/src/main/paradox/stream/operators/Source/mergePrioritizedN.md
@@ -6,7 +6,7 @@ Merge multiple sources with priorities.
 
 ## Signature
 
-@@signature [Source.scala](/pekko-stream/src/main/scala/org/apache/pekko/stream/scaladsl/Source.scala) { #mergePrioritized }
+@apidoc[Source.mergePrioritizedN](Source) { scala="#mergePrioritizedN[T](sourcesAndPriorities:immutable.Seq[(Source[T,_],Int)],eagerComplete:Boolean):Source[T,NotUsed]" java="#mergePrioritized[T](sourcesAndPriorities:java.util.List[Pair[Source[T,_%3C:Any],java.lang.Integer]],eagerComplete:Boolean):javadsl.Source[T,NotUsed]" }
 
 ## Description
 

--- a/docs/src/main/paradox/stream/stream-quickstart.md
+++ b/docs/src/main/paradox/stream/stream-quickstart.md
@@ -116,10 +116,10 @@ whether the stream terminated normally or exceptionally.
 
 ### Browser-embedded example
  
-<a name="here-is-another-example-that-you-can-edit-and-run-in-the-browser-"></a>
-Here is another example that you can edit and run in the browser:
+<a name="here-is-another-example"></a>
+Here is another example:
 
-@@fiddle [TwitterStreamQuickstartDocSpec.scala](/docs/src/test/scala/docs/stream/TwitterStreamQuickstartDocSpec.scala) { #fiddle_code template=Pekko layout=v75 minheight=400px }
+@@snip [TwitterStreamQuickstartDocSpec.scala](/docs/src/test/scala/docs/stream/TwitterStreamQuickstartDocSpec.scala) { #fiddle_code template=Pekko layout=v75 minheight=400px }
 
 
 ## Reusable Pieces

--- a/docs/src/main/paradox/typed/actors.md
+++ b/docs/src/main/paradox/typed/actors.md
@@ -165,9 +165,9 @@ You will also need to add a @ref:[logging dependency](logging.md) to see that ou
 
 @@@ div { .group-scala }
 
-#### Here is another example that you can edit and run in the browser:
+#### Here is another example:
 
-@@fiddle [IntroSpec.scala](/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/IntroSpec.scala) { #fiddle_code template=Pekko layout=v75 minheight=400px }
+@@snip [IntroSpec.scala](/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/IntroSpec.scala) { #fiddle_code template=Pekko layout=v75 minheight=400px }
 
 @@@
 

--- a/project/Paradox.scala
+++ b/project/Paradox.scala
@@ -61,9 +61,9 @@ object Paradox {
       "pekko.version" -> version.value,
       "scalatest.version" -> Dependencies.scalaTestVersion.value,
       "sigar_loader.version" -> "1.6.6-rev002",
-      "signature.akka.base_dir" -> (ThisBuild / baseDirectory).value.getAbsolutePath,
+      "signature.pekko.base_dir" -> (ThisBuild / baseDirectory).value.getAbsolutePath,
       "fiddle.code.base_dir" -> (Test / sourceDirectory).value.getAbsolutePath,
-      "fiddle.akka.base_dir" -> (ThisBuild / baseDirectory).value.getAbsolutePath,
+      "fiddle.pekko.base_dir" -> (ThisBuild / baseDirectory).value.getAbsolutePath,
       "aeron_version" -> Dependencies.aeronVersion,
       "netty_version" -> Dependencies.nettyVersion,
       "logback_version" -> Dependencies.logbackVersion))

--- a/project/Paradox.scala
+++ b/project/Paradox.scala
@@ -61,7 +61,6 @@ object Paradox {
       "pekko.version" -> version.value,
       "scalatest.version" -> Dependencies.scalaTestVersion.value,
       "sigar_loader.version" -> "1.6.6-rev002",
-      "signature.pekko.base_dir" -> (ThisBuild / baseDirectory).value.getAbsolutePath,
       "fiddle.code.base_dir" -> (Test / sourceDirectory).value.getAbsolutePath,
       "fiddle.pekko.base_dir" -> (ThisBuild / baseDirectory).value.getAbsolutePath,
       "aeron_version" -> Dependencies.aeronVersion,

--- a/project/Paradox.scala
+++ b/project/Paradox.scala
@@ -61,8 +61,6 @@ object Paradox {
       "pekko.version" -> version.value,
       "scalatest.version" -> Dependencies.scalaTestVersion.value,
       "sigar_loader.version" -> "1.6.6-rev002",
-      "fiddle.code.base_dir" -> (Test / sourceDirectory).value.getAbsolutePath,
-      "fiddle.pekko.base_dir" -> (ThisBuild / baseDirectory).value.getAbsolutePath,
       "aeron_version" -> Dependencies.aeronVersion,
       "netty_version" -> Dependencies.nettyVersion,
       "logback_version" -> Dependencies.logbackVersion))


### PR DESCRIPTION
Fix issue #246 

- The `Paradox.scala` props have been updated to pekko value.
- The `scalafiddle.js` has been reverted to `org.akka-js`. Akka.js is distributed under [Scala LICENSE](https://www.scala-lang.org/license/)


### This is how is rendered after the conversion from scalafiddler to standard examples:

![Screenshot 2023-04-27 161935](https://user-images.githubusercontent.com/8921095/234909039-f3c62230-b0dd-4e65-a95e-3132fe51a1c6.png)

