### PR TITLE
modify out of date note about java8 compat

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -533,8 +533,12 @@ Scala has proven the most viable way to do it, as long as you keep the following
 1. If the underlying Scala code requires an `ExecutionContext`, make the Java API take an `Executor` and use
    `ExecutionContext.fromExecutor(executor)` for conversion.
 
-1. Use `org.apache.pekko.util.FutureConverters` to translate Futures to `CompletionStage`s.
+1. Use `org.apache.pekko.util.FutureConverters` to translate `Future`s to `CompletionStage`s.
 
+1. Use `org.apache.pekko.util.OptionConverters` to translate `Option`s to Java `Optional`s.
+
+1. Use `org.apache.pekko.util.FunctionConverters` to translate Scala Functions to Java Functions.
+ 
 1. Make sure there are Java tests or sample code touching all parts of the API
 
 1. Do not use lower type bounds: `trait[T] { def method[U >: Something]: U }` as they do not work with Java

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -533,10 +533,6 @@ Scala has proven the most viable way to do it, as long as you keep the following
 1. If the underlying Scala code requires an `ExecutionContext`, make the Java API take an `Executor` and use
    `ExecutionContext.fromExecutor(executor)` for conversion.
 
-1. Make use of `scala-java8-compat` conversions, see [GitHub](https://github.com/scala/scala-java8-compat)
-   (eg. `scala.compat.java8.FutureConverters` to translate Futures to `CompletionStage`s).
-   Note that we cannot upgrade to a newer version scala-java8-compat because of binary compatibility issues.
-
 1. Make sure there are Java tests or sample code touching all parts of the API
 
 1. Do not use lower type bounds: `trait[T] { def method[U >: Something]: U }` as they do not work with Java

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -533,11 +533,11 @@ Scala has proven the most viable way to do it, as long as you keep the following
 1. If the underlying Scala code requires an `ExecutionContext`, make the Java API take an `Executor` and use
    `ExecutionContext.fromExecutor(executor)` for conversion.
 
-1. Use `org.apache.pekko.util.FutureConverters` to translate `Future`s to `CompletionStage`s.
+1. Use `org.apache.pekko.util.FutureConverters` to translate `Future`s to `CompletionStage`s (or vice versa).
 
-1. Use `org.apache.pekko.util.OptionConverters` to translate `Option`s to Java `Optional`s.
+1. Use `org.apache.pekko.util.OptionConverters` to translate `Option`s to Java `Optional`s (or vice versa).
 
-1. Use `org.apache.pekko.util.FunctionConverters` to translate Scala Functions to Java Functions.
+1. Use `org.apache.pekko.util.FunctionConverters` to translate Scala Functions to Java Functions (or vice versa).
  
 1. Make sure there are Java tests or sample code touching all parts of the API
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -533,6 +533,8 @@ Scala has proven the most viable way to do it, as long as you keep the following
 1. If the underlying Scala code requires an `ExecutionContext`, make the Java API take an `Executor` and use
    `ExecutionContext.fromExecutor(executor)` for conversion.
 
+1. Use `org.apache.pekko.util.FutureConverters` to translate Futures to `CompletionStage`s.
+
 1. Make sure there are Java tests or sample code touching all parts of the API
 
 1. Do not use lower type bounds: `trait[T] { def method[U >: Something]: U }` as they do not work with Java


### PR DESCRIPTION
a lot of this is now inlined in Pekko instead to simplify the jar dependencies