### PR TITLE
support negative short ids in async DNS resolver code

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/io/dns/IdGeneratorSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/io/dns/IdGeneratorSpec.scala
@@ -16,12 +16,14 @@ class IdGeneratorSpec extends PekkoSpec {
   "IdGenerator" must {
     "provide a thread-local-random" in {
       val gen = IdGenerator(IdGenerator.Policy.ThreadLocalRandom)
-      gen.nextId() should be < Short.MaxValue
+      gen.nextId() should be <= Short.MaxValue
+      gen.nextId() should be >= Short.MinValue
     }
 
     "provide a secure-random" in {
       val gen = IdGenerator(IdGenerator.Policy.SecureRandom)
-      gen.nextId() should be < Short.MaxValue
+      gen.nextId() should be <= Short.MaxValue
+      gen.nextId() should be >= Short.MinValue
     }
   }
 }

--- a/actor/src/main/scala/org/apache/pekko/io/dns/IdGenerator.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/dns/IdGenerator.scala
@@ -30,6 +30,8 @@ private[pekko] trait IdGenerator {
  */
 @InternalApi
 private[pekko] object IdGenerator {
+  private val MaxUnsignedShort = 65535
+
   sealed trait Policy
 
   object Policy {
@@ -54,7 +56,6 @@ private[pekko] object IdGenerator {
   /**
    * @return a random sequence of ids for production
    */
-  def random(rand: java.util.Random): IdGenerator = new IdGenerator {
-    override def nextId(): Short = rand.nextInt(Short.MaxValue).toShort
-  }
+  def random(rand: java.util.Random): IdGenerator =
+    () => (rand.nextInt(MaxUnsignedShort) - Short.MinValue).toShort
 }


### PR DESCRIPTION
the ID space is small enough - we need to allow negative IDs to double the ID space

fyi @IainHull 