### PR TITLE
Add inline final to FutureConverters

### DIFF
--- a/actor/src/main/scala-2.12/org/apache/pekko/util/FutureConverters.scala
+++ b/actor/src/main/scala-2.12/org/apache/pekko/util/FutureConverters.scala
@@ -21,13 +21,13 @@ import scala.concurrent.Future
  */
 @InternalStableApi
 private[pekko] object FutureConverters {
-  def asJava[T](f: Future[T]): CompletionStage[T] = scala.compat.java8.FutureConverters.toJava(f)
+  @inline final def asJava[T](f: Future[T]): CompletionStage[T] = scala.compat.java8.FutureConverters.toJava(f)
 
   implicit final class FutureOps[T](private val f: Future[T]) extends AnyVal {
     @inline def asJava: CompletionStage[T] = FutureConverters.asJava(f)
   }
 
-  def asScala[T](cs: CompletionStage[T]): Future[T] = scala.compat.java8.FutureConverters.toScala(cs)
+  @inline final def asScala[T](cs: CompletionStage[T]): Future[T] = scala.compat.java8.FutureConverters.toScala(cs)
 
   implicit final class CompletionStageOps[T](private val cs: CompletionStage[T]) extends AnyVal {
     @inline def asScala: Future[T] = FutureConverters.asScala(cs)

--- a/actor/src/main/scala-2.13+/org/apache/pekko/util/FutureConverters.scala
+++ b/actor/src/main/scala-2.13+/org/apache/pekko/util/FutureConverters.scala
@@ -23,13 +23,13 @@ import scala.concurrent.Future
 private[pekko] object FutureConverters {
   import scala.jdk.javaapi
 
-  def asJava[T](f: Future[T]): CompletionStage[T] = javaapi.FutureConverters.asJava(f)
+  @inline final def asJava[T](f: Future[T]): CompletionStage[T] = javaapi.FutureConverters.asJava(f)
 
   implicit final class FutureOps[T](private val f: Future[T]) extends AnyVal {
     @inline def asJava: CompletionStage[T] = FutureConverters.asJava(f)
   }
 
-  def asScala[T](cs: CompletionStage[T]): Future[T] = javaapi.FutureConverters.asScala(cs)
+  @inline final def asScala[T](cs: CompletionStage[T]): Future[T] = javaapi.FutureConverters.asScala(cs)
 
   implicit final class CompletionStageOps[T](private val cs: CompletionStage[T]) extends AnyVal {
     @inline def asScala: Future[T] = FutureConverters.asScala(cs)


### PR DESCRIPTION
While the inline isn't that important here, the most critical thing is that the addition of `final` in order to make sure that we don't get any problems down the road. Note that this change is making `FutureConverters` consistent with `OptionConverters`.