### PR TITLE
+workflow Add JDK 20 to java nightly build matrix.

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -143,7 +143,7 @@ jobs:
         # binary version is required and Akka build will set the right
         # full version from it.
         scalaVersion: ["2.12", "2.13"]
-        javaVersion: [8, 11, 17]
+        javaVersion: [8, 11, 17, 20]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Add JDK 20, which is the latest java release

refs: https://github.com/apache/incubator-pekko/issues/430