### PR TITLE
acknowledge derived code in AbstractBoundedNodeQueue 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -237,10 +237,41 @@ in `org.apache.pekko.util.UUIDComparator.scala` which was released under an Apac
 
 ---------------
 
-pekko-actor contains code in `org.apache.pekko.dispatch.AbstractBoundedNodeQueue.java` which was based on
-code from actors <https://github.com/plokhotnyuk/actors> which was released under the Apache 2.0 license, and
+pekko-actor contains code in `org.apache.pekko.dispatch.AbstractNodeQueue.java` and in
+`org.apache.pekko.dispatch.AbstractBoundedNodeQueue.java` which was based on
 code from https://www.1024cores.net/home/lock-free-algorithms/queues/non-intrusive-mpsc-node-based-queue which
 was released under the Simplified BSD license.
+
+Copyright (c) 2010-2011 Dmitry Vyukov. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice, this list of
+
+      conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice, this list
+
+      of conditions and the following disclaimer in the documentation and/or other materials
+
+      provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY DMITRY VYUKOV "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL DMITRY VYUKOV OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those of the authors and should not
+be interpreted as representing official policies, either expressed or implied, of Dmitry Vyukov.
+
+---------------
+
+pekko-actor contains code in `org.apache.pekko.dispatch.AbstractBoundedNodeQueue.java` which was based on
+code from actors <https://github.com/plokhotnyuk/actors> which was released under the Apache 2.0 license.
 
 ---------------
 

--- a/legal/pekko-actor-jar-license.txt
+++ b/legal/pekko-actor-jar-license.txt
@@ -235,7 +235,38 @@ in `org.apache.pekko.util.UUIDComparator.scala` which was released under an Apac
 
 ---------------
 
-pekko-actor contains code in `org.apache.pekko.dispatch.AbstractBoundedNodeQueue.java` which was based on
-code from actors <https://github.com/plokhotnyuk/actors> which was released under the Apache 2.0 license, and
+pekko-actor contains code in `org.apache.pekko.dispatch.AbstractNodeQueue.java` and in
+`org.apache.pekko.dispatch.AbstractBoundedNodeQueue.java` which was based on
 code from https://www.1024cores.net/home/lock-free-algorithms/queues/non-intrusive-mpsc-node-based-queue which
 was released under the Simplified BSD license.
+
+Copyright (c) 2010-2011 Dmitry Vyukov. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice, this list of
+
+      conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice, this list
+
+      of conditions and the following disclaimer in the documentation and/or other materials
+
+      provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY DMITRY VYUKOV "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL DMITRY VYUKOV OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those of the authors and should not
+be interpreted as representing official policies, either expressed or implied, of Dmitry Vyukov.
+
+---------------
+
+pekko-actor contains code in `org.apache.pekko.dispatch.AbstractBoundedNodeQueue.java` which was based on
+code from actors <https://github.com/plokhotnyuk/actors> which was released under the Apache 2.0 license.


### PR DESCRIPTION
and include text from BSD license with copyright declaration

relates to #426 and #425 

I think we have to include the text of the BSD license - especially the copyright part

https://www.1024cores.net/home/code-license

We will get in a lot less trouble if we include too much than too little.