### PR TITLE
upgrade to protobuf 3.16.3 (due to CVE)

### DIFF
--- a/legal/pekko-protobuf-v3-jar-license.txt
+++ b/legal/pekko-protobuf-v3-jar-license.txt
@@ -202,6 +202,6 @@
 
 ---------------
 
-pekko-protobuf-v3 contains the sources of Google protobuf 3.16.1 runtime support,
+pekko-protobuf-v3 contains the sources of Google protobuf 3.16.3 runtime support,
 moved into the source package `org.apache.pekko.protobufv3.internal` so as to avoid version conflicts.
 For license information see COPYING.protobuf

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
   // https://github.com/real-logic/aeron/blob/1.x.y/build.gradle
   val agronaVersion = "1.15.1"
   val nettyVersion = "3.10.6.Final"
-  val protobufJavaVersion = "3.16.1"
+  val protobufJavaVersion = "3.16.3"
   val logbackVersion = "1.2.11"
 
   val jacksonCoreVersion = "2.14.3"


### PR DESCRIPTION
* https://github.com/apache/incubator-pekko/security/dependabot/59
* bumps from 3.16.1 to 3.16.3 -- so the risks are low (a patch level bump)