### PR TITLE
Document JAVA_8_HOME in error message

### DIFF
--- a/project/JdkOptions.scala
+++ b/project/JdkOptions.scala
@@ -88,7 +88,7 @@ object JdkOptions extends AutoPlugin {
           jdk11options(java8home)
         case None =>
           throw new MessageOnlyException(
-            "A JDK 8 installation was not found, but is required to build Apache Pekko. To manually specify a JDK 8 installation, use the \"set every jdk8home := \\\"/path/to/jdk\\\" sbt command. If you have no JDK 8 installation, target your system JDK with the \"set every targetSystemJdk := true\" sbt command, but beware resulting artifacts will not work on JDK 8")
+            "A JDK 8 installation was not found, but is required to build Apache Pekko. To manually specify a JDK 8 installation, set the JAVA_8_HOME environment variable to its path or use the \"set every jdk8home := \\\"/path/to/jdk\\\" sbt command. If you have no JDK 8 installation, target your system JDK with the \"set every targetSystemJdk := true\" sbt command, but beware resulting artifacts will not work on JDK 8")
       }
 
   val targetJdkSettings = Seq(targetSystemJdk := false, jdk8home := sys.env.get("JAVA_8_HOME").getOrElse(""))


### PR DESCRIPTION
When no Java 8 installation is found, mention in the error message that you can also use the JAVA_8_HOME environment variable to help the build find it.