### PR TITLE
Add root code.google.com domain to link validator ignore

### DIFF
--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -63,7 +63,7 @@ site-link-validator {
     # Bug, see https://github.com/scala/bug/issues/12807 and https://github.com/lampepfl/dotty/issues/17973
     "https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/StandardOpenOption$.html"
     # Occasionally returns a 500 Internal Server Error
-    "http://code.google.com/p/atinject/"
+    "http://code.google.com/"
   ]
 
   non-https-whitelist = [


### PR DESCRIPTION
```
## HTTP failure response
`[http://code.google.com/p/snakeyaml/`](http://code.google.com/p/snakeyaml/%60) status 500 Internal Server Error
 - project/license-report.html
 ```