### PR TITLE
[pekko-testkit-typed] Support for Junit5 

### DIFF
--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -4,10 +4,8 @@ on:
   pull_request:
   push:
     branches:
-      - master
       - main
-    tags:
-      - v2.6.*
+      - 1.0.x
 
 permissions: {}
 

--- a/.github/workflows/publish-check.yml
+++ b/.github/workflows/publish-check.yml
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Generate doc check
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  generate-doc-check:
+    name: Generate doc check
+    runs-on: ubuntu-20.04
+    if: github.repository == 'apache/incubator-pekko'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup Java 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v6
+
+      - name: Install Graphviz
+        run: |-
+          sudo apt-get install graphviz
+
+      - name: Publish to Apache Maven Local repo
+        run: sbt +compile:doc

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -11,6 +11,8 @@ updates.ignore = [
   { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-jsr310" }
   { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-jdk8" }
   { groupId = "com.google.protobuf", artifactId = "protobuf-java" }
+  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox-project-info" }
+  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox "}
   { groupId = "com.typesafe", artifactId = "ssl-config-core" }
   { groupId = "com.typesafe.sbt", artifactId = "sbt-osgi" }
   { groupId = "org.agrona", artifactId = "agrona" }

--- a/actor-testkit-typed/src/main/java/org/apache/pekko/actor/testkit/typed/annotations/Junit5TestKit.java
+++ b/actor-testkit-typed/src/main/java/org/apache/pekko/actor/testkit/typed/annotations/Junit5TestKit.java
@@ -1,9 +1,18 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements; and to You under the Apache License, Version 2.0.
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *   https://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.pekko.actor.testkit.typed.annotations;

--- a/actor-testkit-typed/src/main/java/org/apache/pekko/actor/testkit/typed/annotations/Junit5TestKit.java
+++ b/actor-testkit-typed/src/main/java/org/apache/pekko/actor/testkit/typed/annotations/Junit5TestKit.java
@@ -1,10 +1,9 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * license agreements; and to You under the Apache License, version 2.0:
+ * contributor license agreements; and to You under the Apache License, Version 2.0.
  *
  *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
 package org.apache.pekko.actor.testkit.typed.annotations;

--- a/actor-testkit-typed/src/main/java/org/apache/pekko/actor/testkit/typed/annotations/Junit5TestKit.java
+++ b/actor-testkit-typed/src/main/java/org/apache/pekko/actor/testkit/typed/annotations/Junit5TestKit.java
@@ -7,15 +7,11 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-package org.apache.pekko.actor.testkit.typed.javadsl;
-
+package org.apache.pekko.actor.testkit.typed.annotations;
 
 import java.lang.annotation.*;
 
 @Documented
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
-public  @interface Junit5TestKit {
-}
-
-
+public @interface Junit5TestKit {}

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKit.java
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKit.java
@@ -4,10 +4,11 @@
  *
  *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * This file is part of the Apache Pekko project, derived from Akka.
+ * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
 package org.apache.pekko.actor.testkit.typed.javadsl;
+
 
 import java.lang.annotation.*;
 

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKit.java
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKit.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+package org.apache.pekko.actor.testkit.typed.javadsl;
+
+import java.lang.annotation.*;
+
+@Documented
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public  @interface Junit5TestKit {
+}
+
+

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKitBuilder.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKitBuilder.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+package org.apache.pekko.actor.testkit.typed.javadsl
+
+import com.typesafe.config.Config
+import org.apache.pekko.actor.testkit.typed.internal.TestKitUtils
+import org.apache.pekko.actor.testkit.typed.scaladsl.ActorTestKit.ApplicationTestConfig
+import org.apache.pekko.actor.typed.ActorSystem
+
+ case class Junit5TestKitBuilder()  {
+
+   var system: Option[ActorSystem[_]] = None
+
+   var customConfig: Config = ApplicationTestConfig
+
+   var name: String = TestKitUtils.testNameFromCallStack(classOf[Junit5TestKitBuilder])
+
+  def withSystem(system: ActorSystem[_]): Junit5TestKitBuilder = {
+    this.system = Some(system)
+    this
+  }
+
+  def withCustomConfig(customConfig: Config): Junit5TestKitBuilder = {
+    this.customConfig = customConfig
+    this
+  }
+
+  def withName(name: String): Junit5TestKitBuilder = {
+    this.name = name
+    this
+  }
+
+  def build(): ActorTestKit = {
+    if (system.isDefined) {
+      return ActorTestKit.create(system.get)
+    }
+    ActorTestKit.create(name, customConfig)
+  }
+
+}
+

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKitBuilder.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKitBuilder.scala
@@ -4,7 +4,7 @@
  *
  *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * This file is part of the Apache Pekko project, derived from Akka.
+ * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
 package org.apache.pekko.actor.testkit.typed.javadsl

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKitBuilder.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKitBuilder.scala
@@ -1,10 +1,9 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * license agreements; and to You under the Apache License, version 2.0:
+ * contributor license agreements; and to You under the Apache License, Version 2.0.
  *
  *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
 package org.apache.pekko.actor.testkit.typed.javadsl

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKitBuilder.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKitBuilder.scala
@@ -14,13 +14,13 @@ import org.apache.pekko.actor.testkit.typed.internal.TestKitUtils
 import org.apache.pekko.actor.testkit.typed.scaladsl.ActorTestKit.ApplicationTestConfig
 import org.apache.pekko.actor.typed.ActorSystem
 
- case class Junit5TestKitBuilder()  {
+case class Junit5TestKitBuilder() {
 
-   var system: Option[ActorSystem[_]] = None
+  var system: Option[ActorSystem[_]] = None
 
-   var customConfig: Config = ApplicationTestConfig
+  var customConfig: Config = ApplicationTestConfig
 
-   var name: String = TestKitUtils.testNameFromCallStack(classOf[Junit5TestKitBuilder])
+  var name: String = TestKitUtils.testNameFromCallStack(classOf[Junit5TestKitBuilder])
 
   def withSystem(system: ActorSystem[_]): Junit5TestKitBuilder = {
     this.system = Some(system)
@@ -45,4 +45,3 @@ import org.apache.pekko.actor.typed.ActorSystem
   }
 
 }
-

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKitBuilder.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKitBuilder.scala
@@ -1,9 +1,18 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements; and to You under the Apache License, Version 2.0.
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *   https://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.pekko.actor.testkit.typed.javadsl

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKitBuilder.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/Junit5TestKitBuilder.scala
@@ -17,12 +17,13 @@
 
 package org.apache.pekko.actor.testkit.typed.javadsl
 
+import org.apache.pekko
 import com.typesafe.config.Config
-import org.apache.pekko.actor.testkit.typed.internal.TestKitUtils
-import org.apache.pekko.actor.testkit.typed.scaladsl.ActorTestKit.ApplicationTestConfig
-import org.apache.pekko.actor.typed.ActorSystem
+import pekko.actor.testkit.typed.internal.TestKitUtils
+import pekko.actor.testkit.typed.scaladsl.ActorTestKit.ApplicationTestConfig
+import pekko.actor.typed.ActorSystem
 
-case class Junit5TestKitBuilder() {
+final class Junit5TestKitBuilder() {
 
   var system: Option[ActorSystem[_]] = None
 

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtension.scala
@@ -27,7 +27,6 @@ final class LogCapturingExtension extends InvocationInterceptor {
   override def interceptTestMethod(invocation: Invocation[Void], invocationContext: ReflectiveInvocationContext[Method],
       extensionContext: ExtensionContext): Unit = {
 
-
     val testClassName = invocationContext.getTargetClass.getSimpleName
     val testMethodName = invocationContext.getExecutable.getName
 

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtension.scala
@@ -4,7 +4,7 @@
  *
  *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * This file is part of the Apache Pekko project, derived from Akka.
+ * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
 package org.apache.pekko.actor.testkit.typed.javadsl

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtension.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+package org.apache.pekko.actor.testkit.typed.javadsl
+
+import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation
+import org.junit.jupiter.api.extension.{ ExtensionContext, InvocationInterceptor, ReflectiveInvocationContext }
+import org.slf4j.LoggerFactory
+import org.apache.pekko.actor.testkit.typed.internal.CapturingAppender
+
+import java.lang.reflect.Method
+import scala.util.control.NonFatal
+
+final class LogCapturingExtension extends InvocationInterceptor {
+
+  private val capturingAppender = CapturingAppender.get("")
+
+  private val myLogger = LoggerFactory.getLogger(classOf[LogCapturing])
+
+  @throws[Throwable]
+  override def interceptTestMethod(invocation: Invocation[Void], invocationContext: ReflectiveInvocationContext[Method],
+      extensionContext: ExtensionContext): Unit = {
+
+
+    val testClassName = invocationContext.getTargetClass.getSimpleName
+    val testMethodName = invocationContext.getExecutable.getName
+
+    try {
+      myLogger.info(s"Logging started for test [${testClassName}: ${testMethodName}]")
+      invocation.proceed
+      myLogger.info(
+        s"Logging finished for test [${testClassName}: ${testMethodName}] that was successful")
+    } catch {
+      case NonFatal(e) =>
+        println(
+          s"--> [${Console.BLUE}${testClassName}: ${testMethodName}${Console.RESET}] " +
+          s"Start of log messages of test that failed with ${e.getMessage}")
+        capturingAppender.flush()
+        println(
+          s"<-- [${Console.BLUE}${testClassName}: ${testMethodName}${Console.RESET}] " +
+          s"End of log messages of test that failed with ${e.getMessage}")
+        throw e
+    } finally {
+
+      capturingAppender.clear()
+    }
+  }
+}

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
@@ -12,7 +12,7 @@ package org.apache.pekko.actor.testkit.typed.javadsl
 import org.junit.jupiter.api.extension.{ AfterAllCallback, BeforeTestExecutionCallback, ExtensionContext }
 import org.junit.platform.commons.support.AnnotationSupport
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 final class TestKitJunit5Extension() extends AfterAllCallback with BeforeTestExecutionCallback {
 

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+package org.apache.pekko.actor.testkit.typed.javadsl
+
+import org.apache.pekko
+import org.junit.jupiter.api.extension.{AfterAllCallback, BeforeTestExecutionCallback, ExtensionContext}
+import org.junit.platform.commons.support.AnnotationSupport
+
+import scala.jdk.CollectionConverters._
+
+final class TestKitJunit5Extension() extends AfterAllCallback with BeforeTestExecutionCallback {
+
+  var testKit: Option[ActorTestKit] = None
+
+
+  /**
+   * Get a reference to the field annotated with @Junit5Testkit  [[pekko.actor.testkit.typed.javadsl.Junit5TestKit]]
+   *
+   */
+  override def beforeTestExecution(context: ExtensionContext): Unit =  {
+
+    context.getTestInstance.ifPresent(instance => {
+      val fielValue = AnnotationSupport.findAnnotatedFieldValues(instance, classOf[Junit5TestKit]).asScala.toList.head
+      testKit = Some(fielValue.asInstanceOf[ActorTestKit])
+    })
+  }
+
+
+  /**
+   * Shutdown testKit
+   */
+  override def afterAll(context: ExtensionContext): Unit = {
+     testKit.get.shutdownTestKit()
+  }
+
+}

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
@@ -23,9 +23,14 @@ final class TestKitJunit5Extension() extends AfterAllCallback with BeforeTestExe
    */
   override def beforeTestExecution(context: ExtensionContext): Unit = {
 
-    context.getTestInstance.ifPresent((instance: AnyRef)  => {
-      val fielValue = AnnotationSupport.findAnnotatedFieldValues(instance, classOf[Junit5TestKit]).asScala.toList.head
-      testKit = Some(fielValue.asInstanceOf[ActorTestKit])
+    context.getTestInstance.ifPresent((instance: AnyRef) => {
+      val annotations = AnnotationSupport.findAnnotatedFieldValues(instance, classOf[Junit5TestKit])
+      if (annotations.isEmpty) {
+        throw new IllegalArgumentException("Could not find field annotated with @Junit5TestKit")
+      } else {
+        val fieldValue = annotations.asScala.toList.head
+        testKit = Some(fieldValue.asInstanceOf[ActorTestKit])
+      }
     })
   }
 

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
@@ -9,9 +9,10 @@
 
 package org.apache.pekko.actor.testkit.typed.javadsl
 
-import org.junit.jupiter.api.extension.{ AfterAllCallback, BeforeTestExecutionCallback, ExtensionContext }
+import org.junit.jupiter.api.extension.{AfterAllCallback, BeforeTestExecutionCallback, ExtensionContext}
 import org.junit.platform.commons.support.AnnotationSupport
 import org.apache.pekko
+import org.apache.pekko.actor.testkit.typed.annotations.Junit5TestKit
 import pekko.util.ccompat.JavaConverters.CollectionHasAsScala
 
 final class TestKitJunit5Extension() extends AfterAllCallback with BeforeTestExecutionCallback {
@@ -19,7 +20,7 @@ final class TestKitJunit5Extension() extends AfterAllCallback with BeforeTestExe
   var testKit: Option[ActorTestKit] = None
 
   /**
-   * Get a reference to the field annotated with @Junit5Testkit  [[pekko.actor.testkit.typed.javadsl.Junit5TestKit]]
+   * Get a reference to the field annotated with @Junit5Testkit  [[Junit5TestKit]]
    */
   override def beforeTestExecution(context: ExtensionContext): Unit = {
 

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
@@ -4,7 +4,7 @@
  *
  *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * This file is part of the Apache Pekko project, derived from Akka.
+ * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
 package org.apache.pekko.actor.testkit.typed.javadsl

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
@@ -11,8 +11,8 @@ package org.apache.pekko.actor.testkit.typed.javadsl
 
 import org.junit.jupiter.api.extension.{ AfterAllCallback, BeforeTestExecutionCallback, ExtensionContext }
 import org.junit.platform.commons.support.AnnotationSupport
-
-import scala.jdk.CollectionConverters.CollectionHasAsScala
+import org.apache.pekko
+import pekko.util.ccompat.JavaConverters.CollectionHasAsScala
 
 final class TestKitJunit5Extension() extends AfterAllCallback with BeforeTestExecutionCallback {
 
@@ -23,7 +23,7 @@ final class TestKitJunit5Extension() extends AfterAllCallback with BeforeTestExe
    */
   override def beforeTestExecution(context: ExtensionContext): Unit = {
 
-    context.getTestInstance.ifPresent(instance => {
+    context.getTestInstance.ifPresent((instance: AnyRef)  => {
       val fielValue = AnnotationSupport.findAnnotatedFieldValues(instance, classOf[Junit5TestKit]).asScala.toList.head
       testKit = Some(fielValue.asInstanceOf[ActorTestKit])
     })

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
@@ -9,7 +9,7 @@
 
 package org.apache.pekko.actor.testkit.typed.javadsl
 
-import org.junit.jupiter.api.extension.{AfterAllCallback, BeforeTestExecutionCallback, ExtensionContext}
+import org.junit.jupiter.api.extension.{ AfterAllCallback, BeforeTestExecutionCallback, ExtensionContext }
 import org.junit.platform.commons.support.AnnotationSupport
 
 import scala.jdk.CollectionConverters._

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
@@ -17,7 +17,8 @@
 
 package org.apache.pekko.actor.testkit.typed.javadsl
 
-import org.apache.pekko.actor.testkit.typed.annotations.Junit5TestKit
+import org.apache.pekko
+import pekko.actor.testkit.typed.annotations.Junit5TestKit
 import org.junit.jupiter.api.extension.{ AfterAllCallback, BeforeTestExecutionCallback, ExtensionContext }
 import org.junit.platform.commons.support.AnnotationSupport
 

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
@@ -1,10 +1,9 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * license agreements; and to You under the Apache License, version 2.0:
+ * contributor license agreements; and to You under the Apache License, Version 2.0.
  *
  *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
 package org.apache.pekko.actor.testkit.typed.javadsl

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
@@ -1,9 +1,18 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements; and to You under the Apache License, Version 2.0.
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *   https://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.pekko.actor.testkit.typed.javadsl

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
@@ -9,8 +9,7 @@
 
 package org.apache.pekko.actor.testkit.typed.javadsl
 
-import org.apache.pekko
-import org.junit.jupiter.api.extension.{ AfterAllCallback, BeforeTestExecutionCallback, ExtensionContext }
+import org.junit.jupiter.api.extension.{AfterAllCallback, BeforeTestExecutionCallback, ExtensionContext}
 import org.junit.platform.commons.support.AnnotationSupport
 
 import scala.jdk.CollectionConverters._

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
@@ -10,7 +10,7 @@
 package org.apache.pekko.actor.testkit.typed.javadsl
 
 import org.apache.pekko
-import org.junit.jupiter.api.extension.{AfterAllCallback, BeforeTestExecutionCallback, ExtensionContext}
+import org.junit.jupiter.api.extension.{ AfterAllCallback, BeforeTestExecutionCallback, ExtensionContext }
 import org.junit.platform.commons.support.AnnotationSupport
 
 import scala.jdk.CollectionConverters._
@@ -19,12 +19,10 @@ final class TestKitJunit5Extension() extends AfterAllCallback with BeforeTestExe
 
   var testKit: Option[ActorTestKit] = None
 
-
   /**
    * Get a reference to the field annotated with @Junit5Testkit  [[pekko.actor.testkit.typed.javadsl.Junit5TestKit]]
-   *
    */
-  override def beforeTestExecution(context: ExtensionContext): Unit =  {
+  override def beforeTestExecution(context: ExtensionContext): Unit = {
 
     context.getTestInstance.ifPresent(instance => {
       val fielValue = AnnotationSupport.findAnnotatedFieldValues(instance, classOf[Junit5TestKit]).asScala.toList.head
@@ -32,12 +30,11 @@ final class TestKitJunit5Extension() extends AfterAllCallback with BeforeTestExe
     })
   }
 
-
   /**
    * Shutdown testKit
    */
   override def afterAll(context: ExtensionContext): Unit = {
-     testKit.get.shutdownTestKit()
+    testKit.get.shutdownTestKit()
   }
 
 }

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunit5Extension.scala
@@ -9,11 +9,9 @@
 
 package org.apache.pekko.actor.testkit.typed.javadsl
 
-import org.junit.jupiter.api.extension.{AfterAllCallback, BeforeTestExecutionCallback, ExtensionContext}
-import org.junit.platform.commons.support.AnnotationSupport
-import org.apache.pekko
 import org.apache.pekko.actor.testkit.typed.annotations.Junit5TestKit
-import pekko.util.ccompat.JavaConverters.CollectionHasAsScala
+import org.junit.jupiter.api.extension.{ AfterAllCallback, BeforeTestExecutionCallback, ExtensionContext }
+import org.junit.platform.commons.support.AnnotationSupport
 
 final class TestKitJunit5Extension() extends AfterAllCallback with BeforeTestExecutionCallback {
 
@@ -26,12 +24,9 @@ final class TestKitJunit5Extension() extends AfterAllCallback with BeforeTestExe
 
     context.getTestInstance.ifPresent((instance: AnyRef) => {
       val annotations = AnnotationSupport.findAnnotatedFieldValues(instance, classOf[Junit5TestKit])
-      if (annotations.isEmpty) {
-        throw new IllegalArgumentException("Could not find field annotated with @Junit5TestKit")
-      } else {
-        val fieldValue = annotations.asScala.toList.head
-        testKit = Some(fieldValue.asInstanceOf[ActorTestKit])
-      }
+      val fieldValue = annotations.stream().findFirst().orElseThrow(() =>
+        throw new IllegalArgumentException("Could not find field annotated with @Junit5TestKit"))
+      testKit = Some(fieldValue.asInstanceOf[ActorTestKit])
     })
   }
 

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/GreeterMain.scala
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/GreeterMain.scala
@@ -9,8 +9,9 @@
 
 package jdocs.org.apache.pekko.actor.testkit.typed.javadsl
 
-import org.apache.pekko.actor.typed.{ ActorRef, Behavior }
-import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko
+import pekko.actor.typed.{ ActorRef, Behavior }
+import pekko.actor.typed.scaladsl.Behaviors
 
 object Greeter {
   final case class Greet(whom: String, replyTo: ActorRef[Greeted])

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/GreeterMain.scala
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/GreeterMain.scala
@@ -4,7 +4,7 @@
  *
  *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * This file is part of the Apache Pekko project, derived from Akka.
+ * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
 package jdocs.org.apache.pekko.actor.testkit.typed.javadsl

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/GreeterMain.scala
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/GreeterMain.scala
@@ -9,9 +9,8 @@
 
 package jdocs.org.apache.pekko.actor.testkit.typed.javadsl
 
-import org.apache.pekko.actor.typed.{ActorRef, Behavior}
+import org.apache.pekko.actor.typed.{ ActorRef, Behavior }
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
-
 
 object Greeter {
   final case class Greet(whom: String, replyTo: ActorRef[Greeted])
@@ -19,9 +18,9 @@ object Greeter {
 
   def apply(): Behavior[Greet] = Behaviors.receive { (context, message) =>
     context.log.info("Hello {}!", message.whom)
-    //#greeter-send-messages
+    // #greeter-send-messages
     message.replyTo ! Greeted(message.whom, context.self)
-    //#greeter-send-messages
+    // #greeter-send-messages
     Behaviors.same
   }
 }

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/GreeterMain.scala
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/GreeterMain.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+package jdocs.org.apache.pekko.actor.testkit.typed.javadsl
+
+import org.apache.pekko.actor.typed.{ActorRef, Behavior}
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+
+
+object Greeter {
+  final case class Greet(whom: String, replyTo: ActorRef[Greeted])
+  final case class Greeted(whom: String, from: ActorRef[Greet])
+
+  def apply(): Behavior[Greet] = Behaviors.receive { (context, message) =>
+    context.log.info("Hello {}!", message.whom)
+    //#greeter-send-messages
+    message.replyTo ! Greeted(message.whom, context.self)
+    //#greeter-send-messages
+    Behaviors.same
+  }
+}
+
+object GreeterBot {
+
+  def apply(max: Int): Behavior[Greeter.Greeted] = {
+    bot(0, max)
+  }
+
+  private def bot(greetingCounter: Int, max: Int): Behavior[Greeter.Greeted] =
+    Behaviors.receive { (context, message) =>
+      val n = greetingCounter + 1
+      context.log.info("Greeting {} for {}", n, message.whom)
+      if (n == max) {
+        Behaviors.stopped
+      } else {
+        message.from ! Greeter.Greet(message.whom, context.self)
+        bot(n, max)
+      }
+    }
+}
+
+object GreeterMain {
+
+  final case class SayHello(name: String)
+
+  def apply(): Behavior[SayHello] =
+    Behaviors.setup { context =>
+      val greeter = context.spawn(Greeter(), "greeter")
+
+      Behaviors.receiveMessage { message =>
+        val replyTo = context.spawn(GreeterBot(max = 3), message.name)
+        greeter ! Greeter.Greet(message.name, replyTo)
+        Behaviors.same
+      }
+    }
+}

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/Junit5IntegrationExampleTest.java
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/Junit5IntegrationExampleTest.java
@@ -7,6 +7,8 @@
  * This file is part of the Apache Pekko project, derived from Akka.
  */
 
+// test code copied from JunitIntegrationTest.java
+
 package jdocs.org.apache.pekko.actor.testkit.typed.javadsl;
 
 import org.apache.pekko.actor.Address;

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/Junit5IntegrationExampleTest.java
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/Junit5IntegrationExampleTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+package jdocs.org.apache.pekko.actor.testkit.typed.javadsl;
+
+import org.apache.pekko.actor.Address;
+import org.apache.pekko.actor.testkit.typed.javadsl.*;
+import org.apache.pekko.actor.testkit.typed.javadsl.Junit5TestKitBuilder;
+import org.apache.pekko.actor.typed.ActorRef;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+// #junit5-integration
+@DisplayName("Junit5")
+@ExtendWith(TestKitJunit5Extension.class)
+class Junit5IntegrationExampleTest {
+
+  @Junit5TestKit public ActorTestKit testKit = new Junit5TestKitBuilder().build();
+
+  @Test
+  void junit5Test() {
+    Address address = testKit.system().address();
+    assertNotNull(address);
+  }
+
+  @Test
+  void testSomething() {
+
+    ActorRef<AsyncTestingExampleTest.Echo.Ping> pinger =
+        testKit.spawn(AsyncTestingExampleTest.Echo.create(), "ping");
+    TestProbe<AsyncTestingExampleTest.Echo.Pong> probe = testKit.createTestProbe();
+    pinger.tell(new AsyncTestingExampleTest.Echo.Ping("hello", probe.ref()));
+    AsyncTestingExampleTest.Echo.Pong pong =
+        probe.expectMessage(new AsyncTestingExampleTest.Echo.Pong("hello"));
+    assertEquals("hello", pong.message);
+  }
+
+  @Test
+  void testSomething2() {
+    ActorRef<AsyncTestingExampleTest.Echo.Ping> pinger2 =
+        testKit.spawn(AsyncTestingExampleTest.Echo.create(), "ping2");
+    TestProbe<AsyncTestingExampleTest.Echo.Pong> probe2 = testKit.createTestProbe();
+    pinger2.tell(new AsyncTestingExampleTest.Echo.Ping("hello", probe2.ref()));
+    AsyncTestingExampleTest.Echo.Pong pong =
+        probe2.expectMessage(new AsyncTestingExampleTest.Echo.Pong("hello"));
+    assertEquals("hello", pong.message);
+  }
+}
+// #junit5-integration

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/Junit5IntegrationExampleTest.java
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/Junit5IntegrationExampleTest.java
@@ -11,6 +11,7 @@
 
 package jdocs.org.apache.pekko.actor.testkit.typed.javadsl;
 
+import org.apache.pekko.actor.testkit.typed.annotations.Junit5TestKit;
 import org.apache.pekko.actor.Address;
 import org.apache.pekko.actor.testkit.typed.javadsl.*;
 import org.apache.pekko.actor.testkit.typed.javadsl.Junit5TestKitBuilder;
@@ -27,7 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @ExtendWith(TestKitJunit5Extension.class)
 class Junit5IntegrationExampleTest {
 
-  @Junit5TestKit public ActorTestKit testKit = new Junit5TestKitBuilder().build();
+  @Junit5TestKit
+  public ActorTestKit testKit = new Junit5TestKitBuilder().build();
 
   @Test
   void junit5Test() {

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/Junit5IntegrationExampleTest.java
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/Junit5IntegrationExampleTest.java
@@ -7,8 +7,6 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-// test code copied from JunitIntegrationTest.java
-
 package jdocs.org.apache.pekko.actor.testkit.typed.javadsl;
 
 import org.apache.pekko.actor.testkit.typed.annotations.Junit5TestKit;

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/Junit5IntegrationExampleTest.java
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/Junit5IntegrationExampleTest.java
@@ -4,7 +4,7 @@
  *
  *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * This file is part of the Apache Pekko project, derived from Akka.
+ * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
 // test code copied from JunitIntegrationTest.java

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/Junit5IntegrationExampleTest.java
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/Junit5IntegrationExampleTest.java
@@ -26,8 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @ExtendWith(TestKitJunit5Extension.class)
 class Junit5IntegrationExampleTest {
 
-  @Junit5TestKit
-  public ActorTestKit testKit = new Junit5TestKitBuilder().build();
+  @Junit5TestKit public ActorTestKit testKit = new Junit5TestKitBuilder().build();
 
   @Test
   void junit5Test() {

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtensionExampleTest.java
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtensionExampleTest.java
@@ -7,7 +7,6 @@
  * This file is part of the Apache Pekko project, derived from Akka.
  */
 
-
 package jdocs.org.apache.pekko.actor.testkit.typed.javadsl;
 
 // #log-capturing-junit5

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtensionExampleTest.java
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtensionExampleTest.java
@@ -11,6 +11,7 @@
 package jdocs.org.apache.pekko.actor.testkit.typed.javadsl;
 
 // #log-capturing-junit5
+
 import org.apache.pekko.actor.testkit.typed.javadsl.*;
 import org.apache.pekko.actor.testkit.typed.javadsl.Junit5TestKitBuilder;
 import org.apache.pekko.actor.typed.ActorRef;
@@ -19,6 +20,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static jdocs.org.apache.pekko.actor.testkit.typed.javadsl.AsyncTestingExampleTest.Echo;
+
+// test code copied from LogCapturingExampleTest.java
 
 @DisplayName("Junit5 log capturing")
 @ExtendWith(TestKitJunit5Extension.class)

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtensionExampleTest.java
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtensionExampleTest.java
@@ -7,9 +7,6 @@
  * This file is part of the Apache Pekko project, derived from Akka.
  */
 
-/*
- * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
- */
 
 package jdocs.org.apache.pekko.actor.testkit.typed.javadsl;
 

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtensionExampleTest.java
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtensionExampleTest.java
@@ -11,6 +11,7 @@ package jdocs.org.apache.pekko.actor.testkit.typed.javadsl;
 
 // #log-capturing-junit5
 
+import org.apache.pekko.actor.testkit.typed.annotations.Junit5TestKit;
 import org.apache.pekko.actor.testkit.typed.javadsl.*;
 import org.apache.pekko.actor.testkit.typed.javadsl.Junit5TestKitBuilder;
 import org.apache.pekko.actor.typed.ActorRef;
@@ -27,7 +28,8 @@ import static jdocs.org.apache.pekko.actor.testkit.typed.javadsl.AsyncTestingExa
 @ExtendWith(LogCapturingExtension.class)
 class LogCapturingExtensionExampleTest {
 
-  @Junit5TestKit public ActorTestKit testKit = new Junit5TestKitBuilder().build();
+  @Junit5TestKit
+  public ActorTestKit testKit = new Junit5TestKitBuilder().build();
 
   @Test
   void testSomething() {

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtensionExampleTest.java
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtensionExampleTest.java
@@ -28,8 +28,7 @@ import static jdocs.org.apache.pekko.actor.testkit.typed.javadsl.AsyncTestingExa
 @ExtendWith(LogCapturingExtension.class)
 class LogCapturingExtensionExampleTest {
 
-  @Junit5TestKit
-  public ActorTestKit testKit = new Junit5TestKitBuilder().build();
+  @Junit5TestKit public ActorTestKit testKit = new Junit5TestKitBuilder().build();
 
   @Test
   void testSomething() {

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtensionExampleTest.java
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtensionExampleTest.java
@@ -4,7 +4,7 @@
  *
  *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * This file is part of the Apache Pekko project, derived from Akka.
+ * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
 package jdocs.org.apache.pekko.actor.testkit.typed.javadsl;

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtensionExampleTest.java
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtensionExampleTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package jdocs.org.apache.pekko.actor.testkit.typed.javadsl;
+
+// #log-capturing-junit5
+import org.apache.pekko.actor.testkit.typed.javadsl.*;
+import org.apache.pekko.actor.testkit.typed.javadsl.Junit5TestKitBuilder;
+import org.apache.pekko.actor.typed.ActorRef;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static jdocs.org.apache.pekko.actor.testkit.typed.javadsl.AsyncTestingExampleTest.Echo;
+
+@DisplayName("Junit5 log capturing")
+@ExtendWith(TestKitJunit5Extension.class)
+@ExtendWith(LogCapturingExtension.class)
+class LogCapturingExtensionExampleTest {
+
+  @Junit5TestKit public ActorTestKit testKit = new Junit5TestKitBuilder().build();
+
+  @Test
+  void testSomething() {
+    ActorRef<Echo.Ping> pinger = testKit.spawn(Echo.create(), "ping");
+    TestProbe<Echo.Pong> probe = testKit.createTestProbe();
+    pinger.tell(new Echo.Ping("hello", probe.ref()));
+    probe.expectMessage(new Echo.Pong("hello"));
+  }
+
+  @Test
+  void testSomething2() {
+    ActorRef<Echo.Ping> pinger = testKit.spawn(Echo.create(), "ping");
+    TestProbe<Echo.Pong> probe = testKit.createTestProbe();
+    pinger.tell(new Echo.Ping("hello", probe.ref()));
+    probe.expectMessage(new Echo.Pong("hello"));
+  }
+}
+// #log-capturing-junit5

--- a/actor-testkit-typed/src/test/java/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKitJunit5Test.java
+++ b/actor-testkit-typed/src/test/java/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKitJunit5Test.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package org.apache.pekko.actor.testkit.typed.javadsl;
+
+import org.apache.pekko.Done;
+import org.apache.pekko.actor.typed.javadsl.Behaviors;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.scalatestplus.junit.JUnitSuite;
+
+import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.pekko.Done.done;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DisplayName("ActorTestKitTestJunit5")
+@ExtendWith(TestKitJunit5Extension.class)
+@ExtendWith(LogCapturingExtension.class)
+class ActorTestKitJunit5Test extends JUnitSuite {
+
+  @Junit5TestKit public ActorTestKit testKit = new Junit5TestKitBuilder().build();
+
+  @Test
+  void systemNameShouldComeFromTestClassViaJunitResource() {
+    assertEquals("ActorTestKitJunit5Test", testKit.system().name());
+  }
+
+  @Test
+  void systemNameShouldComeFromTestClass() {
+    final ActorTestKit testKit2 = ActorTestKit.create();
+    try {
+      assertEquals("ActorTestKitJunit5Test", testKit2.system().name());
+    } finally {
+      testKit2.shutdownTestKit();
+    }
+  }
+
+  @Test
+  void systemNameShouldComeFromGivenClassName() {
+    final ActorTestKit testKit2 = ActorTestKit.create(HashMap.class.getName());
+    try {
+      // removing package name and such
+      assertEquals("HashMap", testKit2.system().name());
+    } finally {
+      testKit2.shutdownTestKit();
+    }
+  }
+
+  @Test
+  void testKitShouldSpawnActor() throws Exception {
+    final CompletableFuture<Done> started = new CompletableFuture<>();
+    testKit.spawn(
+        Behaviors.setup(
+            (context) -> {
+              started.complete(done());
+              return Behaviors.same();
+            }));
+    assertNotNull(started.get(3, TimeUnit.SECONDS));
+  }
+}

--- a/actor-testkit-typed/src/test/java/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKitJunit5Test.java
+++ b/actor-testkit-typed/src/test/java/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKitJunit5Test.java
@@ -7,7 +7,6 @@
  * This file is part of the Apache Pekko project, derived from Akka.
  */
 
-
 package org.apache.pekko.actor.testkit.typed.javadsl;
 
 import org.apache.pekko.Done;

--- a/actor-testkit-typed/src/test/java/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKitJunit5Test.java
+++ b/actor-testkit-typed/src/test/java/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKitJunit5Test.java
@@ -9,7 +9,6 @@
 
 package org.apache.pekko.actor.testkit.typed.javadsl;
 
-
 import org.apache.pekko.actor.testkit.typed.annotations.Junit5TestKit;
 import org.apache.pekko.Done;
 import org.apache.pekko.actor.typed.javadsl.Behaviors;
@@ -32,8 +31,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @ExtendWith(LogCapturingExtension.class)
 class ActorTestKitJunit5Test extends JUnitSuite {
 
-  @Junit5TestKit
-  public ActorTestKit testKit = new Junit5TestKitBuilder().build();
+  @Junit5TestKit public ActorTestKit testKit = new Junit5TestKitBuilder().build();
+
   @Test
   void systemNameShouldComeFromTestClassViaJunitResource() {
     assertEquals("ActorTestKitJunit5Test", testKit.system().name());

--- a/actor-testkit-typed/src/test/java/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKitJunit5Test.java
+++ b/actor-testkit-typed/src/test/java/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKitJunit5Test.java
@@ -4,7 +4,7 @@
  *
  *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * This file is part of the Apache Pekko project, derived from Akka.
+ * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
 package org.apache.pekko.actor.testkit.typed.javadsl;

--- a/actor-testkit-typed/src/test/java/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKitJunit5Test.java
+++ b/actor-testkit-typed/src/test/java/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKitJunit5Test.java
@@ -9,6 +9,7 @@
 
 package org.apache.pekko.actor.testkit.typed.javadsl;
 
+
 import org.apache.pekko.actor.testkit.typed.annotations.Junit5TestKit;
 import org.apache.pekko.Done;
 import org.apache.pekko.actor.typed.javadsl.Behaviors;
@@ -33,7 +34,6 @@ class ActorTestKitJunit5Test extends JUnitSuite {
 
   @Junit5TestKit
   public ActorTestKit testKit = new Junit5TestKitBuilder().build();
-
   @Test
   void systemNameShouldComeFromTestClassViaJunitResource() {
     assertEquals("ActorTestKitJunit5Test", testKit.system().name());

--- a/actor-testkit-typed/src/test/java/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKitJunit5Test.java
+++ b/actor-testkit-typed/src/test/java/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKitJunit5Test.java
@@ -7,9 +7,6 @@
  * This file is part of the Apache Pekko project, derived from Akka.
  */
 
-/*
- * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
- */
 
 package org.apache.pekko.actor.testkit.typed.javadsl;
 

--- a/actor-testkit-typed/src/test/java/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKitJunit5Test.java
+++ b/actor-testkit-typed/src/test/java/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKitJunit5Test.java
@@ -9,6 +9,7 @@
 
 package org.apache.pekko.actor.testkit.typed.javadsl;
 
+import org.apache.pekko.actor.testkit.typed.annotations.Junit5TestKit;
 import org.apache.pekko.Done;
 import org.apache.pekko.actor.typed.javadsl.Behaviors;
 
@@ -30,7 +31,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @ExtendWith(LogCapturingExtension.class)
 class ActorTestKitJunit5Test extends JUnitSuite {
 
-  @Junit5TestKit public ActorTestKit testKit = new Junit5TestKitBuilder().build();
+  @Junit5TestKit
+  public ActorTestKit testKit = new Junit5TestKitBuilder().build();
 
   @Test
   void systemNameShouldComeFromTestClassViaJunitResource() {

--- a/actor-testkit-typed/src/test/resources/application.conf
+++ b/actor-testkit-typed/src/test/resources/application.conf
@@ -2,3 +2,4 @@
 
 # used by ActorTestKitSpec
 test.from-application = yes
+test.value = someValue

--- a/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/Junit5TestKitBuilderSpec.scala
+++ b/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/Junit5TestKitBuilderSpec.scala
@@ -17,19 +17,19 @@
 
 package org.apache.pekko.actor.testkit.typed.scaladsl
 
+import org.apache.pekko
+import pekko.actor.testkit.typed.javadsl.Junit5TestKitBuilder
+import pekko.actor.typed.ActorSystem
 import com.typesafe.config.ConfigFactory
 import jdocs.org.apache.pekko.actor.testkit.typed.javadsl.GreeterMain
-import org.apache.pekko.actor.testkit.typed.javadsl.Junit5TestKitBuilder
-import org.apache.pekko.actor.typed.ActorSystem
+
 import org.scalatest.wordspec.AnyWordSpec
 
 class Junit5TestKitBuilderSpec extends AnyWordSpec {
 
   "the Junit5TestKitBuilder" should {
     "create a Testkit with name hello" in {
-      val actualTestKit = Junit5TestKitBuilder()
-        .withName("hello")
-        .build()
+      val actualTestKit = new Junit5TestKitBuilder().withName("hello").build()
 
       assertResult("hello")(actualTestKit.system.name)
     }
@@ -37,7 +37,7 @@ class Junit5TestKitBuilderSpec extends AnyWordSpec {
 
   "the Junit5TestKitBuilder" should {
     "create a Testkit with the classname as name" in {
-      val actualTestKit = Junit5TestKitBuilder()
+      val actualTestKit = new Junit5TestKitBuilder()
         .build()
 
       assertResult("Junit5TestKitBuilderSpec")(actualTestKit.system.name)
@@ -48,7 +48,7 @@ class Junit5TestKitBuilderSpec extends AnyWordSpec {
     "create a Testkit with a custom config" in {
 
       val conf = ConfigFactory.load("application.conf")
-      val actualTestKit = Junit5TestKitBuilder()
+      val actualTestKit = new Junit5TestKitBuilder()
         .withCustomConfig(conf)
         .build()
       assertResult("someValue")(actualTestKit.system.settings.config.getString("test.value"))
@@ -61,7 +61,7 @@ class Junit5TestKitBuilderSpec extends AnyWordSpec {
     "create a Testkit with a custom config and name" in {
 
       val conf = ConfigFactory.load("application.conf")
-      val actualTestKit = Junit5TestKitBuilder()
+      val actualTestKit = new Junit5TestKitBuilder()
         .withCustomConfig(conf)
         .withName("hello")
         .build()
@@ -76,7 +76,7 @@ class Junit5TestKitBuilderSpec extends AnyWordSpec {
 
       val system: ActorSystem[GreeterMain.SayHello] = ActorSystem(GreeterMain(), "AkkaQuickStart")
 
-      val actualTestKit = Junit5TestKitBuilder()
+      val actualTestKit = new Junit5TestKitBuilder()
         .withSystem(system)
         .build()
       assertResult("AkkaQuickStart")(actualTestKit.system.name)

--- a/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/Junit5TestKitBuilderSpec.scala
+++ b/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/Junit5TestKitBuilderSpec.scala
@@ -15,10 +15,7 @@ import org.apache.pekko.actor.testkit.typed.javadsl.Junit5TestKitBuilder
 import org.apache.pekko.actor.typed.ActorSystem
 import org.scalatest.wordspec.AnyWordSpec
 
-
-
-class Junit5TestKitBuilderSpec extends AnyWordSpec{
-
+class Junit5TestKitBuilderSpec extends AnyWordSpec {
 
   "the Junit5TestKitBuilder" should {
     "create a Testkit with name hello" in {
@@ -38,7 +35,6 @@ class Junit5TestKitBuilderSpec extends AnyWordSpec{
       assertResult("Junit5TestKitBuilderSpec")(actualTestKit.system.name)
     }
   }
-
 
   "the Junit5TestKitBuilder" should {
     "create a Testkit with a custom config" in {
@@ -78,6 +74,5 @@ class Junit5TestKitBuilderSpec extends AnyWordSpec{
       assertResult("AkkaQuickStart")(actualTestKit.system.name)
     }
   }
-
 
 }

--- a/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/Junit5TestKitBuilderSpec.scala
+++ b/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/Junit5TestKitBuilderSpec.scala
@@ -1,9 +1,18 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements; and to You under the Apache License, Version 2.0.
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *   https://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.pekko.actor.testkit.typed.scaladsl

--- a/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/Junit5TestKitBuilderSpec.scala
+++ b/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/Junit5TestKitBuilderSpec.scala
@@ -4,7 +4,7 @@
  *
  *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * This file is part of the Apache Pekko project, derived from Akka.
+ * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
 package org.apache.pekko.actor.testkit.typed.scaladsl

--- a/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/Junit5TestKitBuilderSpec.scala
+++ b/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/Junit5TestKitBuilderSpec.scala
@@ -1,10 +1,9 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * license agreements; and to You under the Apache License, version 2.0:
+ * contributor license agreements; and to You under the Apache License, Version 2.0.
  *
  *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
 package org.apache.pekko.actor.testkit.typed.scaladsl

--- a/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/Junit5TestKitBuilderSpec.scala
+++ b/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/Junit5TestKitBuilderSpec.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+package org.apache.pekko.actor.testkit.typed.scaladsl
+
+import com.typesafe.config.ConfigFactory
+import jdocs.org.apache.pekko.actor.testkit.typed.javadsl.GreeterMain
+import org.apache.pekko.actor.testkit.typed.javadsl.Junit5TestKitBuilder
+import org.apache.pekko.actor.typed.ActorSystem
+import org.scalatest.wordspec.AnyWordSpec
+
+
+
+class Junit5TestKitBuilderSpec extends AnyWordSpec{
+
+
+  "the Junit5TestKitBuilder" should {
+    "create a Testkit with name hello" in {
+      val actualTestKit = Junit5TestKitBuilder()
+        .withName("hello")
+        .build()
+
+      assertResult("hello")(actualTestKit.system.name)
+    }
+  }
+
+  "the Junit5TestKitBuilder" should {
+    "create a Testkit with the classname as name" in {
+      val actualTestKit = Junit5TestKitBuilder()
+        .build()
+
+      assertResult("Junit5TestKitBuilderSpec")(actualTestKit.system.name)
+    }
+  }
+
+
+  "the Junit5TestKitBuilder" should {
+    "create a Testkit with a custom config" in {
+
+      val conf = ConfigFactory.load("application.conf")
+      val actualTestKit = Junit5TestKitBuilder()
+        .withCustomConfig(conf)
+        .build()
+      assertResult("someValue")(actualTestKit.system.settings.config.getString("test.value"))
+      assertResult("Junit5TestKitBuilderSpec")(actualTestKit.system.name)
+
+    }
+  }
+
+  "the Junit5TestKitBuilder" should {
+    "create a Testkit with a custom config and name" in {
+
+      val conf = ConfigFactory.load("application.conf")
+      val actualTestKit = Junit5TestKitBuilder()
+        .withCustomConfig(conf)
+        .withName("hello")
+        .build()
+      assertResult("someValue")(actualTestKit.system.settings.config.getString("test.value"))
+      assertResult("hello")(actualTestKit.system.name)
+
+    }
+  }
+
+  "the Junit5TestKitBuilder" should {
+    "create a Testkit with a custom system" in {
+
+      val system: ActorSystem[GreeterMain.SayHello] = ActorSystem(GreeterMain(), "AkkaQuickStart")
+
+      val actualTestKit = Junit5TestKitBuilder()
+        .withSystem(system)
+        .build()
+      assertResult("AkkaQuickStart")(actualTestKit.system.name)
+    }
+  }
+
+
+}

--- a/actor-typed/src/main/scala-jdk-9/org/apache/pekko/actor/typed/internal/jfr/Events.scala
+++ b/actor-typed/src/main/scala-jdk-9/org/apache/pekko/actor/typed/internal/jfr/Events.scala
@@ -20,8 +20,6 @@ import jdk.jfr.Label
 import jdk.jfr.StackTrace
 import org.apache.pekko.annotation.InternalApi
 
-import scala.annotation.unused
-
 // requires jdk9+ to compile
 // for editing these in IntelliJ, open module settings, change JDK dependency to 11 for only this module
 
@@ -97,7 +95,7 @@ final class DeliveryProducerReceived(val producerId: String, val currentSeqNr: L
 @StackTrace(false)
 @Category(Array("Pekko", "Delivery", "ProducerController")) @Label(
   "Delivery ProducerController received demand request")
-final class DeliveryProducerReceivedRequest(val producerId: String, val requestedSeqNr: Long, @unused confirmedSeqNr: Long)
+final class DeliveryProducerReceivedRequest(val producerId: String, val requestedSeqNr: Long, confirmedSeqNr: Long)
     extends Event
 
 /** INTERNAL API */

--- a/actor-typed/src/main/scala-jdk-9/org/apache/pekko/actor/typed/internal/jfr/Events.scala
+++ b/actor-typed/src/main/scala-jdk-9/org/apache/pekko/actor/typed/internal/jfr/Events.scala
@@ -18,8 +18,9 @@ import jdk.jfr.Enabled
 import jdk.jfr.Event
 import jdk.jfr.Label
 import jdk.jfr.StackTrace
-
 import org.apache.pekko.annotation.InternalApi
+
+import scala.annotation.unused
 
 // requires jdk9+ to compile
 // for editing these in IntelliJ, open module settings, change JDK dependency to 11 for only this module
@@ -96,7 +97,7 @@ final class DeliveryProducerReceived(val producerId: String, val currentSeqNr: L
 @StackTrace(false)
 @Category(Array("Pekko", "Delivery", "ProducerController")) @Label(
   "Delivery ProducerController received demand request")
-final class DeliveryProducerReceivedRequest(val producerId: String, val requestedSeqNr: Long, confirmedSeqNr: Long)
+final class DeliveryProducerReceivedRequest(val producerId: String, val requestedSeqNr: Long, @unused confirmedSeqNr: Long)
     extends Event
 
 /** INTERNAL API */

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/ExtensionsImpl.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/ExtensionsImpl.scala
@@ -42,7 +42,7 @@ private[pekko] trait ExtensionsImpl extends Extensions { self: ActorSystem[_] wi
     /*
      * @param throwOnLoadFail Throw exception when an extension fails to load (needed for backwards compatibility)
      */
-    def loadExtensions(key: String, throwOnLoadFail: Boolean): Unit = {
+    def loadExtensionsFor(key: String, throwOnLoadFail: Boolean): Unit = {
 
       settings.config.getStringList(key).asScala.foreach { extensionIdFQCN =>
         // it is either a Scala object or it is a Java class with a static singleton accessor
@@ -72,8 +72,8 @@ private[pekko] trait ExtensionsImpl extends Extensions { self: ActorSystem[_] wi
           }
       }
 
-    loadExtensions("pekko.actor.typed.library-extensions", throwOnLoadFail = true)
-    loadExtensions("pekko.actor.typed.extensions", throwOnLoadFail = false)
+    loadExtensionsFor("pekko.actor.typed.library-extensions", throwOnLoadFail = true)
+    loadExtensionsFor("pekko.actor.typed.extensions", throwOnLoadFail = false)
   }
 
   final override def hasExtension(ext: ExtensionId[_ <: Extension]): Boolean = findExtension(ext) != null

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@
  */
 
 import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCheckResolver
+import org.apache.pekko.Dependencies
 
 ThisBuild / scalafixScalaBinaryVersion := scalaBinaryVersion.value
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -97,7 +97,7 @@ object Dependencies {
     // Added explicitly for when artery tcp is used
     val agrona = "org.agrona" % "agrona" % agronaVersion
 
-    val asnOne = ("com.hierynomus" % "asn-one" % "0.5.0").exclude("org.slf4j", "slf4j-api")
+    val asnOne = ("com.hierynomus" % "asn-one" % "0.6.0").exclude("org.slf4j", "slf4j-api")
 
     val jacksonCore = Def.setting {
       "com.fasterxml.jackson.core" % "jackson-core" % jacksonCoreVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,12 +4,14 @@
  *
  *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * This file is part of the Apache Pekko project, which was derived from Akka.
+ * This file is part of the Apache Pekko project, derived from Akka.
  */
 
 /*
  * Copyright (C) 2016-2022 Lightbend Inc. <https://www.lightbend.com>
  */
+
+package org.apache.pekko
 
 import sbt._
 import Keys._
@@ -22,6 +24,8 @@ object Dependencies {
     .withRank(KeyRanks.Invisible) // avoid 'unused key' warning
 
   val junitVersion = "4.13.2"
+  val junit5Version = "5.10.0"
+
   val slf4jVersion = "1.7.36"
   // check agrona version when updating this
   val aeronVersion = "1.42.1"
@@ -85,6 +89,7 @@ object Dependencies {
     val lmdb = "org.lmdbjava" % "lmdbjava" % "0.8.3"
 
     val junit = "junit" % "junit" % junitVersion
+    val junit5 = "org.junit.jupiter" % "junit-jupiter-engine" % junit5Version
 
     // For Java 8 Conversions
     val java8Compat = Def.setting {
@@ -139,6 +144,9 @@ object Dependencies {
       val commonsCompress = "org.apache.commons" % "commons-compress" % "1.24.0" % Test
       val junit = "junit" % "junit" % junitVersion % Test
       val httpClient = "org.apache.httpcomponents" % "httpclient" % "4.5.14" % Test
+      val junit = "junit" % "junit" % junitVersion % "test"
+      val junit5 = "org.junit.jupiter" % "junit-jupiter-engine" % junit5Version % Test
+
 
       val logback = Compile.logback % Test
 
@@ -212,6 +220,7 @@ object Dependencies {
       val levelDBNative = "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8" % "optional;provided"
 
       val junit = Compile.junit % "optional;provided;test"
+      val junit5 = Compile.junit5 % "optional;provided;test"
 
       val scalatest = Def.setting { "org.scalatest" %% "scalatest" % scalaTestVersion % "optional;provided;test" }
 
@@ -265,6 +274,7 @@ object Dependencies {
   val actorTestkitTyped = l ++= Seq(
     Provided.logback,
     Provided.junit,
+    Provided.junit5,
     Provided.scalatest.value,
     TestDependencies.scalatestJUnit.value)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -135,7 +135,7 @@ object Dependencies {
     object TestDependencies {
       val bcpkix = "org.bouncycastle" % "bcpkix-jdk15on" % "1.70" % Test
       val commonsMath = "org.apache.commons" % "commons-math" % "2.2" % Test
-      val commonsIo = "commons-io" % "commons-io" % "2.11.0" % Test
+      val commonsIo = "commons-io" % "commons-io" % "2.14.0" % Test
       val commonsCodec = "commons-codec" % "commons-codec" % "1.15" % Test
       val commonsCompress = "org.apache.commons" % "commons-compress" % "1.24.0" % Test
       val junit = "junit" % "junit" % junitVersion % Test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -137,7 +137,7 @@ object Dependencies {
       val commonsMath = "org.apache.commons" % "commons-math" % "2.2" % Test
       val commonsIo = "commons-io" % "commons-io" % "2.11.0" % Test
       val commonsCodec = "commons-codec" % "commons-codec" % "1.15" % Test
-      val commonsCompress = "org.apache.commons" % "commons-compress" % "1.23.0" % Test
+      val commonsCompress = "org.apache.commons" % "commons-compress" % "1.24.0" % Test
       val junit = "junit" % "junit" % junitVersion % Test
       val httpClient = "org.apache.httpcomponents" % "httpclient" % "4.5.14" % Test
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
   val agronaVersion = "1.19.2"
   val nettyVersion = "4.1.100.Final"
   val protobufJavaVersion = "3.19.6"
-  val logbackVersion = "1.2.11"
+  val logbackVersion = "1.2.12"
 
   val jacksonCoreVersion = "2.14.3"
   val jacksonDatabindVersion = jacksonCoreVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -166,7 +166,7 @@ object Dependencies {
       val log4j = "log4j" % "log4j" % "1.2.17" % Test
 
       // in-memory filesystem for file related tests
-      val jimfs = "com.google.jimfs" % "jimfs" % "1.1" % Test
+      val jimfs = "com.google.jimfs" % "jimfs" % "1.3.0" % Test
 
       // docker utils
       val dockerClient = "com.spotify" % "docker-client" % "8.16.0" % Test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -73,7 +73,7 @@ object Dependencies {
 
     val sigar = "org.fusesource" % "sigar" % "1.6.4"
 
-    val jctools = "org.jctools" % "jctools-core" % "3.3.0"
+    val jctools = "org.jctools" % "jctools-core" % "4.0.1"
 
     // reactive streams
     val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -182,8 +182,8 @@ object Dependencies {
       }
 
       // metrics, measurements, perf testing
-      val metrics = "io.dropwizard.metrics" % "metrics-core" % "4.2.10" % Test
-      val metricsJvm = "io.dropwizard.metrics" % "metrics-jvm" % "4.2.10" % Test
+      val metrics = "io.dropwizard.metrics" % "metrics-core" % "4.2.21" % Test
+      val metricsJvm = "io.dropwizard.metrics" % "metrics-jvm" % "4.2.21" % Test
       val latencyUtils = "org.latencyutils" % "LatencyUtils" % "2.0.3" % Test
       val hdrHistogram = "org.hdrhistogram" % "HdrHistogram" % "2.1.12" % Test
       val metricsAll = Seq(metrics, metricsJvm, latencyUtils, hdrHistogram)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -91,7 +91,6 @@ object Dependencies {
     val junit = "junit" % "junit" % junitVersion
     val junit5 = "org.junit.jupiter" % "junit-jupiter-engine" % junit5Version
 
-
     // For Java 8 Conversions
     val java8Compat = Def.setting {
       "org.scala-lang.modules" %% "scala-java8-compat" % java8CompatVersion.value
@@ -146,7 +145,6 @@ object Dependencies {
       val httpClient = "org.apache.httpcomponents" % "httpclient" % "4.5.14" % Test
       val junit = "junit" % "junit" % junitVersion % Test
       val junit5 = "org.junit.jupiter" % "junit-jupiter-engine" % junit5Version % Test
-
 
       val logback = Compile.logback % Test
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -132,7 +132,7 @@ object Dependencies {
     }
 
     object TestDependencies {
-      val bcpkix = "org.bouncycastle" % "bcpkix-jdk15on" % "1.70" % Test
+      val bcpkix = "org.bouncycastle" % "bcpkix-jdk18on" % "1.76" % Test
       val commonsMath = "org.apache.commons" % "commons-math" % "2.2" % Test
       val commonsIo = "commons-io" % "commons-io" % "2.14.0" % Test
       val commonsCodec = "commons-codec" % "commons-codec" % "1.16.0" % Test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -133,7 +133,7 @@ object Dependencies {
     }
 
     object TestDependencies {
-      val bcpkix = "org.bouncycastle" % "bcpkix-jdk15on" % "1.68" % Test
+      val bcpkix = "org.bouncycastle" % "bcpkix-jdk15on" % "1.70" % Test
       val commonsMath = "org.apache.commons" % "commons-math" % "2.2" % Test
       val commonsIo = "commons-io" % "commons-io" % "2.11.0" % Test
       val commonsCodec = "commons-codec" % "commons-codec" % "1.15" % Test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,10 +46,9 @@ object Dependencies {
 
   val sslConfigVersion = "0.6.1"
 
-  val scalaTestVersion = "3.2.14"
-  val scalaTestBaseVersion = "3.2.10"
-  val scalaTestScalaCheckVersion = "1-16"
-  val scalaCheckVersion = "1.15.1"
+  val scalaTestVersion = "3.2.17"
+  val scalaTestScalaCheckVersion = "1-17"
+  val scalaCheckVersion = "1.17.0"
 
   val Versions =
     Seq(crossScalaVersions := allScalaVersions, scalaVersion := allScalaVersions.head,
@@ -152,13 +151,13 @@ object Dependencies {
         "org.scalatestplus" %% "junit-4-13" % (scalaTestVersion + ".0") % Test
       }
       val scalatestTestNG = Def.setting {
-        "org.scalatestplus" %% "testng-6-7" % (scalaTestBaseVersion + ".0") % Test
+        "org.scalatestplus" %% "testng-7-5" % (scalaTestVersion + ".0") % Test
       }
       val scalatestScalaCheck = Def.setting {
         "org.scalatestplus" %% s"scalacheck-$scalaTestScalaCheckVersion" % (scalaTestVersion + ".0") % Test
       }
       val scalatestMockito = Def.setting {
-        "org.scalatestplus" %% "mockito-3-4" % (scalaTestBaseVersion + ".0") % Test
+        "org.scalatestplus" %% "mockito-4-11" % (scalaTestVersion + ".0") % Test
       }
 
       val pojosr = "com.googlecode.pojosr" % "de.kalpatec.pojosr.framework" % "0.2.1" % Test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -136,7 +136,7 @@ object Dependencies {
       val bcpkix = "org.bouncycastle" % "bcpkix-jdk15on" % "1.70" % Test
       val commonsMath = "org.apache.commons" % "commons-math" % "2.2" % Test
       val commonsIo = "commons-io" % "commons-io" % "2.14.0" % Test
-      val commonsCodec = "commons-codec" % "commons-codec" % "1.15" % Test
+      val commonsCodec = "commons-codec" % "commons-codec" % "1.16.0" % Test
       val commonsCompress = "org.apache.commons" % "commons-compress" % "1.24.0" % Test
       val junit = "junit" % "junit" % junitVersion % Test
       val httpClient = "org.apache.httpcomponents" % "httpclient" % "4.5.14" % Test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -129,7 +129,7 @@ object Dependencies {
 
     object Docs {
       val sprayJson = "io.spray" %% "spray-json" % "1.3.6" % Test
-      val gson = "com.google.code.gson" % "gson" % "2.9.1" % Test
+      val gson = "com.google.code.gson" % "gson" % "2.10.1" % Test
     }
 
     object TestDependencies {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -91,6 +91,7 @@ object Dependencies {
     val junit = "junit" % "junit" % junitVersion
     val junit5 = "org.junit.jupiter" % "junit-jupiter-engine" % junit5Version
 
+
     // For Java 8 Conversions
     val java8Compat = Def.setting {
       "org.scala-lang.modules" %% "scala-java8-compat" % java8CompatVersion.value
@@ -142,9 +143,8 @@ object Dependencies {
       val commonsIo = "commons-io" % "commons-io" % "2.14.0" % Test
       val commonsCodec = "commons-codec" % "commons-codec" % "1.16.0" % Test
       val commonsCompress = "org.apache.commons" % "commons-compress" % "1.24.0" % Test
-      val junit = "junit" % "junit" % junitVersion % Test
       val httpClient = "org.apache.httpcomponents" % "httpclient" % "4.5.14" % Test
-      val junit = "junit" % "junit" % junitVersion % "test"
+      val junit = "junit" % "junit" % junitVersion % Test
       val junit5 = "org.junit.jupiter" % "junit-jupiter-engine" % junit5Version % Test
 
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -83,7 +83,7 @@ object Dependencies {
       "com.typesafe" %% "ssl-config-core" % sslConfigVersion
     }
 
-    val lmdb = "org.lmdbjava" % "lmdbjava" % "0.7.0"
+    val lmdb = "org.lmdbjava" % "lmdbjava" % "0.8.3"
 
     val junit = "junit" % "junit" % junitVersion
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -203,7 +203,7 @@ object Dependencies {
 
     object Provided {
       // TODO remove from "test" config
-      val sigarLoader = "io.kamon" % "sigar-loader" % "1.6.6-rev002" % "optional;provided;test"
+      val sigarLoader = "io.kamon" % "sigar-loader" % "1.6.6" % "optional;provided;test"
 
       val activation = "com.sun.activation" % "javax.activation" % "1.2.0" % "provided;test"
 

--- a/project/PekkoBuild.scala
+++ b/project/PekkoBuild.scala
@@ -284,24 +284,25 @@ object PekkoBuild {
       },
       logoColor := scala.Console.BLUE,
       usefulTasks := Seq(
-        UsefulTask("", "compile", "Compile the current project"),
-        UsefulTask("", "test", "Run all the tests"),
-        UsefulTask("", "testQuick",
+        UsefulTask("compile", "Compile the current project"),
+        UsefulTask("test", "Run all the tests"),
+        UsefulTask("testQuick",
           "Runs all the tests. When run multiple times will only run previously failing tests (shell mode only)"),
-        UsefulTask("", "testOnly *.AnySpec", "Only run a selected test"),
-        UsefulTask("", "testQuick *.AnySpec",
+        UsefulTask("testOnly *.AnySpec", "Only run a selected test"),
+        UsefulTask("testQuick *.AnySpec",
           "Only run a selected test. When run multiple times will only run previously failing tests (shell mode only)"),
-        UsefulTask("", "testQuickUntilPassed", "Runs all tests in a continuous loop until all tests pass"),
-        UsefulTask("", "publishLocal", "Publish current snapshot version to local ~/.ivy2 repo"),
-        UsefulTask("", "verifyCodeStyle", "Verify code style"),
-        UsefulTask("", "applyCodeStyle", "Apply code style"),
-        UsefulTask("", "sortImports", "Sort the imports"),
-        UsefulTask("", "mimaReportBinaryIssues ", "Check binary issues"),
-        UsefulTask("", "validatePullRequest ", "Validate pull request"),
-        UsefulTask("", "docs/paradox", "Build documentation"),
-        UsefulTask("", "docs/paradoxBrowse", "Browse the generated documentation"),
-        UsefulTask("", "tips:", "prefix commands with `+` to run against cross Scala versions."),
-        UsefulTask("", "Contributing guide:", "https://github.com/apache/incubator-pekko/blob/main/CONTRIBUTING.md")))
+        UsefulTask("testQuickUntilPassed", "Runs all tests in a continuous loop until all tests pass"),
+        UsefulTask("publishLocal", "Publish current snapshot version to local ~/.ivy2 repo"),
+        UsefulTask("verifyCodeStyle", "Verify code style"),
+        UsefulTask("applyCodeStyle", "Apply code style"),
+        UsefulTask("sortImports", "Sort the imports"),
+        UsefulTask("mimaReportBinaryIssues ", "Check binary issues"),
+        UsefulTask("validatePullRequest ", "Validate pull request"),
+        UsefulTask("docs/paradox", "Build documentation"),
+        UsefulTask("docs/paradoxBrowse", "Browse the generated documentation"),
+        UsefulTask("tips:", "prefix commands with `+` to run against cross Scala versions."),
+        UsefulTask("Contributing guide:", "https://github.com/apache/incubator-pekko/blob/main/CONTRIBUTING.md")).map(
+        _.noAlias))
   }
 
   private def optionalDir(path: String): Option[File] =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -29,7 +29,7 @@ addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.31")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.10")
 addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.10")
-addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.2.2")
+addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.3.2")
 addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.6.1")
 
 // We have to deliberately use older versions of sbt-paradox because current Pekko sbt build

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -26,7 +26,7 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
 addSbtPlugin("com.hpe.sbt" % "sbt-pull-request-validator" % "1.0.0")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.31")
 
-addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
+addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.10")
 addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.10")
 addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.2.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -30,7 +30,7 @@ addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.10")
 addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.10")
 addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.2.2")
-addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.5.0")
+addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.6.1")
 
 // We have to deliberately use older versions of sbt-paradox because current Pekko sbt build
 // only loads on JDK 1.8 so we need to bring in older versions of parboiled which support JDK 1.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,7 +19,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.4")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.3")
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.6")
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.3")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.7.0")
 addSbtPlugin("com.lightbend.sbt" % "sbt-bill-of-materials" % "1.0.2")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.33")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.1")
 // sbt-osgi 0.9.5 is available but breaks including jdk9-only classes
 // sbt-osgi 0.9.6 is available but breaks populating pekko-protobuf-v3
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.4")


### PR DESCRIPTION

I added a Junit5 Extension to support Junit5 framework integration.

The extension is activated through an annotation:
@ExtendWith(TestKitJunit5Extension.class)
on the class level.

Additionally, a testKit with a @Junit5TestKit annotation needs to be created.
A builder pattern is used to construct the Testkit instance.

@Junit5TestKit
public ActorTestKit testKit = new Junit5TestKitBuilder().build();

The extension itself uses the Junit5 AfterAllCallback to shutdown the testkit after all tests are executed.


I closed the the last PR due to some rebase issues, this PR is directly based on main. Additionally, i discarded the changes in the docs. Sorry for the inconvenience.