### PR TITLE
Add java Optional primitive to Scala converters

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/util/Scala212CompatTest.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/Scala212CompatTest.scala
@@ -37,4 +37,17 @@ object Scala212CompatTest {
   val scalaLongOption: Option[Long] = Some(1L)
   val longOptionalToJavaPrimitive: OptionalLong = javaLongOptional.toJavaPrimitive
   val longOptionToJavaPrimitive: OptionalLong = scalaLongOption.toJavaPrimitive
+
+  // from java optional primitive
+  val javaOptionalDouble: java.util.OptionalDouble = java.util.OptionalDouble.of(1.0)
+  val optionalDoubleToScala: Option[Double] = javaOptionalDouble.toScala
+  val optionalDoubleToJavaGeneric: Optional[Double] = javaOptionalDouble.toJavaGeneric
+
+  val javaOptionalInt: java.util.OptionalInt = java.util.OptionalInt.of(1)
+  val optionalIntToScala: Option[Int] = javaOptionalInt.toScala
+  val optionalIntToJavaGeneric: Optional[Int] = javaOptionalInt.toJavaGeneric
+
+  val javaOptionalLong: java.util.OptionalLong = java.util.OptionalLong.of(1L)
+  val optionalLongToScala: Option[Long] = javaOptionalLong.toScala
+  val optionalLongToJavaGeneric: Optional[Long] = javaOptionalLong.toJavaGeneric
 }

--- a/actor/src/main/scala-2.12/org/apache/pekko/util/OptionConverters.scala
+++ b/actor/src/main/scala-2.12/org/apache/pekko/util/OptionConverters.scala
@@ -11,7 +11,7 @@ package org.apache.pekko.util
 
 import org.apache.pekko.annotation.InternalStableApi
 
-import java.util.Optional
+import java.util._
 
 /**
  * INTERNAL API
@@ -34,5 +34,34 @@ private[pekko] object OptionConverters {
 
     @inline def toJavaPrimitive[O](implicit specOp: SpecializerOfOptions[A, O]): O =
       scala.compat.java8.OptionConverters.RichOptionForJava8(o).asPrimitive
+  }
+
+  implicit class RichOptionalDouble(private val o: OptionalDouble) extends AnyVal {
+
+    /** Convert a Java `OptionalDouble` to a Scala `Option` */
+    @inline def toScala: Option[Double] = scala.compat.java8.OptionConverters.RichOptionalDouble(o).asScala
+
+    /** Convert a Java `OptionalDouble` to a generic Java `Optional` */
+    @inline def toJavaGeneric: Optional[Double] = scala.compat.java8.OptionConverters.RichOptionalDouble(o).asGeneric
+  }
+
+  /** Provides conversions from `OptionalInt` to Scala `Option` and the generic `Optional` */
+  implicit class RichOptionalInt(private val o: OptionalInt) extends AnyVal {
+
+    /** Convert a Java `OptionalInt` to a Scala `Option` */
+    @inline def toScala: Option[Int] = scala.compat.java8.OptionConverters.RichOptionalInt(o).asScala
+
+    /** Convert a Java `OptionalInt` to a generic Java `Optional` */
+    @inline def toJavaGeneric: Optional[Int] = scala.compat.java8.OptionConverters.RichOptionalInt(o).asGeneric
+  }
+
+  /** Provides conversions from `OptionalLong` to Scala `Option` and the generic `Optional` */
+  implicit class RichOptionalLong(private val o: OptionalLong) extends AnyVal {
+
+    /** Convert a Java `OptionalLong` to a Scala `Option` */
+    @inline def toScala: Option[Long] = scala.compat.java8.OptionConverters.RichOptionalLong(o).asScala
+
+    /** Convert a Java `OptionalLong` to a generic Java `Optional` */
+    @inline def toJavaGeneric: Optional[Long] = scala.compat.java8.OptionConverters.RichOptionalLong(o).asGeneric
   }
 }

--- a/actor/src/main/scala-2.13+/org/apache/pekko/util/OptionConverters.scala
+++ b/actor/src/main/scala-2.13+/org/apache/pekko/util/OptionConverters.scala
@@ -11,7 +11,7 @@ package org.apache.pekko.util
 
 import org.apache.pekko.annotation.InternalStableApi
 
-import java.util.Optional
+import java.util._
 import scala.jdk.OptionShape
 
 /**
@@ -33,5 +33,34 @@ private[pekko] object OptionConverters {
 
     def toJavaPrimitive[O](implicit shape: OptionShape[A, O]): O =
       scala.jdk.OptionConverters.RichOption(o).toJavaPrimitive
+  }
+
+  implicit class RichOptionalDouble(private val o: OptionalDouble) extends AnyVal {
+
+    /** Convert a Java `OptionalDouble` to a Scala `Option` */
+    @inline def toScala: Option[Double] = scala.jdk.OptionConverters.RichOptionalDouble(o).toScala
+
+    /** Convert a Java `OptionalDouble` to a generic Java `Optional` */
+    @inline def toJavaGeneric: Optional[Double] = scala.jdk.OptionConverters.RichOptionalDouble(o).toJavaGeneric
+  }
+
+  /** Provides conversions from `OptionalInt` to Scala `Option` and the generic `Optional` */
+  implicit class RichOptionalInt(private val o: OptionalInt) extends AnyVal {
+
+    /** Convert a Java `OptionalInt` to a Scala `Option` */
+    @inline def toScala: Option[Int] = scala.jdk.OptionConverters.RichOptionalInt(o).toScala
+
+    /** Convert a Java `OptionalInt` to a generic Java `Optional` */
+    @inline def toJavaGeneric: Optional[Int] = scala.jdk.OptionConverters.RichOptionalInt(o).toJavaGeneric
+  }
+
+  /** Provides conversions from `OptionalLong` to Scala `Option` and the generic `Optional` */
+  implicit class RichOptionalLong(private val o: OptionalLong) extends AnyVal {
+
+    /** Convert a Java `OptionalLong` to a Scala `Option` */
+    @inline def toScala: Option[Long] = scala.jdk.OptionConverters.RichOptionalLong(o).toScala
+
+    /** Convert a Java `OptionalLong` to a generic Java `Optional` */
+    @inline def toJavaGeneric: Optional[Long] = scala.jdk.OptionConverters.RichOptionalLong(o).toJavaGeneric
   }
 }


### PR DESCRIPTION
Another case of finding more converters that have to be added to `OptionConverters` to get pekko-http with https://github.com/apache/incubator-pekko/pull/281 PR