### PR TITLE
Add toJavaPrimitive to OptionConverters

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/util/Scala212CompatTest.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/Scala212CompatTest.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+package org.apache.pekko.util
+
+import org.apache.pekko.util.OptionConverters._
+
+import java.util._
+
+/**
+ * These tests are here to ensure that methods from [[org.apache.pekko.util.FutureConverters]], [[org.apache.pekko.util.OptionConverters]]
+ * and [[org.apache.pekko.util.FunctionConverters]] that used within Pekko ecosystem but not Pekko core properly cross compile on Scala 2.12
+ * and Scala 2.13+.
+ *
+ * Remove this once Scala 2.12 support is dropped since all methods are in Scala 2.13+ stdlib
+ */
+object Scala212CompatTest {
+
+  // .toJavaPrimitive tests
+  val javaDoubleOptional: java.util.Optional[Double] = java.util.Optional.of(1.0)
+  val scalaDoubleOption: Option[Double] = Some(1.0)
+  val doubleOptionalToJavaPrimitive: OptionalDouble = javaDoubleOptional.toJavaPrimitive
+  val doubleOptionToJavaPrimitive: OptionalDouble = scalaDoubleOption.toJavaPrimitive
+
+  val javaIntOptional: java.util.Optional[Int] = java.util.Optional.of(1)
+  val scalaIntOption: Option[Int] = Some(1)
+  val intOptionalToJavaPrimitive: OptionalInt = javaIntOptional.toJavaPrimitive
+  val intOptionToJavaPrimitive: OptionalInt = scalaIntOption.toJavaPrimitive
+
+  val javaLongOptional: java.util.Optional[Long] = java.util.Optional.of(1L)
+  val scalaLongOption: Option[Long] = Some(1L)
+  val longOptionalToJavaPrimitive: OptionalLong = javaLongOptional.toJavaPrimitive
+  val longOptionToJavaPrimitive: OptionalLong = scalaLongOption.toJavaPrimitive
+}

--- a/actor/src/main/scala-2.12/org/apache/pekko/util/OptionConverters.scala
+++ b/actor/src/main/scala-2.12/org/apache/pekko/util/OptionConverters.scala
@@ -20,11 +20,19 @@ import java.util.Optional
  */
 @InternalStableApi
 private[pekko] object OptionConverters {
+  import scala.compat.java8.OptionConverters.SpecializerOfOptions
+
   implicit final class RichOptional[A](private val o: java.util.Optional[A]) extends AnyVal {
     @inline def toScala: Option[A] = scala.compat.java8.OptionConverters.RichOptionalGeneric(o).asScala
+
+    @inline def toJavaPrimitive[O](implicit specOp: SpecializerOfOptions[A, O]): O =
+      scala.compat.java8.OptionConverters.RichOptionalGeneric(o).asPrimitive
   }
 
   implicit final class RichOption[A](private val o: Option[A]) extends AnyVal {
     @inline def toJava: Optional[A] = scala.compat.java8.OptionConverters.RichOptionForJava8(o).asJava
+
+    @inline def toJavaPrimitive[O](implicit specOp: SpecializerOfOptions[A, O]): O =
+      scala.compat.java8.OptionConverters.RichOptionForJava8(o).asPrimitive
   }
 }

--- a/actor/src/main/scala-2.13+/org/apache/pekko/util/OptionConverters.scala
+++ b/actor/src/main/scala-2.13+/org/apache/pekko/util/OptionConverters.scala
@@ -12,6 +12,7 @@ package org.apache.pekko.util
 import org.apache.pekko.annotation.InternalStableApi
 
 import java.util.Optional
+import scala.jdk.OptionShape
 
 /**
  * INTERNAL API
@@ -22,9 +23,15 @@ import java.util.Optional
 private[pekko] object OptionConverters {
   implicit final class RichOptional[A](private val o: java.util.Optional[A]) extends AnyVal {
     @inline def toScala: Option[A] = scala.jdk.OptionConverters.RichOptional(o).toScala
+
+    @inline def toJavaPrimitive[O](implicit shape: OptionShape[A, O]): O =
+      scala.jdk.OptionConverters.RichOptional(o).toJavaPrimitive
   }
 
   implicit final class RichOption[A](private val o: Option[A]) extends AnyVal {
     @inline def toJava: Optional[A] = scala.jdk.OptionConverters.RichOption(o).toJava
+
+    def toJavaPrimitive[O](implicit shape: OptionShape[A, O]): O =
+      scala.jdk.OptionConverters.RichOption(o).toJavaPrimitive
   }
 }


### PR DESCRIPTION
When trying to integrate the changes from https://github.com/apache/incubator-pekko/pull/281 into pekko-http I hit a stumbling block where I missed the `.toJavaPrimitive` methods so this PR adds these methods into our `OptionConverters` helper. Since the `.toJavaPrimitive` methods are not being used within Pekko core itself, `Scala212CompatTest` was added to make sure that these helper methods cross compile against all Scala versions so that we don't deal with any regressions.