### PR TITLE
[pekko-testkit-typed] Support for Junit5  

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -212,7 +212,6 @@ Copyright (c) 2003-2011, LAMP/EPFL
 
 pekko-actor contains code from scala-collection-compat in the `org.apache.pekko.util.ccompat` package
 which has released under an Apache 2.0 license.
-- actor/src/main/scala-2.12/org/apache/pekko/util/ccompat/package.scala
 
 Scala (https://www.scala-lang.org)
 
@@ -221,13 +220,9 @@ Copyright EPFL and Lightbend, Inc.
 ---------------
 
 pekko-actor contains code from scala-library in the `org.apache.pekko.util.ccompat` package
-and in `org.apache.pekko.util.Helpers.scala` which was released under an Apache 2.0 license.
-- actor/src/main/scala-2.12/org/apache/pekko/util/ccompat/package.scala
-- actor/src/main/scala/org/apache/pekko/util/Helpers.scala
-
-Scala (https://www.scala-lang.org)
-
-Copyright EPFL and Lightbend, Inc.
+which has released under an Apache 2.0 license.
+Copyright (c) 2002-2023 EPFL
+Copyright (c) 2011-2023 Lightbend, Inc.
 
 ---------------
 
@@ -242,72 +237,10 @@ in `org.apache.pekko.util.UUIDComparator.scala` which was released under an Apac
 
 ---------------
 
-pekko-actor contains code in `org.apache.pekko.dispatch.AbstractNodeQueue.java` and in
-`org.apache.pekko.dispatch.AbstractBoundedNodeQueue.java` which was based on
+pekko-actor contains code in `org.apache.pekko.dispatch.AbstractBoundedNodeQueue.java` which was based on
+code from actors <https://github.com/plokhotnyuk/actors> which was released under the Apache 2.0 license, and
 code from https://www.1024cores.net/home/lock-free-algorithms/queues/non-intrusive-mpsc-node-based-queue which
 was released under the Simplified BSD license.
-
-Copyright (c) 2010-2011 Dmitry Vyukov. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that
-the following conditions are met:
-
-   1. Redistributions of source code must retain the above copyright notice, this list of
-
-      conditions and the following disclaimer.
-
-   2. Redistributions in binary form must reproduce the above copyright notice, this list
-
-      of conditions and the following disclaimer in the documentation and/or other materials
-
-      provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY DMITRY VYUKOV "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL DMITRY VYUKOV OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
-WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-The views and conclusions contained in the software and documentation are those of the authors and should not
-be interpreted as representing official policies, either expressed or implied, of Dmitry Vyukov.
-
----------------
-
-pekko-actor contains code in `org.apache.pekko.dispatch.AbstractBoundedNodeQueue.java` which was based on
-code from actors <https://github.com/plokhotnyuk/actors> which was released under the Apache 2.0 license.
-
----------------
-
-pekko-actor contains code in `org.apache.pekko.util.FrequencySketch.scala` which was based on
-code from hash-prospector <https://github.com/skeeto/hash-prospector> which has been placed
-in the public domain.
-
-This is free and unencumbered software released into the public domain.
-
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
-
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
-For more information, please refer to <http://unlicense.org/>
 
 ---------------
 
@@ -315,16 +248,6 @@ pekko-cluster contains VectorClock.scala which is derived from code written
 by Coda Hale <https://github.com/codahale/vlock>.
 He has agreed to allow us to use this code under an Apache 2.0 license
 <https://github.com/apache/incubator-pekko/issues/232#issuecomment-1465281263>.
-
----------------
-
-pekko-distributed-data and pekko-persistence-typed contain `ORSet.scala`
-which is derived from code written for the Riak DT project
-<https://github.com/basho/riak_dt/blob/develop/src/riak_dt_orswot.erl>.
-This code is licensed under an Apache 2.0 license.
-- distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/ORSet.scala
-- persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/crdt/ORSet.scala
-Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
 
 ---------------
 

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKit.java
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKit.java
@@ -1,0 +1,11 @@
+package org.apache.pekko.actor.testkit.typed.javadsl;
+
+import java.lang.annotation.*;
+
+@Documented
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public  @interface Junit5TestKit {
+}
+
+

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKit.java
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKit.java
@@ -1,3 +1,12 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
 package org.apache.pekko.actor.testkit.typed.javadsl;
 
 import java.lang.annotation.*;

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKitBuilder.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKitBuilder.scala
@@ -1,0 +1,39 @@
+package org.apache.pekko.actor.testkit.typed.javadsl
+
+import com.typesafe.config.Config
+import org.apache.pekko.actor.testkit.typed.internal.TestKitUtils
+import org.apache.pekko.actor.testkit.typed.scaladsl.ActorTestKit.ApplicationTestConfig
+import org.apache.pekko.actor.typed.ActorSystem
+
+ case class Junit5TestKitBuilder()  {
+
+   var system: ActorSystem[_] = null
+
+   var customConfig: Config = ApplicationTestConfig
+
+   var name: String = TestKitUtils.testNameFromCallStack(classOf[Junit5TestKitBuilder])
+
+  def withSystem(system: ActorSystem[_]): Junit5TestKitBuilder = {
+    this.system = system
+    this
+  }
+
+  def withCustomConfig(customConfig: Config): Junit5TestKitBuilder = {
+    this.customConfig = customConfig
+    this
+  }
+
+  def withName(name: String): Junit5TestKitBuilder = {
+    this.name = name;
+    this
+  }
+
+  def build(): ActorTestKit = {
+    if (system != null) {
+      return ActorTestKit.create(system)
+    }
+    ActorTestKit.create(name, customConfig)
+  }
+
+}
+

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKitBuilder.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKitBuilder.scala
@@ -1,3 +1,12 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
 package org.apache.pekko.actor.testkit.typed.javadsl
 
 import com.typesafe.config.Config
@@ -7,14 +16,14 @@ import org.apache.pekko.actor.typed.ActorSystem
 
  case class Junit5TestKitBuilder()  {
 
-   var system: ActorSystem[_] = null
+   var system: Option[ActorSystem[_]] = None
 
    var customConfig: Config = ApplicationTestConfig
 
    var name: String = TestKitUtils.testNameFromCallStack(classOf[Junit5TestKitBuilder])
 
   def withSystem(system: ActorSystem[_]): Junit5TestKitBuilder = {
-    this.system = system
+    this.system = Some(system)
     this
   }
 
@@ -24,13 +33,13 @@ import org.apache.pekko.actor.typed.ActorSystem
   }
 
   def withName(name: String): Junit5TestKitBuilder = {
-    this.name = name;
+    this.name = name
     this
   }
 
   def build(): ActorTestKit = {
-    if (system != null) {
-      return ActorTestKit.create(system)
+    if (system.isDefined) {
+      return ActorTestKit.create(system.get)
     }
     ActorTestKit.create(name, customConfig)
   }

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtension.scala
@@ -1,0 +1,45 @@
+package org.apache.pekko.actor.testkit.typed.javadsl
+
+import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation
+import org.junit.jupiter.api.extension.{ ExtensionContext, InvocationInterceptor, ReflectiveInvocationContext }
+import org.slf4j.LoggerFactory
+import org.apache.pekko.actor.testkit.typed.internal.CapturingAppender
+
+import java.lang.reflect.Method
+import scala.util.control.NonFatal
+
+final class LogCapturingExtension extends InvocationInterceptor {
+
+  private val capturingAppender = CapturingAppender.get("")
+
+  private val myLogger = LoggerFactory.getLogger(classOf[LogCapturing])
+
+  @throws[Throwable]
+  override def interceptTestMethod(invocation: Invocation[Void], invocationContext: ReflectiveInvocationContext[Method],
+      extensionContext: ExtensionContext): Unit = {
+
+
+    val testClassName = invocationContext.getTargetClass.getSimpleName
+    val testMethodName = invocationContext.getExecutable.getName
+
+    try {
+      myLogger.info(s"Logging started for test [${testClassName}: ${testMethodName}]")
+      invocation.proceed
+      myLogger.info(
+        s"Logging finished for test [${testClassName}: ${testMethodName}] that was successful")
+    } catch {
+      case NonFatal(e) =>
+        println(
+          s"--> [${Console.BLUE}${testClassName}: ${testMethodName}${Console.RESET}] " +
+          s"Start of log messages of test that failed with ${e.getMessage}")
+        capturingAppender.flush()
+        println(
+          s"<-- [${Console.BLUE}${testClassName}: ${testMethodName}${Console.RESET}] " +
+          s"End of log messages of test that failed with ${e.getMessage}")
+        throw e
+    } finally {
+
+      capturingAppender.clear()
+    }
+  }
+}

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtension.scala
@@ -1,3 +1,12 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
 package org.apache.pekko.actor.testkit.typed.javadsl
 
 import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
@@ -1,0 +1,34 @@
+package org.apache.pekko.actor.testkit.typed.javadsl
+
+import org.apache.pekko
+import org.junit.jupiter.api.extension.{AfterAllCallback, BeforeTestExecutionCallback, ExtensionContext}
+import org.junit.platform.commons.support.AnnotationSupport
+
+import scala.jdk.CollectionConverters._
+
+final class TestKitJunit5Extension() extends AfterAllCallback with BeforeTestExecutionCallback {
+
+  var testKit: ActorTestKit = null
+
+
+  /**
+   * Get a reference to the field annotated with @Junit5Testkit  [[pekko.actor.testkit.typed.javadsl.Junit5TestKit]]
+   *
+   */
+  override def beforeTestExecution(context: ExtensionContext): Unit =  {
+
+    context.getTestInstance.ifPresent(instance => {
+      val fielValue = AnnotationSupport.findAnnotatedFieldValues(instance, classOf[Junit5TestKit]).asScala.toList.head
+      testKit = fielValue.asInstanceOf[ActorTestKit]
+    })
+  }
+
+
+  /**
+   * Shutdown testKit
+   */
+  override def afterAll(context: ExtensionContext): Unit = {
+     testKit.shutdownTestKit()
+  }
+
+}

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
@@ -1,3 +1,12 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
 package org.apache.pekko.actor.testkit.typed.javadsl
 
 import org.apache.pekko
@@ -8,7 +17,7 @@ import scala.jdk.CollectionConverters._
 
 final class TestKitJunit5Extension() extends AfterAllCallback with BeforeTestExecutionCallback {
 
-  var testKit: ActorTestKit = null
+  var testKit: Option[ActorTestKit] = None
 
 
   /**
@@ -19,7 +28,7 @@ final class TestKitJunit5Extension() extends AfterAllCallback with BeforeTestExe
 
     context.getTestInstance.ifPresent(instance => {
       val fielValue = AnnotationSupport.findAnnotatedFieldValues(instance, classOf[Junit5TestKit]).asScala.toList.head
-      testKit = fielValue.asInstanceOf[ActorTestKit]
+      testKit = Some(fielValue.asInstanceOf[ActorTestKit])
     })
   }
 
@@ -28,7 +37,7 @@ final class TestKitJunit5Extension() extends AfterAllCallback with BeforeTestExe
    * Shutdown testKit
    */
   override def afterAll(context: ExtensionContext): Unit = {
-     testKit.shutdownTestKit()
+     testKit.get.shutdownTestKit()
   }
 
 }

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/GreeterMain.scala
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/GreeterMain.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+package jdocs.org.apache.pekko.actor.testkit.typed.javadsl
+
+import org.apache.pekko.actor.typed.{ActorRef, Behavior}
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+
+
+object Greeter {
+  final case class Greet(whom: String, replyTo: ActorRef[Greeted])
+  final case class Greeted(whom: String, from: ActorRef[Greet])
+
+  def apply(): Behavior[Greet] = Behaviors.receive { (context, message) =>
+    context.log.info("Hello {}!", message.whom)
+    //#greeter-send-messages
+    message.replyTo ! Greeted(message.whom, context.self)
+    //#greeter-send-messages
+    Behaviors.same
+  }
+}
+
+object GreeterBot {
+
+  def apply(max: Int): Behavior[Greeter.Greeted] = {
+    bot(0, max)
+  }
+
+  private def bot(greetingCounter: Int, max: Int): Behavior[Greeter.Greeted] =
+    Behaviors.receive { (context, message) =>
+      val n = greetingCounter + 1
+      context.log.info("Greeting {} for {}", n, message.whom)
+      if (n == max) {
+        Behaviors.stopped
+      } else {
+        message.from ! Greeter.Greet(message.whom, context.self)
+        bot(n, max)
+      }
+    }
+}
+
+object GreeterMain {
+
+  final case class SayHello(name: String)
+
+  def apply(): Behavior[SayHello] =
+    Behaviors.setup { context =>
+      val greeter = context.spawn(Greeter(), "greeter")
+
+      Behaviors.receiveMessage { message =>
+        val replyTo = context.spawn(GreeterBot(max = 3), message.name)
+        greeter ! Greeter.Greet(message.name, replyTo)
+        Behaviors.same
+      }
+    }
+}

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/Junit5IntegrationExampleTest.java
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/Junit5IntegrationExampleTest.java
@@ -7,9 +7,7 @@
  * This file is part of the Apache Pekko project, derived from Akka.
  */
 
-
 package jdocs.org.apache.pekko.actor.testkit.typed.javadsl;
-
 
 import org.apache.pekko.actor.Address;
 import org.apache.pekko.actor.testkit.typed.javadsl.*;
@@ -27,33 +25,35 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @ExtendWith(TestKitJunit5Extension.class)
 class Junit5IntegrationExampleTest {
 
-    @Junit5TestKit
-    public ActorTestKit testKit = new Junit5TestKitBuilder()
-            .build();
+  @Junit5TestKit public ActorTestKit testKit = new Junit5TestKitBuilder().build();
 
-    @Test
-    void junit5Test() {
-        Address address = testKit.system().address();
-        assertNotNull(address);
-    }
+  @Test
+  void junit5Test() {
+    Address address = testKit.system().address();
+    assertNotNull(address);
+  }
 
-    @Test
-    void testSomething() {
+  @Test
+  void testSomething() {
 
-        ActorRef<AsyncTestingExampleTest.Echo.Ping> pinger = testKit.spawn(AsyncTestingExampleTest.Echo.create(), "ping");
-        TestProbe<AsyncTestingExampleTest.Echo.Pong> probe = testKit.createTestProbe();
-        pinger.tell(new AsyncTestingExampleTest.Echo.Ping("hello", probe.ref()));
-        AsyncTestingExampleTest.Echo.Pong pong =  probe.expectMessage(new AsyncTestingExampleTest.Echo.Pong("hello"));
-        assertEquals("hello", pong.message);
-    }
+    ActorRef<AsyncTestingExampleTest.Echo.Ping> pinger =
+        testKit.spawn(AsyncTestingExampleTest.Echo.create(), "ping");
+    TestProbe<AsyncTestingExampleTest.Echo.Pong> probe = testKit.createTestProbe();
+    pinger.tell(new AsyncTestingExampleTest.Echo.Ping("hello", probe.ref()));
+    AsyncTestingExampleTest.Echo.Pong pong =
+        probe.expectMessage(new AsyncTestingExampleTest.Echo.Pong("hello"));
+    assertEquals("hello", pong.message);
+  }
 
-    @Test
-    void testSomething2() {
-         ActorRef<AsyncTestingExampleTest.Echo.Ping> pinger2 = testKit.spawn(AsyncTestingExampleTest.Echo.create(), "ping2");
-        TestProbe<AsyncTestingExampleTest.Echo.Pong> probe2 = testKit.createTestProbe();
-        pinger2.tell(new AsyncTestingExampleTest.Echo.Ping("hello", probe2.ref()));
-        AsyncTestingExampleTest.Echo.Pong pong =  probe2.expectMessage(new AsyncTestingExampleTest.Echo.Pong("hello"));
-        assertEquals("hello", pong.message);
-    }
+  @Test
+  void testSomething2() {
+    ActorRef<AsyncTestingExampleTest.Echo.Ping> pinger2 =
+        testKit.spawn(AsyncTestingExampleTest.Echo.create(), "ping2");
+    TestProbe<AsyncTestingExampleTest.Echo.Pong> probe2 = testKit.createTestProbe();
+    pinger2.tell(new AsyncTestingExampleTest.Echo.Ping("hello", probe2.ref()));
+    AsyncTestingExampleTest.Echo.Pong pong =
+        probe2.expectMessage(new AsyncTestingExampleTest.Echo.Pong("hello"));
+    assertEquals("hello", pong.message);
+  }
 }
 // #junit5-integration

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/Junit5IntegrationExampleTest.java
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/Junit5IntegrationExampleTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+
+package jdocs.org.apache.pekko.actor.testkit.typed.javadsl;
+
+
+import org.apache.pekko.actor.Address;
+import org.apache.pekko.actor.testkit.typed.javadsl.*;
+import org.apache.pekko.actor.testkit.typed.javadsl.Junit5TestKitBuilder;
+import org.apache.pekko.actor.typed.ActorRef;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+// #junit5-integration
+@DisplayName("Junit5")
+@ExtendWith(TestKitJunit5Extension.class)
+class Junit5IntegrationExampleTest {
+
+    @Junit5TestKit
+    public ActorTestKit testKit = new Junit5TestKitBuilder()
+            .build();
+
+    @Test
+    void junit5Test() {
+        Address address = testKit.system().address();
+        assertNotNull(address);
+    }
+
+    @Test
+    void testSomething() {
+
+        ActorRef<AsyncTestingExampleTest.Echo.Ping> pinger = testKit.spawn(AsyncTestingExampleTest.Echo.create(), "ping");
+        TestProbe<AsyncTestingExampleTest.Echo.Pong> probe = testKit.createTestProbe();
+        pinger.tell(new AsyncTestingExampleTest.Echo.Ping("hello", probe.ref()));
+        AsyncTestingExampleTest.Echo.Pong pong =  probe.expectMessage(new AsyncTestingExampleTest.Echo.Pong("hello"));
+        assertEquals("hello", pong.message);
+    }
+
+    @Test
+    void testSomething2() {
+         ActorRef<AsyncTestingExampleTest.Echo.Ping> pinger2 = testKit.spawn(AsyncTestingExampleTest.Echo.create(), "ping2");
+        TestProbe<AsyncTestingExampleTest.Echo.Pong> probe2 = testKit.createTestProbe();
+        pinger2.tell(new AsyncTestingExampleTest.Echo.Ping("hello", probe2.ref()));
+        AsyncTestingExampleTest.Echo.Pong pong =  probe2.expectMessage(new AsyncTestingExampleTest.Echo.Pong("hello"));
+        assertEquals("hello", pong.message);
+    }
+}
+// #junit5-integration

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtensionExampleTest.java
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtensionExampleTest.java
@@ -13,7 +13,6 @@
 
 package jdocs.org.apache.pekko.actor.testkit.typed.javadsl;
 
-
 // #log-capturing-junit5
 import org.apache.pekko.actor.testkit.typed.javadsl.*;
 import org.apache.pekko.actor.testkit.typed.javadsl.Junit5TestKitBuilder;
@@ -22,7 +21,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-
 import static jdocs.org.apache.pekko.actor.testkit.typed.javadsl.AsyncTestingExampleTest.Echo;
 
 @DisplayName("Junit5 log capturing")
@@ -30,10 +28,7 @@ import static jdocs.org.apache.pekko.actor.testkit.typed.javadsl.AsyncTestingExa
 @ExtendWith(LogCapturingExtension.class)
 class LogCapturingExtensionExampleTest {
 
-  @Junit5TestKit
-  public ActorTestKit testKit = new Junit5TestKitBuilder()
-          .build();
-
+  @Junit5TestKit public ActorTestKit testKit = new Junit5TestKitBuilder().build();
 
   @Test
   void testSomething() {
@@ -43,8 +38,8 @@ class LogCapturingExtensionExampleTest {
     probe.expectMessage(new Echo.Pong("hello"));
   }
 
- @Test
- void testSomething2() {
+  @Test
+  void testSomething2() {
     ActorRef<Echo.Ping> pinger = testKit.spawn(Echo.create(), "ping");
     TestProbe<Echo.Pong> probe = testKit.createTestProbe();
     pinger.tell(new Echo.Ping("hello", probe.ref()));

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtensionExampleTest.java
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtensionExampleTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package jdocs.org.apache.pekko.actor.testkit.typed.javadsl;
+
+
+// #log-capturing-junit5
+import org.apache.pekko.actor.testkit.typed.javadsl.*;
+import org.apache.pekko.actor.testkit.typed.javadsl.Junit5TestKitBuilder;
+import org.apache.pekko.actor.typed.ActorRef;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+
+import static jdocs.org.apache.pekko.actor.testkit.typed.javadsl.AsyncTestingExampleTest.Echo;
+
+@DisplayName("Junit5 log capturing")
+@ExtendWith(TestKitJunit5Extension.class)
+@ExtendWith(LogCapturingExtension.class)
+class LogCapturingExtensionExampleTest {
+
+  @Junit5TestKit
+  public ActorTestKit testKit = new Junit5TestKitBuilder()
+          .build();
+
+
+  @Test
+  void testSomething() {
+    ActorRef<Echo.Ping> pinger = testKit.spawn(Echo.create(), "ping");
+    TestProbe<Echo.Pong> probe = testKit.createTestProbe();
+    pinger.tell(new Echo.Ping("hello", probe.ref()));
+    probe.expectMessage(new Echo.Pong("hello"));
+  }
+
+ @Test
+ void testSomething2() {
+    ActorRef<Echo.Ping> pinger = testKit.spawn(Echo.create(), "ping");
+    TestProbe<Echo.Pong> probe = testKit.createTestProbe();
+    pinger.tell(new Echo.Ping("hello", probe.ref()));
+    probe.expectMessage(new Echo.Pong("hello"));
+  }
+}
+// #log-capturing-junit5

--- a/actor-testkit-typed/src/test/java/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKitJunit5Test.java
+++ b/actor-testkit-typed/src/test/java/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKitJunit5Test.java
@@ -26,28 +26,26 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.pekko.Done.done;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @DisplayName("ActorTestKitTestJunit5")
 @ExtendWith(TestKitJunit5Extension.class)
 @ExtendWith(LogCapturingExtension.class)
 class ActorTestKitJunit5Test extends JUnitSuite {
 
-
-  @Junit5TestKit
-  public ActorTestKit testKit = new Junit5TestKitBuilder()
-          .build();
+  @Junit5TestKit public ActorTestKit testKit = new Junit5TestKitBuilder().build();
 
   @Test
   void systemNameShouldComeFromTestClassViaJunitResource() {
-    assertEquals("ActorTestKitTestJunit5", testKit.system().name());
+    assertEquals("ActorTestKitJunit5Test", testKit.system().name());
   }
 
   @Test
   void systemNameShouldComeFromTestClass() {
     final ActorTestKit testKit2 = ActorTestKit.create();
     try {
-      assertEquals("ActorTestKitTestJunit5", testKit2.system().name());
+      assertEquals("ActorTestKitJunit5Test", testKit2.system().name());
     } finally {
       testKit2.shutdownTestKit();
     }
@@ -73,8 +71,6 @@ class ActorTestKitJunit5Test extends JUnitSuite {
               started.complete(done());
               return Behaviors.same();
             }));
-     assertNotNull(started.get(3, TimeUnit.SECONDS));
-
-
-   }
+    assertNotNull(started.get(3, TimeUnit.SECONDS));
+  }
 }

--- a/actor-testkit-typed/src/test/java/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKitJunit5Test.java
+++ b/actor-testkit-typed/src/test/java/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKitJunit5Test.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package org.apache.pekko.actor.testkit.typed.javadsl;
+
+import org.apache.pekko.Done;
+import org.apache.pekko.actor.typed.javadsl.Behaviors;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.scalatestplus.junit.JUnitSuite;
+
+import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.pekko.Done.done;
+import static org.junit.Assert.*;
+
+@DisplayName("ActorTestKitTestJunit5")
+@ExtendWith(TestKitJunit5Extension.class)
+@ExtendWith(LogCapturingExtension.class)
+class ActorTestKitJunit5Test extends JUnitSuite {
+
+
+  @Junit5TestKit
+  public ActorTestKit testKit = new Junit5TestKitBuilder()
+          .build();
+
+  @Test
+  void systemNameShouldComeFromTestClassViaJunitResource() {
+    assertEquals("ActorTestKitTestJunit5", testKit.system().name());
+  }
+
+  @Test
+  void systemNameShouldComeFromTestClass() {
+    final ActorTestKit testKit2 = ActorTestKit.create();
+    try {
+      assertEquals("ActorTestKitTestJunit5", testKit2.system().name());
+    } finally {
+      testKit2.shutdownTestKit();
+    }
+  }
+
+  @Test
+  void systemNameShouldComeFromGivenClassName() {
+    final ActorTestKit testKit2 = ActorTestKit.create(HashMap.class.getName());
+    try {
+      // removing package name and such
+      assertEquals("HashMap", testKit2.system().name());
+    } finally {
+      testKit2.shutdownTestKit();
+    }
+  }
+
+  @Test
+  void testKitShouldSpawnActor() throws Exception {
+    final CompletableFuture<Done> started = new CompletableFuture<>();
+    testKit.spawn(
+        Behaviors.setup(
+            (context) -> {
+              started.complete(done());
+              return Behaviors.same();
+            }));
+     assertNotNull(started.get(3, TimeUnit.SECONDS));
+
+
+   }
+}

--- a/actor-testkit-typed/src/test/resources/application.conf
+++ b/actor-testkit-typed/src/test/resources/application.conf
@@ -2,3 +2,4 @@
 
 # used by ActorTestKitSpec
 test.from-application = yes
+test.value = someValue

--- a/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/Junit5TestKitBuilderSpec.scala
+++ b/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/Junit5TestKitBuilderSpec.scala
@@ -1,0 +1,77 @@
+package org.apache.pekko.actor.testkit.typed.scaladsl
+
+import com.typesafe.config.ConfigFactory
+import jdocs.org.apache.pekko.actor.testkit.typed.javadsl.GreeterMain
+import org.apache.pekko.actor.testkit.typed.javadsl.Junit5TestKitBuilder
+import org.apache.pekko.actor.typed.ActorSystem
+import org.scalatest.wordspec.AnyWordSpec
+
+
+
+class Junit5TestKitBuilderSpec extends AnyWordSpec{
+
+
+
+
+
+  "the Junit5TestKitBuilder" should {
+    "create a Testkit with name hello" in {
+      val actualTestKit = Junit5TestKitBuilder()
+        .withName("hello")
+        .build()
+
+      assertResult("hello")(actualTestKit.system.name)
+    }
+  }
+
+  "the Junit5TestKitBuilder" should {
+    "create a Testkit with the classname as name" in {
+      val actualTestKit = Junit5TestKitBuilder()
+        .build()
+
+      assertResult("Junit5TestKitBuilderSpec")(actualTestKit.system.name)
+    }
+  }
+
+
+  "the Junit5TestKitBuilder" should {
+    "create a Testkit with a custom config" in {
+
+      val conf = ConfigFactory.load("application-junit5.conf")
+      val actualTestKit = Junit5TestKitBuilder()
+        .withCustomConfig(conf)
+        .build()
+      assertResult("someValue")(actualTestKit.system.settings.config.getString("test.value"))
+      assertResult("Junit5TestKitBuilderSpec")(actualTestKit.system.name)
+
+    }
+  }
+
+  "the Junit5TestKitBuilder" should {
+    "create a Testkit with a custom config and name" in {
+
+      val conf = ConfigFactory.load("application.conf")
+      val actualTestKit = Junit5TestKitBuilder()
+        .withCustomConfig(conf)
+        .withName("hello")
+        .build()
+      assertResult("someValue")(actualTestKit.system.settings.config.getString("test.value"))
+      assertResult("hello")(actualTestKit.system.name)
+
+    }
+  }
+
+  "the Junit5TestKitBuilder" should {
+    "create a Testkit with a custom system" in {
+
+      val system: ActorSystem[GreeterMain.SayHello] = ActorSystem(GreeterMain(), "AkkaQuickStart")
+
+      val actualTestKit = Junit5TestKitBuilder()
+        .withSystem(system)
+        .build()
+      assertResult("AkkaQuickStart")(actualTestKit.system.name)
+    }
+  }
+
+
+}

--- a/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/Junit5TestKitBuilderSpec.scala
+++ b/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/Junit5TestKitBuilderSpec.scala
@@ -1,3 +1,12 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
 package org.apache.pekko.actor.testkit.typed.scaladsl
 
 import com.typesafe.config.ConfigFactory
@@ -9,9 +18,6 @@ import org.scalatest.wordspec.AnyWordSpec
 
 
 class Junit5TestKitBuilderSpec extends AnyWordSpec{
-
-
-
 
 
   "the Junit5TestKitBuilder" should {
@@ -37,7 +43,7 @@ class Junit5TestKitBuilderSpec extends AnyWordSpec{
   "the Junit5TestKitBuilder" should {
     "create a Testkit with a custom config" in {
 
-      val conf = ConfigFactory.load("application-junit5.conf")
+      val conf = ConfigFactory.load("application.conf")
       val actualTestKit = Junit5TestKitBuilder()
         .withCustomConfig(conf)
         .build()

--- a/actor/src/main/scala-2.12/org/apache/pekko/util/ccompat/package.scala
+++ b/actor/src/main/scala-2.12/org/apache/pekko/util/ccompat/package.scala
@@ -11,18 +11,6 @@
  * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-/*
- * Scala (https://www.scala-lang.org)
- *
- * Copyright EPFL and Lightbend, Inc.
- *
- * Licensed under Apache License 2.0
- * (http://www.apache.org/licenses/LICENSE-2.0).
- *
- * See the NOTICE file distributed with this work for
- * additional information regarding copyright ownership.
- */
-
 package org.apache.pekko.util
 
 import scala.{ collection => c }
@@ -90,8 +78,6 @@ package object ccompat {
   }
 
   private[pekko] implicit final class IterableExtensions(private val fact: Iterable.type) extends AnyVal {
-    // derived from https://github.com/scala/scala/blob/0842f23f6017f93160b115b8bf29ec5347cdbe94/src/library/scala/Predef.scala#L356-L361
-    // Apache License 2.0 (see Scala license header at top of this file)
     def single[A](a: A): Iterable[A] = new Iterable[A] {
       override def iterator = Iterator.single(a)
       override def sizeHintIfCheap: Int = 1

--- a/docs/src/main/paradox/typed/testing-async.md
+++ b/docs/src/main/paradox/typed/testing-async.md
@@ -111,7 +111,7 @@ Java
 
 @@@ div { .group-java }
 
-If you are using JUnit you can use @javadoc[TestKitJunitResource](pekko.actor.testkit.typed.javadsl.TestKitJunitResource) to have the async test kit automatically
+If you are using JUnit you can use @javadoc[TestKitJunitResource](pekko.actor.testkit.typed.javadsl.TestKitJunitResource) for junit4 or @javadoc[TestKitJunit5Extension](pekko.actor.testkit.typed.javadsl.TestKitJunit5Extension) for Junit5 to have the async test kit automatically
 shutdown when the test is complete.
 
 Note that the dependency on JUnit is marked as optional from the test kit module, so your project must explicitly include
@@ -134,8 +134,12 @@ a dependency on ScalaTest to use this.
 Scala
 :  @@snip [AsyncTestingExampleSpec.scala](/actor-testkit-typed/src/test/scala/docs/org/apache/pekko/actor/testkit/typed/scaladsl/ScalaTestIntegrationExampleSpec.scala) { #scalatest-integration }
 
-Java
+Java 
 :  @@snip [AsyncTestingExampleTest.java](/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/JunitIntegrationExampleTest.java) { #junit-integration }
+
+Java Junit5
+:  @@snip [Junit5IntegrationExampleTest.java](/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/Junit5IntegrationExampleTest.java) { #junit5-integration }
+
 
 As you may have noticed @scaladoc[ScalaTestWithActorTestKit](pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit) is an abstract class
 which means its problematic if you want treat a given test suite as a value and extend it in multiple ways (i.e. as an example you happen to be using 

--- a/legal/pekko-actor-jar-license.txt
+++ b/legal/pekko-actor-jar-license.txt
@@ -212,22 +212,15 @@ Copyright (c) 2003-2011, LAMP/EPFL
 
 pekko-actor contains code from scala-collection-compat in the `org.apache.pekko.util.ccompat` package
 which has released under an Apache 2.0 license.
-- actor/src/main/scala-2.12/org/apache/pekko/util/ccompat/package.scala
-
-Scala (https://www.scala-lang.org)
-
-Copyright EPFL and Lightbend, Inc.
+Copyright (c) 2002-2023 EPFL
+Copyright (c) 2011-2023 Lightbend, Inc.
 
 ---------------
 
 pekko-actor contains code from scala-library in the `org.apache.pekko.util.ccompat` package
-and in `org.apache.pekko.util.Helpers.scala` which was released under an Apache 2.0 license.
-- actor/src/main/scala-2.12/org/apache/pekko/util/ccompat/package.scala
-- actor/src/main/scala/org/apache/pekko/util/Helpers.scala
-
-Scala (https://www.scala-lang.org)
-
-Copyright EPFL and Lightbend, Inc.
+which has released under an Apache 2.0 license.
+Copyright (c) 2002-2023 EPFL
+Copyright (c) 2011-2023 Lightbend, Inc.
 
 ---------------
 
@@ -242,69 +235,7 @@ in `org.apache.pekko.util.UUIDComparator.scala` which was released under an Apac
 
 ---------------
 
-pekko-actor contains code in `org.apache.pekko.dispatch.AbstractNodeQueue.java` and in
-`org.apache.pekko.dispatch.AbstractBoundedNodeQueue.java` which was based on
+pekko-actor contains code in `org.apache.pekko.dispatch.AbstractBoundedNodeQueue.java` which was based on
+code from actors <https://github.com/plokhotnyuk/actors> which was released under the Apache 2.0 license, and
 code from https://www.1024cores.net/home/lock-free-algorithms/queues/non-intrusive-mpsc-node-based-queue which
 was released under the Simplified BSD license.
-
-Copyright (c) 2010-2011 Dmitry Vyukov. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that
-the following conditions are met:
-
-   1. Redistributions of source code must retain the above copyright notice, this list of
-
-      conditions and the following disclaimer.
-
-   2. Redistributions in binary form must reproduce the above copyright notice, this list
-
-      of conditions and the following disclaimer in the documentation and/or other materials
-
-      provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY DMITRY VYUKOV "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL DMITRY VYUKOV OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
-WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-The views and conclusions contained in the software and documentation are those of the authors and should not
-be interpreted as representing official policies, either expressed or implied, of Dmitry Vyukov.
-
----------------
-
-pekko-actor contains code in `org.apache.pekko.dispatch.AbstractBoundedNodeQueue.java` which was based on
-code from actors <https://github.com/plokhotnyuk/actors> which was released under the Apache 2.0 license.
-
----------------
-
-pekko-actor contains code in `org.apache.pekko.util.FrequencySketch.scala` which was based on
-code from hash-prospector <https://github.com/skeeto/hash-prospector> which has been placed
-in the public domain.
-
-This is free and unencumbered software released into the public domain.
-
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
-
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
-For more information, please refer to <http://unlicense.org/>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,6 +24,8 @@ object Dependencies {
     .withRank(KeyRanks.Invisible) // avoid 'unused key' warning
 
   val junitVersion = "4.13.2"
+  val junit5Version = "5.10.0-M1"
+
   val slf4jVersion = "1.7.36"
   // check agrona version when updating this
   val aeronVersion = "1.38.1"
@@ -86,6 +88,8 @@ object Dependencies {
     val lmdb = "org.lmdbjava" % "lmdbjava" % "0.7.0"
 
     val junit = "junit" % "junit" % junitVersion
+    val junit5 = "org.junit.jupiter" % "junit-jupiter-engine" % junit5Version
+
 
     // For Java 8 Conversions
     val java8Compat = Def.setting {
@@ -138,8 +142,9 @@ object Dependencies {
       val commonsIo = "commons-io" % "commons-io" % "2.11.0" % Test
       val commonsCodec = "commons-codec" % "commons-codec" % "1.15" % Test
       val commonsCompress = "org.apache.commons" % "commons-compress" % "1.23.0" % Test
-      val junit = "junit" % "junit" % junitVersion % Test
       val httpClient = "org.apache.httpcomponents" % "httpclient" % "4.5.14" % Test
+      val junit = "junit" % "junit" % junitVersion % "test"
+      val junit5 = "org.junit.jupiter" % "junit-jupiter-engine" % junit5Version % Test
 
       val logback = Compile.logback % Test
 
@@ -170,16 +175,6 @@ object Dependencies {
 
       // docker utils
       val dockerClient = "com.spotify" % "docker-client" % "8.16.0" % Test
-
-      val jackson = Def.setting {
-        Seq(
-          (jacksonCore.value % Test).force(),
-          (jacksonAnnotations.value % Test).force(),
-          (jacksonDatabind.value % Test).force(),
-          ("com.fasterxml.jackson.jaxrs" % "jackson-jaxrs-base" % jacksonCoreVersion % Test).force(),
-          ("com.fasterxml.jackson.jaxrs" % "jackson-jaxrs-json-provider" % jacksonCoreVersion % Test).force(),
-          ("com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % jacksonCoreVersion % Test).force())
-      }
 
       // metrics, measurements, perf testing
       val metrics = "io.dropwizard.metrics" % "metrics-core" % "4.2.10" % Test
@@ -213,6 +208,7 @@ object Dependencies {
       val levelDBNative = "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8" % "optional;provided"
 
       val junit = Compile.junit % "optional;provided;test"
+      val junit5 = Compile.junit5 % "optional;provided;test"
 
       val scalatest = Def.setting { "org.scalatest" %% "scalatest" % scalaTestVersion % "optional;provided;test" }
 
@@ -266,6 +262,7 @@ object Dependencies {
   val actorTestkitTyped = l ++= Seq(
     Provided.logback,
     Provided.junit,
+    Provided.junit5,
     Provided.scalatest.value,
     TestDependencies.scalatestJUnit.value)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -146,6 +146,10 @@ object Dependencies {
       val junit = "junit" % "junit" % junitVersion % "test"
       val junit5 = "org.junit.jupiter" % "junit-jupiter-engine" % junit5Version % Test
 
+      val commonsCompress = "org.apache.commons" % "commons-compress" % "1.23.0" % Test
+      val junit = "junit" % "junit" % junitVersion % Test
+      val httpClient = "org.apache.httpcomponents" % "httpclient" % "4.5.14" % Test
+
       val logback = Compile.logback % Test
 
       val scalatest = Def.setting { "org.scalatest" %% "scalatest" % scalaTestVersion % Test } // ApacheV2

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -146,7 +146,6 @@ object Dependencies {
       val junit = "junit" % "junit" % junitVersion % "test"
       val junit5 = "org.junit.jupiter" % "junit-jupiter-engine" % junit5Version % Test
 
-
       val logback = Compile.logback % Test
 
       val scalatest = Def.setting { "org.scalatest" %% "scalatest" % scalaTestVersion % Test } // ApacheV2

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -146,9 +146,6 @@ object Dependencies {
       val junit = "junit" % "junit" % junitVersion % "test"
       val junit5 = "org.junit.jupiter" % "junit-jupiter-engine" % junit5Version % Test
 
-      val commonsCompress = "org.apache.commons" % "commons-compress" % "1.23.0" % Test
-      val junit = "junit" % "junit" % junitVersion % Test
-      val httpClient = "org.apache.httpcomponents" % "httpclient" % "4.5.14" % Test
 
       val logback = Compile.logback % Test
 
@@ -179,6 +176,16 @@ object Dependencies {
 
       // docker utils
       val dockerClient = "com.spotify" % "docker-client" % "8.16.0" % Test
+
+      val jackson = Def.setting {
+        Seq(
+          (jacksonCore.value % Test).force(),
+          (jacksonAnnotations.value % Test).force(),
+          (jacksonDatabind.value % Test).force(),
+          ("com.fasterxml.jackson.jaxrs" % "jackson-jaxrs-base" % jacksonCoreVersion % Test).force(),
+          ("com.fasterxml.jackson.jaxrs" % "jackson-jaxrs-json-provider" % jacksonCoreVersion % Test).force(),
+          ("com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % jacksonCoreVersion % Test).force())
+      }
 
       // metrics, measurements, perf testing
       val metrics = "io.dropwizard.metrics" % "metrics-core" % "4.2.10" % Test


### PR DESCRIPTION
I added a Junit5 Extension to support Junit5 framework integration.

The extension is activated through an annotation:
@ExtendWith(TestKitJunit5Extension.class) 
on the class level.

Additionally, a testKit with a @Junit5TestKit annotation needs to be created.
A builder pattern is used to construct the Testkit instance.

 @Junit5TestKit 
public ActorTestKit testKit = new Junit5TestKitBuilder().build();



The extension itself uses the Junit5 AfterAllCallback to shutdown the testkit after all tests are executed.
