### PR TITLE
Integrate sbt-license-report

### DIFF
--- a/docs/src/main/paradox/project/index.md
+++ b/docs/src/main/paradox/project/index.md
@@ -15,6 +15,7 @@
 * [rolling-update](rolling-update.md)
 * [issue-tracking](issue-tracking.md)
 * [licenses](licenses.md)
+* [license-report](license-report.md) 
 * [faq](../additional/faq.md)
 * [books](../additional/books.md)
 * [examples](examples.md)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -75,44 +75,44 @@ object Dependencies {
   object Compile {
     // Compile
 
-    val config = "com.typesafe" % "config" % "1.4.2" // ApacheV2
-    val netty = "io.netty" % "netty" % nettyVersion // ApacheV2
+    val config = "com.typesafe" % "config" % "1.4.2"
+    val netty = "io.netty" % "netty" % nettyVersion
 
-    val scalaReflect = ScalaVersionDependentModuleID.versioned("org.scala-lang" % "scala-reflect" % _) // Scala License
+    val scalaReflect = ScalaVersionDependentModuleID.versioned("org.scala-lang" % "scala-reflect" % _)
 
-    val slf4jApi = "org.slf4j" % "slf4j-api" % slf4jVersion // MIT
+    val slf4jApi = "org.slf4j" % "slf4j-api" % slf4jVersion
 
     // mirrored in OSGi sample https://github.com/akka/akka-samples/tree/2.6/akka-sample-osgi-dining-hakkers
-    val osgiCore = "org.osgi" % "org.osgi.core" % "6.0.0" // ApacheV2
-    val osgiCompendium = "org.osgi" % "org.osgi.compendium" % "5.0.0" // ApacheV2
+    val osgiCore = "org.osgi" % "org.osgi.core" % "6.0.0"
+    val osgiCompendium = "org.osgi" % "org.osgi.compendium" % "5.0.0"
 
-    val sigar = "org.fusesource" % "sigar" % "1.6.4" // ApacheV2
+    val sigar = "org.fusesource" % "sigar" % "1.6.4"
 
-    val jctools = "org.jctools" % "jctools-core" % "3.3.0" // ApacheV2
+    val jctools = "org.jctools" % "jctools-core" % "3.3.0"
 
     // reactive streams
-    val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion // MIT-0
+    val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion
 
     // ssl-config
     val sslConfigCore = Def.setting {
-      "com.typesafe" %% "ssl-config-core" % sslConfigVersion.value // ApacheV2
+      "com.typesafe" %% "ssl-config-core" % sslConfigVersion.value
     }
 
-    val lmdb = "org.lmdbjava" % "lmdbjava" % "0.7.0" // ApacheV2, OpenLDAP Public License
+    val lmdb = "org.lmdbjava" % "lmdbjava" % "0.7.0"
 
-    val junit = "junit" % "junit" % junitVersion // Common Public License 1.0
+    val junit = "junit" % "junit" % junitVersion
 
     // For Java 8 Conversions
     val java8Compat = Def.setting {
       "org.scala-lang.modules" %% "scala-java8-compat" % java8CompatVersion.value
-    } // Scala License
+    }
 
-    val aeronDriver = "io.aeron" % "aeron-driver" % aeronVersion // ApacheV2
-    val aeronClient = "io.aeron" % "aeron-client" % aeronVersion // ApacheV2
+    val aeronDriver = "io.aeron" % "aeron-driver" % aeronVersion
+    val aeronClient = "io.aeron" % "aeron-client" % aeronVersion
     // Added explicitly for when artery tcp is used
-    val agrona = "org.agrona" % "agrona" % agronaVersion // ApacheV2
+    val agrona = "org.agrona" % "agrona" % agronaVersion
 
-    val asnOne = ("com.hierynomus" % "asn-one" % "0.5.0").exclude("org.slf4j", "slf4j-api") // ApacheV2
+    val asnOne = ("com.hierynomus" % "asn-one" % "0.5.0").exclude("org.slf4j", "slf4j-api")
 
     val jacksonCore = Def.setting {
       "com.fasterxml.jackson.core" % "jackson-core" % jacksonCoreVersion
@@ -138,9 +138,9 @@ object Dependencies {
     val jacksonCbor = Def.setting {
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonCoreVersion
     } // ApacheV2
-    val lz4Java = "org.lz4" % "lz4-java" % "1.8.0" // ApacheV2
+    val lz4Java = "org.lz4" % "lz4-java" % "1.8.0"
 
-    val logback = "ch.qos.logback" % "logback-classic" % logbackVersion // EPL 1.0
+    val logback = "ch.qos.logback" % "logback-classic" % logbackVersion
 
     object Docs {
       val sprayJson = "io.spray" %% "spray-json" % "1.3.6" % Test
@@ -148,11 +148,11 @@ object Dependencies {
     }
 
     object TestDependencies {
-      val commonsMath = "org.apache.commons" % "commons-math" % "2.2" % Test // ApacheV2
-      val commonsIo = "commons-io" % "commons-io" % "2.11.0" % Test // ApacheV2
-      val commonsCodec = "commons-codec" % "commons-codec" % "1.15" % Test // ApacheV2
-      val junit = "junit" % "junit" % junitVersion % "test" // Common Public License 1.0
-      val logback = Compile.logback % Test // EPL 1.0
+      val commonsMath = "org.apache.commons" % "commons-math" % "2.2" % Test
+      val commonsIo = "commons-io" % "commons-io" % "2.11.0" % Test
+      val commonsCodec = "commons-codec" % "commons-codec" % "1.15" % Test
+      val junit = "junit" % "junit" % junitVersion % "test"
+      val logback = Compile.logback % Test
 
       val scalatest = Def.setting { "org.scalatest" %% "scalatest" % scalaTestVersion.value % Test } // ApacheV2
 
@@ -161,63 +161,63 @@ object Dependencies {
       // version it was intended to work with
       val scalatestJUnit = Def.setting {
         "org.scalatestplus" %% "junit-4-13" % (scalaTestVersion.value + ".0") % Test
-      } // ApacheV2
+      }
       val scalatestTestNG = Def.setting {
         "org.scalatestplus" %% "testng-6-7" % (scalaTestVersion.value + ".0") % Test
-      } // ApacheV2
+      }
       val scalatestScalaCheck = Def.setting {
         "org.scalatestplus" %% s"scalacheck-${scalaTestScalaCheckVersion.value}" % (scalaTestVersion.value + ".0") % Test
-      } // ApacheV2
+      }
       val scalatestMockito = Def.setting {
         "org.scalatestplus" %% "mockito-3-4" % (scalaTestVersion.value + ".0") % Test
-      } // ApacheV2
+      }
 
-      val pojosr = "com.googlecode.pojosr" % "de.kalpatec.pojosr.framework" % "0.2.1" % Test // ApacheV2
-      val tinybundles = "org.ops4j.pax.tinybundles" % "tinybundles" % "3.0.0" % Test // ApacheV2
-      val log4j = "log4j" % "log4j" % "1.2.17" % Test // ApacheV2
+      val pojosr = "com.googlecode.pojosr" % "de.kalpatec.pojosr.framework" % "0.2.1" % Test
+      val tinybundles = "org.ops4j.pax.tinybundles" % "tinybundles" % "3.0.0" % Test
+      val log4j = "log4j" % "log4j" % "1.2.17" % Test
 
       // in-memory filesystem for file related tests
-      val jimfs = "com.google.jimfs" % "jimfs" % "1.1" % Test // ApacheV2
+      val jimfs = "com.google.jimfs" % "jimfs" % "1.1" % Test
 
       // docker utils
-      val dockerClient = "com.spotify" % "docker-client" % "8.16.0" % Test // ApacheV2
+      val dockerClient = "com.spotify" % "docker-client" % "8.16.0" % Test
 
       // metrics, measurements, perf testing
-      val metrics = "io.dropwizard.metrics" % "metrics-core" % "4.2.10" % Test // ApacheV2
-      val metricsJvm = "io.dropwizard.metrics" % "metrics-jvm" % "4.2.10" % Test // ApacheV2
-      val latencyUtils = "org.latencyutils" % "LatencyUtils" % "2.0.3" % Test // Free BSD
-      val hdrHistogram = "org.hdrhistogram" % "HdrHistogram" % "2.1.12" % Test // CC0
+      val metrics = "io.dropwizard.metrics" % "metrics-core" % "4.2.10" % Test
+      val metricsJvm = "io.dropwizard.metrics" % "metrics-jvm" % "4.2.10" % Test
+      val latencyUtils = "org.latencyutils" % "LatencyUtils" % "2.0.3" % Test
+      val hdrHistogram = "org.hdrhistogram" % "HdrHistogram" % "2.1.12" % Test
       val metricsAll = Seq(metrics, metricsJvm, latencyUtils, hdrHistogram)
 
       // sigar logging
-      val slf4jJul = "org.slf4j" % "jul-to-slf4j" % slf4jVersion % Test // MIT
-      val slf4jLog4j = "org.slf4j" % "log4j-over-slf4j" % slf4jVersion % Test // MIT
+      val slf4jJul = "org.slf4j" % "jul-to-slf4j" % slf4jVersion % Test
+      val slf4jLog4j = "org.slf4j" % "log4j-over-slf4j" % slf4jVersion % Test
 
       // reactive streams tck
       val reactiveStreamsTck = ("org.reactivestreams" % "reactive-streams-tck" % reactiveStreamsVersion % Test)
-        .exclude("org.testng", "testng") // MIT-0
+        .exclude("org.testng", "testng")
 
       val protobufRuntime = "com.google.protobuf" % "protobuf-java" % protobufJavaVersion % Test
 
       // YCSB (Yahoo Cloud Serving Benchmark https://ycsb.site)
-      val ycsb = "site.ycsb" % "core" % "0.17.0" % Test // ApacheV2
+      val ycsb = "site.ycsb" % "core" % "0.17.0" % Test
     }
 
     object Provided {
       // TODO remove from "test" config
-      val sigarLoader = "io.kamon" % "sigar-loader" % "1.6.6-rev002" % "optional;provided;test" // ApacheV2
+      val sigarLoader = "io.kamon" % "sigar-loader" % "1.6.6-rev002" % "optional;provided;test"
 
       val activation = "com.sun.activation" % "javax.activation" % "1.2.0" % "provided;test"
 
-      val levelDB = "org.iq80.leveldb" % "leveldb" % "0.12" % "optional;provided" // ApacheV2
-      val levelDBmultiJVM = "org.iq80.leveldb" % "leveldb" % "0.12" % "optional;provided;multi-jvm;test" // ApacheV2
-      val levelDBNative = "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8" % "optional;provided" // New BSD
+      val levelDB = "org.iq80.leveldb" % "leveldb" % "0.12" % "optional;provided"
+      val levelDBmultiJVM = "org.iq80.leveldb" % "leveldb" % "0.12" % "optional;provided;multi-jvm;test"
+      val levelDBNative = "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8" % "optional;provided"
 
       val junit = Compile.junit % "optional;provided;test"
 
-      val scalatest = Def.setting { "org.scalatest" %% "scalatest" % scalaTestVersion.value % "optional;provided;test" } // ApacheV2
+      val scalatest = Def.setting { "org.scalatest" %% "scalatest" % scalaTestVersion.value % "optional;provided;test" }
 
-      val logback = Compile.logback % "optional;provided;test" // EPL 1.0
+      val logback = Compile.logback % "optional;provided;test"
 
       val protobufRuntime = "com.google.protobuf" % "protobuf-java" % protobufJavaVersion % "optional;provided"
 

--- a/project/LicenseReport.scala
+++ b/project/LicenseReport.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+import com.lightbend.paradox.sbt.ParadoxPlugin
+import com.lightbend.paradox.sbt.ParadoxPlugin.autoImport.paradox
+import org.apache.pekko.Paradox
+import sbt.Keys._
+import sbt._
+import sbtlicensereport.SbtLicenseReport
+import sbtlicensereport.SbtLicenseReport.autoImportImpl._
+import sbtlicensereport.license.{ DepModuleInfo, MarkDown }
+
+object LicenseReport extends AutoPlugin {
+
+  override lazy val projectSettings = Seq(
+    licenseReportTypes := Seq(MarkDown),
+    licenseReportMakeHeader := (language => language.header1("License Report")),
+    licenseConfigurations := Set("compile", "test", "provided"),
+    licenseDepExclusions := {
+      case DepModuleInfo("org.apache.pekko", _, _) => true // Inter pekko project dependencies are pointless
+      case DepModuleInfo(_, "scala-library", _)    => true // Scala library is part of Scala language
+    },
+    licenseReportColumns := Seq(
+      Column.Category,
+      Column.License,
+      Column.Dependency,
+      Column.OriginatingArtifactName,
+      Column.Configuration))
+
+  override def requires = plugins.JvmPlugin && SbtLicenseReport
+
+  override def trigger = allRequirements
+
+}

--- a/project/Paradox.scala
+++ b/project/Paradox.scala
@@ -20,6 +20,7 @@ import com.lightbend.sbt.publishrsync.PublishRsyncPlugin.autoImport._
 import org.apache.pekko.PekkoParadoxPlugin.autoImport._
 import sbt.Keys._
 import sbt._
+import sbtlicensereport.SbtLicenseReport.autoImportImpl.dumpLicenseReportAggregate
 
 import scala.concurrent.duration._
 
@@ -89,6 +90,15 @@ object Paradox {
 
   val parsingSettings = Seq(Compile / paradoxParsingTimeout := 5.seconds)
 
+  val sourceGeneratorSettings = Seq(
+    Compile / paradoxMarkdownToHtml / sourceGenerators += Def.taskDyn {
+      val targetFile = (Compile / paradox / sourceManaged).value / "project" / "license-report.md"
+
+      (LocalRootProject / dumpLicenseReportAggregate).map { dir =>
+        IO.copy(List(dir / "pekko-root-licenses.md" -> targetFile)).toList
+      }
+    }.taskValue)
+
   val settings =
     propertiesSettings ++
     rootsSettings ++
@@ -96,6 +106,7 @@ object Paradox {
     groupsSettings ++
     parsingSettings ++
     themeSettings ++
+    sourceGeneratorSettings ++
     Seq(
       Compile / paradox / name := "Pekko",
       resolvers += Resolver.jcenterRepo,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,6 +22,7 @@ addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.2")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.5")
 addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.6")
 addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.2.2")
+addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.5.0")
 
 // allow access to snapshots for pekko-sbt-paradox
 resolvers += Resolver.ApacheMavenSnapshotsRepo


### PR DESCRIPTION
This PR integrates the latest release of [sbt-license-report](https://github.com/sbt/sbt-license-report) into Pekko docs. This is done by using paradox's source generator support (see https://developer.lightbend.com/docs/paradox/current/customization/generators.html), the integration is quite straight forward due to the fact that sbt-license-report generates markdown format. In summary the whole process is entirely automated, when you run `paradox/docs` the report will be there for you and one can always manually run the various sbt license-report tasks manually (such as `dumpLicenseReportAggregate`). In the current implementation, the report is put into the `Project -> License Report `section of the docs and looks like this

![image](https://github.com/apache/incubator-pekko/assets/2337269/99178b41-f942-419b-8ecb-456819d98af1)

In addition, this PR removes the license comments in `project/Dependencies.scala` since the whole point of sbt-license-report is to automate this (and it also does it correctly since it inspects the internal dependency resolution that SBT performs). 

Last thing to talk about is the configuration of the plugin, notably

* `licenseConfigurations`: This specifies which scopes we want the license report to scan. I opted for `Set("compile", "test", "provided")` which basically means that it will include all of the dependencies, even for tests. There is an argument to just set it to `Set("compile")` since thats typically the only thing that companies care about (i.e. its only code in `compile` that gets run)
* `licenseDepExclusions`: This allows us to remove dependencies from the report that we may find problematic. I opted to remove the Scala library with `DepModuleInfo(_, "scala-library", _)` since it can be considered implied? I also removed `case DepModuleInfo("org.apache.pekko", _, _)` since the various pekko artifacts defined in this project depend on eachother and just make extra noise
`licenseReportColumns`: Lets us specify which columns we want. Of note is `Column.OriginatingArtifactName` which shows from which specific pekko module a project comes from. If we remove this column it greatly reduces the length of the report  since a lot of dependencies (i.e. slf4j) are shared between a lot of pekko artifacts but then the ability to know which artifact contains which dependency is lost.