### PR TITLE
Update sbt-apache-sonatype and handle rename

### DIFF
--- a/project/AddMetaInfLicenseFiles.scala
+++ b/project/AddMetaInfLicenseFiles.scala
@@ -9,8 +9,8 @@
 
 import sbt.Keys._
 import sbt._
-import org.mdedetrich.apache.sonatype.SonatypeApachePlugin
-import org.mdedetrich.apache.sonatype.SonatypeApachePlugin.autoImport._
+import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin
+import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin.autoImport._
 
 /**
  * Copies LICENSE and NOTICE files into jar META-INF dir
@@ -53,7 +53,7 @@ object AddMetaInfLicenseFiles extends AutoPlugin {
     resourceGenerators += {
       Def.task {
         List(
-          SonatypeApachePlugin.addFileToMetaInf(resourceManaged.value, baseDir.value / "COPYING.protobuf"))
+          ApacheSonatypePlugin.addFileToMetaInf(resourceManaged.value, baseDir.value / "COPYING.protobuf"))
       }
     }))
 
@@ -67,11 +67,11 @@ object AddMetaInfLicenseFiles extends AutoPlugin {
       resourceGenerators += {
         Def.task {
           List(
-            SonatypeApachePlugin.addFileToMetaInf(resourceManaged.value, baseDir.value / "COPYING.protobuf"))
+            ApacheSonatypePlugin.addFileToMetaInf(resourceManaged.value, baseDir.value / "COPYING.protobuf"))
         }
       }))
 
   override def trigger = allRequirements
 
-  override def requires = SonatypeApachePlugin
+  override def requires = ApacheSonatypePlugin
 }

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -16,7 +16,7 @@ package org.apache.pekko
 import sbt._
 import sbt.Keys._
 import com.lightbend.sbt.publishrsync.PublishRsyncPlugin.autoImport.publishRsyncHost
-import org.mdedetrich.apache.sonatype.SonatypeApachePlugin
+import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin
 import sbtdynver.DynVerPlugin
 import sbtdynver.DynVerPlugin.autoImport.dynverSonatypeSnapshots
 
@@ -37,7 +37,7 @@ object Publish extends AutoPlugin {
   override lazy val buildSettings = Seq(
     dynverSonatypeSnapshots := true)
 
-  override def requires = SonatypeApachePlugin && DynVerPlugin
+  override def requires = ApacheSonatypePlugin && DynVerPlugin
 }
 
 /**

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,7 +20,7 @@ addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.30")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.2")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.5")
-addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.6")
+addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.7")
 addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.2.2")
 addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.5.0")
 


### PR DESCRIPTION
Updates sbt-apache-sonatype. Note that this new version renames `SonatypeApachePlugin` to `ApacheSonatypePlugin` to be consistent with the project name.