### PR TITLE
upgrade sbt-source-dist plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -27,7 +27,7 @@ addSbtPlugin("com.hpe.sbt" % "sbt-pull-request-validator" % "1.0.0")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.30")
 
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
-addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.5")
+addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.6")
 addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.10")
 addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.2.2")
 addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.5.0")


### PR DESCRIPTION
* brings in an improvement where the files in the zip and tgz archives are grouped with a root directory (while preserving the other paths).
* https://github.com/pjfanning/sbt-source-dist/pull/22