### PR TITLE
Fix Scala 3.3 compile issues

### DIFF
--- a/osgi/src/test/scala/org/apache/pekko/osgi/ActorSystemActivatorTest.scala
+++ b/osgi/src/test/scala/org/apache/pekko/osgi/ActorSystemActivatorTest.scala
@@ -19,7 +19,6 @@ import scala.concurrent.duration._
 
 import PojoSRTestSupport.bundle
 import de.kalpatec.pojosr.framework.launch.BundleDescriptor
-import language.postfixOps
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import test.{ PingPongActorSystemActivator, RuntimeNameActorSystemActivator, TestActivators }
@@ -55,7 +54,7 @@ class PingPongActorSystemActivatorTest extends AnyWordSpec with Matchers with Po
         val system = serviceForType[ActorSystem]
         val actor = system.actorSelection("/user/pong")
 
-        implicit val timeout = Timeout(5 seconds)
+        implicit val timeout: Timeout = Timeout(5.seconds)
         Await.result(actor ? Ping, timeout.duration) should be(Pong)
       }
     }


### PR DESCRIPTION
Not sure how this was missed but when I locally compile Pekko for Scala 3.3 it fails on this code. We should probably investigate adding Scala 3.3 to normal CI, at least `compile`/`test:compile`.