### PR TITLE
Use proper type for SemVerSpec

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ ThisBuild / scalafixScalaBinaryVersion := scalaBinaryVersion.value
 scalaVersion := Dependencies.allScalaVersions.head
 
 ThisBuild / apacheSonatypeProjectProfile := "pekko"
-ThisBuild / versionScheme := Some("semver-spec")
+ThisBuild / versionScheme := Some(VersionScheme.SemVerSpec)
 sourceDistName := "incubating-pekko"
 
 enablePlugins(


### PR DESCRIPTION
@He-Pin Was correct, there is an actual proper type for `SemVerSpec` which is better than using a `String`.