### PR TITLE
Add occasionally failing link to validator ignore list

### DIFF
--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -62,6 +62,8 @@ site-link-validator {
     "https://www.scala-lang.org/api/2.13.11/scala/runtime/AbstractPartialFunction.html"
     # Bug, see https://github.com/scala/bug/issues/12807 and https://github.com/lampepfl/dotty/issues/17973
     "https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/StandardOpenOption$.html"
+    # Occasionally returns a 500 Internal Server Error
+    "http://code.google.com/p/atinject/"
   ]
 
   non-https-whitelist = [


### PR DESCRIPTION
I have seen this failing already a couple of times which makes it unreliable enough to get added onto ignore list