### PR TITLE
Add final to methods to prepare for future inline

### DIFF
--- a/actor/src/main/scala-2.12/org/apache/pekko/util/ByteIterator.scala
+++ b/actor/src/main/scala-2.12/org/apache/pekko/util/ByteIterator.scala
@@ -208,7 +208,7 @@ object ByteIterator {
 
     @inline private def current: ByteArrayIterator = iterators.head
     @inline private def dropCurrent(): Unit = { iterators = iterators.tail }
-    @inline def clear(): Unit = { iterators = MultiByteArrayIterator.empty.iterators }
+    @inline final def clear(): Unit = { iterators = MultiByteArrayIterator.empty.iterators }
 
     @inline final def hasNext: Boolean = current.hasNext
 

--- a/actor/src/main/scala-2.13/org/apache/pekko/util/ByteIterator.scala
+++ b/actor/src/main/scala-2.13/org/apache/pekko/util/ByteIterator.scala
@@ -220,7 +220,7 @@ object ByteIterator {
 
     @inline private def current: ByteArrayIterator = iterators.head
     @inline private def dropCurrent(): Unit = { iterators = iterators.tail }
-    @inline def clear(): Unit = { iterators = MultiByteArrayIterator.empty.iterators }
+    @inline final def clear(): Unit = { iterators = MultiByteArrayIterator.empty.iterators }
 
     @inline final def hasNext: Boolean = current.hasNext
 


### PR DESCRIPTION
Since https://github.com/apache/incubator-pekko/pull/305 is basically ready and just waiting for an upstream fix to Scala 2.13, this PR brings in some changes from that PR in preparation for the RC so that we don't potentially break users when we do add the inline.

The changes are quite trivial, i.e. it involves add `final` to some methods inside of `ByteIterator`. If you don't do this and enable the inliner then the inliner complains with the following

```
[error] /Users/mdedetrich/github/incubator-pekko/actor/src/main/scala-2.12/org/apache/pekko/util/ByteIterator.scala:227:12: org/apache/pekko/util/ByteIterator$MultiByteArrayIterator::clear()V is annotated @inline but could not be inlined:
[error] The method is not final and may be overridden.
[error]       clear()
```

While this will prevent users from overriding the methods, it doesn't make sense to override this method because the implementation relies on this implementation to work. Furthermore other similar methods are marked as `final` so I believe missing this was an oversight like due to `@inline` currently not doing anything.