### PR TITLE
Use setup-coursier Instead downloading on every run in link-validator (#357)

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
+      - name: Setup Coursier
+        uses: coursier/setup-coursier@v1.3.3
+
       - name: create the Pekko site
         run: sbt -Dpekko.genjavadoc.enabled=true "Javaunidoc/doc; Compile/unidoc; docs/paradox"
 
-      - name: Install Coursier command line tool
-        run: curl -fLo cs https://git.io/coursier-cli-linux && chmod +x cs && ./cs
-
       - name: Run Link Validator
-        run: ./cs launch net.runne::site-link-validator:0.2.2 -- scripts/link-validator.conf
+        run: cs launch net.runne::site-link-validator:0.2.2 -- scripts/link-validator.conf


### PR DESCRIPTION
- According to Issue #357, `Link validator` job often failed when downloading coursier from git.io possibly due to git.io rate limit
- To fix the issue, Instead download coursier on every run, apply [coursier/setup-action](https://github.com/coursier/setup-action) with [coursier/cache-action](https://github.com/coursier/cache-action)