### PR TITLE
compile problems due to `@Deprecated` annotations

### DIFF
--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/ShardingProducerController.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/ShardingProducerController.scala
@@ -213,7 +213,6 @@ object ShardingProducerController {
       val resendFirstUnconfirmedIdleTimeout: FiniteDuration,
       val producerControllerSettings: ProducerController.Settings) {
 
-    @Deprecated
     @deprecated("use resendFirstUnconfirmedIdleTimeout", "Akka 2.6.19")
     def resendFirsUnconfirmedIdleTimeout: FiniteDuration = resendFirstUnconfirmedIdleTimeout
 
@@ -245,7 +244,7 @@ object ShardingProducerController {
     def withResendFirsUnconfirmedIdleTimeout(newResendFirstUnconfirmedIdleTimeout: FiniteDuration): Settings =
       copy(resendFirstUnconfirmedIdleTimeout = newResendFirstUnconfirmedIdleTimeout)
 
-    @Deprecated
+    @deprecated("use resendFirstUnconfirmedIdleTimeout", "Akka 2.6.19")
     def withResendFirsUnconfirmedIdleTimeout(newResendFirstUnconfirmedIdleTimeout: java.time.Duration): Settings =
       copy(resendFirstUnconfirmedIdleTimeout = newResendFirstUnconfirmedIdleTimeout.asScala)
 


### PR DESCRIPTION
```
2023-06-15T00:53:33.2191358Z [0m[[0m[31merror[0m] [0m[0m[31m[31m-- Error: cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/ShardingProducerController.scala:216:4 [0m[0m[0m
2023-06-15T00:53:33.2192931Z [0m[[0m[31merror[0m] [0m[0m[31m216 |[0m    @[35mDeprecated[0m[0m
2023-06-15T00:53:33.2193740Z [0m[[0m[31merror[0m] [0m[0m[31m[31m    |[0m    ^^^^^^^^^^^[0m[0m
2023-06-15T00:53:33.2195052Z [0m[[0m[31merror[0m] [0m[0m[31m    |[0mwrong number of arguments at <no phase> for (since: String, forRemoval: Boolean): Deprecated: (Deprecated#<init> : (since: String, forRemoval: Boolean): Deprecated), expected: 2, found: 0[0m
2023-06-15T00:53:33.2209503Z [0m[[0m[31merror[0m] [0m[0m[31m[31m-- Error: cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/ShardingProducerController.scala:248:4 [0m[0m[0m
2023-06-15T00:53:33.2210896Z [0m[[0m[31merror[0m] [0m[0m[31m248 |[0m    @[35mDeprecated[0m[0m
2023-06-15T00:53:33.2211966Z [0m[[0m[31merror[0m] [0m[0m[31m[31m    |[0m    ^^^^^^^^^^^[0m[0m
2023-06-15T00:53:33.2213463Z [0m[[0m[31merror[0m] [0m[0m[31m    |[0mwrong number of arguments at <no phase> for (since: String, forRemoval: Boolean): Deprecated: (Deprecated#<init> : (since: String, forRemoval: Boolean): Deprecated), expected: 2, found: 0[0m
```