### PR TITLE
Enable doc publishing for Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -260,8 +260,6 @@ lazy val docs = pekkoModule("docs")
     Jdk9)
   .disablePlugins(MimaPlugin)
   .disablePlugins((if (ScalafixSupport.fixTestScope) Nil else Seq(ScalafixPlugin)): _*)
-  // TODO https://github.com/akka/akka/issues/30243
-  .settings(crossScalaVersions -= Dependencies.scala3Version)
 
 lazy val jackson = pekkoModule("serialization-jackson")
   .dependsOn(

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -43,14 +43,7 @@ object Scaladoc extends AutoPlugin {
         // -release caused build failures when generating javadoc:
         Compile / scalacOptions --= Seq("-release", "8"),
         autoAPIMappings := CliOptions.scaladocAutoAPI.get)) ++
-    Seq(
-      // Publishing scala3 docs is broken (https://github.com/akka/akka/issues/30788),
-      // for now we just skip it:
-      Compile / doc / sources := (
-        if (scalaVersion.value.startsWith("3.")) Seq()
-        else (Compile / doc / sources).value
-      ),
-      Compile / validateDiagrams := true) ++
+    Seq(Compile / validateDiagrams := true) ++
     CliOptions.scaladocDiagramsEnabled.ifTrue(Compile / doc := {
       val docs = (Compile / doc).value
       if ((Compile / validateDiagrams).value)


### PR DESCRIPTION
I don't believe this is an issue anymore. Running `doc` for all projects with Scala 3 works fine now.