### PR TITLE
add build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,29 @@ Pekko is a fork of [Akka](https://github.com/akka/akka) 2.6.x, prior to the Akka
 Reference Documentation
 -----------------------
 
-See https://pekko.apache.org for the documentation including the API docs.
+See https://pekko.apache.org for the documentation including the API docs. The docs for all the Apache Pekko modules can be found there.
 
 Building from Source
 --------------------
 
-* You will need to install [sbt](https://www.scala-sbt.org/) if you don't already have it installed
-* Use git to clone the [repo](https://github.com/apache/incubator-pekko) or download a source release from https://pekko.apache.org
-* Open a command window and change directory to the directory where you installed the source
-* `sbt test` will build the jars and run the unit tests
-* `sbt docs/paradox` will build the docs
+- You will need to install [sbt](https://www.scala-sbt.org/) if you don't already have it installed
+- You should have a Java Runtime installed. Java 8 minimum.
+- Use git to clone the [repo](https://github.com/apache/incubator-pekko) or download a source release from https://pekko.apache.org
+- Open a command window and change directory to the directory where you installed the source
+- `sbt compile` compiles the main source for project default version of Scala (2.13)
+    - `sbt +compile` will compile for all supported versions of Scala
+- `sbt test` will compile the code and run the unit tests
+- `sbt package` will build the jars
+    - the jars will built into target dirs of the various modules
+    - for the the 'actor' module, the jar will be built to `actor/target/scala-2.13/`
+- `sbt publishLocal` will push the jars to your local Apache Ivy repository
+- `sbt publishM2` will push the jars to your local Apache Maven repository
+- `sbt docs/paradox` will build the docs (the ones describing the module features)
+     - Requires Java 11 minimum
+     - `sbt docs/paradoxBrowse` does the same but will open the docs in your browser when complete
+     - the `index.html` file will appear in `target/paradox/site/main/`
+- `sbt unidoc` will build the Javadocs for all the modules and load them to one place
+     - the `index.html` file will appear in `target/scala-2.13/unidoc/`
 
 Community
 ---------
@@ -31,6 +44,7 @@ There are several ways to interact with the Pekko community:
 
 - [GitHub discussions](https://github.com/apache/incubator-pekko/discussions): for questions and general discussion.
 - [Pekko dev mailing list](https://lists.apache.org/list.html?dev@pekko.apache.org): for Pekko development discussions.
+- [Pekko users mailing list](https://lists.apache.org/list.html?users@pekko.apache.org): for Pekko user discussions.
 - [GitHub issues](https://github.com/apache/incubator-pekko/issues): for bug reports and feature requests. Please search the existing issues before creating new ones. If you are unsure whether you have found a bug, consider asking in GitHub discussions or the mailing list first.
 
 Contributing

--- a/README.md
+++ b/README.md
@@ -13,7 +13,16 @@ Pekko is a fork of [Akka](https://github.com/akka/akka) 2.6.x, prior to the Akka
 Reference Documentation
 -----------------------
 
-**TODO add documentation links**
+See https://pekko.apache.org for the documentation including the API docs.
+
+Building from Source
+--------------------
+
+* You will need to install [sbt](https://www.scala-sbt.org/) if you don't already have it installed
+* Use git to clone the [repo](https://github.com/apache/incubator-pekko) or download a source release from https://pekko.apache.org
+* Open a command window and change directory to the directory where you installed the source
+* `sbt test` will build the jars and run the unit tests
+* `sbt docs/paradox` will build the docs
 
 Community
 ---------


### PR DESCRIPTION
* it's useful if our source release has some basic build instructions
* The Apache Incubator team will need basic instructions for validating our source releases
