### PR TITLE
=sbt Add headers for sbt files.

### DIFF
--- a/project/CopyrightHeaderForBuild.scala
+++ b/project/CopyrightHeaderForBuild.scala
@@ -24,7 +24,9 @@ object CopyrightHeaderForBuild extends CopyrightHeader {
     Seq(Compile, Test).flatMap { config =>
       inConfig(config) {
         Seq(
-          config / headerSources ++= (((config / baseDirectory).value / "project") ** "*.scala").get,
+          config / headerSources ++= (((config / baseDirectory).value / "project") ** ("*.scala" || "*.sbt")).get,
+          config / headerSources ++= ((config / baseDirectory).value ** "*.sbt").get,
+          headerMappings := headerMappings.value ++ Map(HeaderFileType("sbt") -> cStyleComment),
           headerMappings := headerMappings.value ++ Map(HeaderFileType.scala -> cStyleComment))
       }
     }


### PR DESCRIPTION
Added the `sbt` files to the plugin configuration.

I checked it locally.