### PR TITLE
add netty license header to file with significant netty input

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/io/dns/DnsSettings.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/dns/DnsSettings.scala
@@ -11,6 +11,22 @@
  * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.pekko.io.dns
 
 import java.io.File


### PR DESCRIPTION
see https://lists.apache.org/thread/mo611z4dpro1373r4f5pbgtlyjmhhtz9

The original source is https://github.com/netty/netty/blob/4.1/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsServerAddressStreamProvider.java

we already have https://github.com/apache/incubator-pekko/pull/237/files - this just builds on those changes

