### PR TITLE
issue with osgi project scaladoc (scala3)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -278,7 +278,7 @@ lazy val osgi = pekkoModule("osgi")
   .settings(Dependencies.osgi)
   .settings(AutomaticModuleName.settings("pekko.osgi"))
   .settings(OSGi.osgi)
-  .settings(Test / parallelExecution := false, crossScalaVersions -= Dependencies.scala3Version)
+  .settings(Test / parallelExecution := false)
 
 lazy val persistence = pekkoModule("persistence")
   .dependsOn(actor, stream, testkit % "test->test")


### PR DESCRIPTION
* this exclusion of Scala3 cross build causes the scaladoc build to fail for me
* maybe there is a good reason to exclude this - but I don't know what it is
* this PR change means `sbt ++3.3.0 publishSigned` works for me now
* not sure why this does not seem to happen in CI build

@raboof @jrudolph would you have any ideas about this?

I had a quick look at Akka and they don't seem to have the osgi stuff any more - see https://github.com/akka/akka/issues/28304

fyi @mdedetrich 