### PR TITLE
setup CI job to publish 1.0 docs

### DIFF
--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -58,10 +58,10 @@ jobs:
       # Create directory structure upfront since rsync does not create intermediate directories otherwise
       - name: Create nightly directory structure
         run: |-
-          mkdir -p target/nightly-docs/docs/pekko/1.0/
-          mv docs/target/paradox/site/main/ target/nightly-docs/docs/pekko/1.0/docs
-          mv target/scala-2.13/unidoc target/nightly-docs/docs/pekko/1.0/api
-          mv target/javaunidoc target/nightly-docs/docs/pekko/1.0/japi
+          mkdir -p target/nightly-docs/docs/pekko/1.0.0/
+          mv docs/target/paradox/site/main/ target/nightly-docs/docs/pekko/1.0.0/docs
+          mv target/scala-2.13/unidoc target/nightly-docs/docs/pekko/1.0.0/api
+          mv target/javaunidoc target/nightly-docs/docs/pekko/1.0.0/japi
 
       - name: Upload nightly docs
         uses: ./.github/actions/sync-nightlies

--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Based on Apache Arrow's java-nightly workflow
+# https://github.com/apache/arrow/blob/master/.github/workflows/java_nightly.yml
+name: Publish 1.0 documentation
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish-nightly:
+    name: Publish 1.0 docs
+    runs-on: ubuntu-20.04
+    if: github.repository == 'apache/incubator-pekko'
+    steps:
+      # TODO we will need to change to a 1.0 branch or a release tag
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v6
+
+      - name: Install Graphviz
+        run: |-
+          sudo apt-get install graphviz
+
+      # TODO come up with a better way to control the version, possibly based on git tags
+      - name: Build Documentation
+        run: |-
+          sbt -Dpekko.genjavadoc.enabled=true "set ThisBuild / version := \"1.0.0\"; docs/paradox; unidoc"
+
+      # Create directory structure upfront since rsync does not create intermediate directories otherwise
+      - name: Create nightly directory structure
+        run: |-
+          mkdir -p target/nightly-docs/docs/pekko/1.0/
+          mv docs/target/paradox/site/main/ target/nightly-docs/docs/pekko/1.0/docs
+          mv target/scala-2.13/unidoc target/nightly-docs/docs/pekko/1.0/api
+          mv target/javaunidoc target/nightly-docs/docs/pekko/1.0/japi
+
+      - name: Upload nightly docs
+        uses: ./.github/actions/sync-nightlies
+        with:
+          upload: true
+          switches: --archive --compress --update --delete --progress --relative
+          local_path: target/nightly-docs/./docs/pekko/ # The intermediate dot is to show `--relative` which paths to operate on
+          remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/pekko/
+          remote_host: ${{ secrets.NIGHTLIES_RSYNC_HOST }}
+          remote_port: ${{ secrets.NIGHTLIES_RSYNC_PORT }}
+          remote_user: ${{ secrets.NIGHTLIES_RSYNC_USER }}
+          remote_key: ${{ secrets.NIGHTLIES_RSYNC_KEY }}


### PR DESCRIPTION
* publishes docs for Pekko 1.0
* matches https://doc.akka.io/docs/akka/2.6/typed/index.html
  * the version number appears in HTML pages is the full x.y.z version (Akka 2.6.21; Pekko 1.0.0)
  * the version number in URL path is just x.y (Akka 2.6; Pekko 1.0)
* we need a GitHub CI job because the rsync needs secrets and I don't know them
* we can run the job off a branch after we complete the 1.0.0 release 
* we don't need to run the job every night after we are happy the docs are stable