### PR TITLE
Add OptionConverters.toJava and OptionConverters.toScala

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/util/Scala212CompatTest.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/Scala212CompatTest.scala
@@ -50,4 +50,7 @@ object Scala212CompatTest {
   val javaOptionalLong: java.util.OptionalLong = java.util.OptionalLong.of(1L)
   val optionalLongToScala: Option[Long] = javaOptionalLong.toScala
   val optionalLongToJavaGeneric: Optional[Long] = javaOptionalLong.toJavaGeneric
+
+  // OptionConverters toScala and toJava
+  OptionConverters.toJava(OptionConverters.toScala(java.util.Optional.of("")))
 }

--- a/actor/src/main/scala-2.12/org/apache/pekko/util/OptionConverters.scala
+++ b/actor/src/main/scala-2.12/org/apache/pekko/util/OptionConverters.scala
@@ -22,6 +22,10 @@ import java.util._
 private[pekko] object OptionConverters {
   import scala.compat.java8.OptionConverters.SpecializerOfOptions
 
+  @inline final def toScala[A](o: Optional[A]): Option[A] = scala.compat.java8.OptionConverters.toScala(o)
+
+  @inline final def toJava[A](o: Option[A]): Optional[A] = scala.compat.java8.OptionConverters.toJava(o)
+
   implicit final class RichOptional[A](private val o: java.util.Optional[A]) extends AnyVal {
     @inline def toScala: Option[A] = scala.compat.java8.OptionConverters.RichOptionalGeneric(o).asScala
 

--- a/actor/src/main/scala-2.13+/org/apache/pekko/util/OptionConverters.scala
+++ b/actor/src/main/scala-2.13+/org/apache/pekko/util/OptionConverters.scala
@@ -21,6 +21,11 @@ import scala.jdk.OptionShape
  */
 @InternalStableApi
 private[pekko] object OptionConverters {
+
+  @inline final def toScala[A](o: Optional[A]): Option[A] = scala.jdk.javaapi.OptionConverters.toScala(o)
+
+  @inline final def toJava[A](o: Option[A]): Optional[A] = scala.jdk.javaapi.OptionConverters.toJava(o)
+
   implicit final class RichOptional[A](private val o: java.util.Optional[A]) extends AnyVal {
     @inline def toScala: Option[A] = scala.jdk.OptionConverters.RichOptional(o).toScala
 


### PR DESCRIPTION
And yet another case of finding more converters that have to be added to `OptionConverters` to get pekko-http with https://github.com/apache/incubator-pekko/pull/281 PR