### PR TITLE
Add OptionConverters.toScala methods for java Optional primitives

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/util/Scala212CompatTest.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/Scala212CompatTest.scala
@@ -53,4 +53,8 @@ object Scala212CompatTest {
 
   // OptionConverters toScala and toJava
   OptionConverters.toJava(OptionConverters.toScala(java.util.Optional.of("")))
+  OptionConverters.toJava(OptionConverters.toScala(java.util.OptionalDouble.of(1.0)))
+  OptionConverters.toJava(OptionConverters.toScala(java.util.OptionalInt.of(1)))
+  OptionConverters.toJava(OptionConverters.toScala(java.util.OptionalLong.of(1L)))
+
 }

--- a/actor/src/main/scala-2.12/org/apache/pekko/util/OptionConverters.scala
+++ b/actor/src/main/scala-2.12/org/apache/pekko/util/OptionConverters.scala
@@ -21,8 +21,20 @@ import java.util._
 @InternalStableApi
 private[pekko] object OptionConverters {
   import scala.compat.java8.OptionConverters.SpecializerOfOptions
+  import scala.compat.java8.OptionConverters._
 
   @inline final def toScala[A](o: Optional[A]): Option[A] = scala.compat.java8.OptionConverters.toScala(o)
+
+  // The rest of the .toScala methods that work with OptionalDouble/OptionalInt/OptionalLong have to be manually
+  // redefined because the scala.compat.java8.OptionConverters.toScala variants work with scala.lang primitive types
+  // where as scala.jdk.javaapi.OptionConverters.toScala works with java.lang primitive types. Since the primary
+  // usecase of these functions is for calling within Java code its preferrable to return Java primitives, see
+  // https://github.com/scala/bug/issues/4214
+  def toScala(o: OptionalDouble): Option[java.lang.Double] = if (o.isPresent) Some(o.getAsDouble) else None
+
+  def toScala(o: OptionalInt): Option[java.lang.Integer] = if (o.isPresent) Some(o.getAsInt) else None
+
+  def toScala(o: OptionalLong): Option[java.lang.Long] = if (o.isPresent) Some(o.getAsLong) else None
 
   @inline final def toJava[A](o: Option[A]): Optional[A] = scala.compat.java8.OptionConverters.toJava(o)
 

--- a/actor/src/main/scala-2.13+/org/apache/pekko/util/OptionConverters.scala
+++ b/actor/src/main/scala-2.13+/org/apache/pekko/util/OptionConverters.scala
@@ -24,6 +24,12 @@ private[pekko] object OptionConverters {
 
   @inline final def toScala[A](o: Optional[A]): Option[A] = scala.jdk.javaapi.OptionConverters.toScala(o)
 
+  @inline def toScala(o: OptionalDouble): Option[java.lang.Double] = scala.jdk.javaapi.OptionConverters.toScala(o)
+
+  @inline def toScala(o: OptionalInt): Option[java.lang.Integer] = scala.jdk.javaapi.OptionConverters.toScala(o)
+
+  @inline def toScala(o: OptionalLong): Option[java.lang.Long] = scala.jdk.javaapi.OptionConverters.toScala(o)
+
   @inline final def toJava[A](o: Option[A]): Optional[A] = scala.jdk.javaapi.OptionConverters.toJava(o)
 
   implicit final class RichOptional[A](private val o: java.util.Optional[A]) extends AnyVal {


### PR DESCRIPTION
As pointed out in https://github.com/apache/incubator-pekko-http/pull/142#pullrequestreview-1417421049 we should do our best to avoid usage of the `Rich*` implicit classes within Java code especially since Java doesn't do inlining (unlike Scala).

I checked the pekko-http code and within Java sources we only use the `.toScala` methods (the Scala to Java conversion cases are done within Scala source which uses the standard extension methods).