### PR TITLE
Update SSL Config version for Scala 2.12 and 2.13

### DIFF
--- a/docs/src/main/paradox/project/migration-guides.md
+++ b/docs/src/main/paradox/project/migration-guides.md
@@ -25,6 +25,8 @@ This is just stub documentation. It will be improved.
   If this is not possible/desired then you can add `scala-java8-compat` as dependency yourself.
 * In addition to the previous point, for Scala 2.12 `scala-java8-compat` has been updated to `1.0.2`. If you are using
   an older binary incompatible version of `scala-java8-compat` its recommend to update to `1.0.2`.
+* For Scala 2.12 and 2.13 [ssl-config](https://github.com/lightbend/ssl-config) has been updated to 0.6.1 in order
+  to bring in bug/security fixes. Note that ssl-config 0.6.1 is binary and source compatible with 0.4.1.
 
 We are still investigating the effects of how the package name changes affect the @ref:[Persistence](../persistence.md)
 and @ref:[Cluster](../cluster-usage.md) modules.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,13 +46,7 @@ object Dependencies {
 
   val reactiveStreamsVersion = "1.0.4"
 
-  val sslConfigVersion = Def.setting {
-    if (scalaVersion.value.startsWith("3.")) {
-      "0.6.1"
-    } else {
-      "0.4.3"
-    }
-  }
+  val sslConfigVersion = "0.6.1"
 
   val scalaTestVersion = Def.setting {
     if (scalaVersion.value.startsWith("3.")) {
@@ -97,7 +91,7 @@ object Dependencies {
 
     // ssl-config
     val sslConfigCore = Def.setting {
-      "com.typesafe" %% "ssl-config-core" % sslConfigVersion.value
+      "com.typesafe" %% "ssl-config-core" % sslConfigVersion
     }
 
     val lmdb = "org.lmdbjava" % "lmdbjava" % "0.7.0"


### PR DESCRIPTION
This PR updates ssl config specifically for Scala 2.12/Scala 2.13 (note that the Scala 3 version is unchanged because Pekko was forced to use the latest version of ssl-config for Scala 3 support). The reasoning why this is being done now is the following

* The current version of ssl-config has an actual bug when it comes to PKCS12 (see https://github.com/lightbend/ssl-config/pull/306)
* 0.6.1 is binary compatible with 0.4.3, not that it matters since we only really care about source compatibility (see https://github.com/lightbend/ssl-config/pull/342). Thanks to our friendly resident @raboof 
* While having different versions for libraries due to different Scala versions in `Test` scope is tolerable, I think this is something we should strongly avoid when it comes to actual compile/runtime dependencies otherwise people can get interesting surprises when updating Scala versions
* Other depending libraries like Play also use ssl-config, so its best that we all agree on the latest version.