### PR TITLE
add license header to sbt files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,12 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
 import org.apache.pekko._
 
 ThisBuild / scalafixScalaBinaryVersion := scalaBinaryVersion.value

--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -35,7 +35,8 @@ trait CopyrightHeader extends AutoPlugin {
             HeaderFileType.scala -> cStyleComment,
             HeaderFileType.java -> cStyleComment,
             HeaderFileType.conf -> hashLineComment,
-            HeaderFileType("template") -> cStyleComment)))
+            HeaderFileType("template") -> cStyleComment,
+            HeaderFileType("sbt") -> cStyleComment)))
     }
 
   override def projectSettings: Seq[Def.Setting[_]] =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,12 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
 
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.7.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,7 +22,7 @@ addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
 
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.7.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.9.0")
 addSbtPlugin("com.hpe.sbt" % "sbt-pull-request-validator" % "1.0.0")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.30")
 


### PR DESCRIPTION
The CopyrightHeader.scala change to apply headers to `.sbt` files didn't actually have an effect. I then manually added the headers. I left the CopyrightHeader.scala change there just in case a future version of sbt-header checks the `.sbt` files.