### PR TITLE
add license information for Caffeine code used in FrequencySketch

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -311,6 +311,12 @@ For more information, please refer to <http://unlicense.org/>
 
 ---------------
 
+pekko-actor contains code in `org.apache.pekko.util.FrequencySketch.scala` which was based on code from
+Caffeine <https://github.com/ben-manes/caffeine> which was developed under an under the Apache 2.0 license.
+Copyright 2015 Ben Manes. All Rights Reserved.
+
+---------------
+
 pekko-cluster contains VectorClock.scala which is derived from code written
 by Coda Hale <https://github.com/codahale/vlock>.
 He has agreed to allow us to use this code under an Apache 2.0 license

--- a/LICENSE
+++ b/LICENSE
@@ -312,7 +312,7 @@ For more information, please refer to <http://unlicense.org/>
 ---------------
 
 pekko-actor contains code in `org.apache.pekko.util.FrequencySketch.scala` which was based on code from
-Caffeine <https://github.com/ben-manes/caffeine> which was developed under an under the Apache 2.0 license.
+Caffeine <https://github.com/ben-manes/caffeine> which was developed under the Apache 2.0 license.
 Copyright 2015 Ben Manes. All Rights Reserved.
 
 ---------------

--- a/actor/src/main/scala/org/apache/pekko/util/FrequencySketch.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/FrequencySketch.scala
@@ -11,6 +11,22 @@
  * Copyright (C) 2021-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
+/*
+ * Copyright 2015 Ben Manes. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.pekko.util
 
 import org.apache.pekko.annotation.InternalApi
@@ -253,7 +269,7 @@ private[pekko] object FastFrequencySketch {
  * so that constants can be used for improved efficiency. It also uses its own rehashing of item hash codes.
  *
  * The implementation is inspired by the approach used in the Caffeine caching library:
- * https://github.com/ben-manes/caffeine
+ * https://github.com/ben-manes/caffeine/blob/a6be555f0f2a44d33a9d7e52ea923622e373ac7f/caffeine/src/main/java/com/github/benmanes/caffeine/cache/FrequencySketch.java
  *
  * @param width width of the count-min sketch (number of counters)
  * @param resetSize the size (number of counter increments) to apply the reset operation

--- a/legal/pekko-actor-jar-license.txt
+++ b/legal/pekko-actor-jar-license.txt
@@ -308,3 +308,9 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 For more information, please refer to <http://unlicense.org/>
+
+---------------
+
+pekko-actor contains code in `org.apache.pekko.util.FrequencySketch.scala` which was based on code from
+Caffeine <https://github.com/ben-manes/caffeine> which was developed under an under the Apache 2.0 license.
+Copyright 2015 Ben Manes. All Rights Reserved.

--- a/legal/pekko-actor-jar-license.txt
+++ b/legal/pekko-actor-jar-license.txt
@@ -312,5 +312,5 @@ For more information, please refer to <http://unlicense.org/>
 ---------------
 
 pekko-actor contains code in `org.apache.pekko.util.FrequencySketch.scala` which was based on code from
-Caffeine <https://github.com/ben-manes/caffeine> which was developed under an under the Apache 2.0 license.
+Caffeine <https://github.com/ben-manes/caffeine> which was developed under the Apache 2.0 license.
 Copyright 2015 Ben Manes. All Rights Reserved.


### PR DESCRIPTION
Relates to #439 

There is no NOTICE file in https://github.com/ben-manes/caffeine/.

Nor in https://github.com/ben-manes/caffeine/tree/a6be555f0f2a44d33a9d7e52ea923622e373ac7f