### PR TITLE
use github links as a 1st step away from lightbend links

### DIFF
--- a/docs/src/main/paradox/project/examples.md
+++ b/docs/src/main/paradox/project/examples.md
@@ -5,8 +5,8 @@ of how to run.
 
 ## Quickstart
 
-@scala[[Quickstart Guide](https://developer.lightbend.com/guides/akka-quickstart-scala/)]
-@java[[Quickstart Guide](https://developer.lightbend.com/guides/akka-quickstart-java/)]
+@scala[[Quickstart Guide](https://github.com/apache/incubator-pekko-quickstart-scala.g8)]
+@java[[Quickstart Guide](https://github.com/apache/incubator-pekko-quickstart-java.g8)]
  
 The *Quickstart* guide walks you through example code that introduces how to define actor systems, actors, and
 messages as well as how to use the test module and logging.

--- a/docs/src/main/paradox/typed/guide/introduction.md
+++ b/docs/src/main/paradox/typed/guide/introduction.md
@@ -31,7 +31,7 @@ efficiently.
 ## How to get started
 
 If this is your first experience with Pekko, we recommend that you start by
-running a simple Hello World project. See the @scala[[Quickstart Guide](https://developer.lightbend.com/guides/akka-quickstart-scala/)] @java[[Quickstart Guide](https://developer.lightbend.com/guides/akka-quickstart-java/)] for
+running a simple Hello World project. See the @scala[[Quickstart Guide](https://github.com/apache/incubator-pekko-quickstart-scala.g8)] @java[[Quickstart Guide](https://github.com/apache/incubator-pekko-quickstart-java.g8)] for
 instructions on downloading and running the Hello World example. The *Quickstart* guide walks you through example code that introduces how to define actor systems, actors, and messages as well as how to use the test module and logging. Within 30 minutes, you should be able to run the Hello World example and learn how it is constructed.
 
 This *Getting Started* guide provides the next level of information. It covers why the actor model fits the needs of modern distributed systems and includes a tutorial that will help further your knowledge of Pekko. Topics include:

--- a/docs/src/main/paradox/typed/guide/tutorial.md
+++ b/docs/src/main/paradox/typed/guide/tutorial.md
@@ -5,12 +5,12 @@ when starting to build a Pekko system. You might wonder: Which should be the fir
 Fortunately &#8212; unlike with prose &#8212; established best practices can guide us through these initial steps. In the remainder of this guide, we examine the core logic of a simple Pekko application to introduce you to actors and show you how to formulate solutions with them. The example demonstrates common patterns that will help you kickstart your Pekko projects.
 
 ## Prerequisites
-You should have already followed the instructions in the @scala[[Pekko Quickstart with Scala guide](https://developer.lightbend.com/guides/akka-quickstart-scala/)] @java[[Pekko Quickstart with Java guide](https://developer.lightbend.com/guides/akka-quickstart-java/)] to download and run the Hello World example. You will use this as a seed project and add the functionality described in this tutorial.
+You should have already followed the instructions in the @scala[[Pekko Quickstart with Scala guide](https://github.com/apache/incubator-pekko-quickstart-scala.g8)] @java[[Pekko Quickstart with Java guide](https://github.com/apache/incubator-pekko-quickstart-java.g8)] to download and run the Hello World example. You will use this as a seed project and add the functionality described in this tutorial.
 
 @@@ note
 Both the Java and Scala DSLs of Pekko modules bundled in the same JAR. For a smooth development experience,
 when using an IDE such as Eclipse or IntelliJ, you can disable the auto-importer from suggesting `javadsl`
-imports when working in Scala, or viceversa. See @ref:[IDE Tips](../../additional/ide.md). 
+imports when working in Scala, or vice versa. See @ref:[IDE Tips](../../additional/ide.md). 
 @@@
 
 ## IoT example use case

--- a/docs/src/main/paradox/typed/guide/tutorial_1.md
+++ b/docs/src/main/paradox/typed/guide/tutorial_1.md
@@ -23,7 +23,7 @@ An actor in Pekko always belongs to a parent. You create an actor by calling  @a
 _parent_ of the newly created _child_ actor. You might ask then, who is the parent of the _first_ actor you create?
 
 As illustrated below, all actors have a common parent, the user guardian, which is defined and created when you start the @apidoc[actor.typed.ActorSystem].
-As we covered in the @scala[[Quickstart Guide](https://developer.lightbend.com/guides/akka-quickstart-scala/)]@java[[Quickstart Guide](https://developer.lightbend.com/guides/akka-quickstart-java/)], creation of an actor returns a reference that is a valid URL. So, for example, if we create an actor named `someActor` from the user guardian with `context.spawn(someBehavior, "someActor")`, its reference will include the path `/user/someActor`.
+As we covered in the @scala[[Quickstart Guide](https://github.com/apache/incubator-pekko-quickstart-scala.g8)]@java[[Quickstart Guide](https://github.com/apache/incubator-pekko-quickstart-java.g8)], creation of an actor returns a reference that is a valid URL. So, for example, if we create an actor named `someActor` from the user guardian with `context.spawn(someBehavior, "someActor")`, its reference will include the path `/user/someActor`.
 
 ![actor tree diagram](diagrams/actor_top_tree.png)
 


### PR DESCRIPTION
will later try to publish the paradox docs for the 2 quickstart projects but the github links act as a start