### PR TITLE
modify rsync jobs for docs to try to stop them deleting each other's work

### DIFF
--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           upload: true
           switches: --archive --compress --update --delete --progress --relative
-          local_path: target/nightly-docs/./docs/pekko/ # The intermediate dot is to show `--relative` which paths to operate on
+          local_path: target/nightly-docs/./docs/pekko/1.0.0 # The intermediate dot is to show `--relative` which paths to operate on
           remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/pekko/
           remote_host: ${{ secrets.NIGHTLIES_RSYNC_HOST }}
           remote_port: ${{ secrets.NIGHTLIES_RSYNC_PORT }}

--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -69,7 +69,7 @@ jobs:
           upload: true
           switches: --archive --compress --update --delete --progress --relative
           local_path: target/nightly-docs/./docs/pekko/1.0.0 # The intermediate dot is to show `--relative` which paths to operate on
-          remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/pekko/
+          remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/pekko/1.0.0
           remote_host: ${{ secrets.NIGHTLIES_RSYNC_HOST }}
           remote_port: ${{ secrets.NIGHTLIES_RSYNC_PORT }}
           remote_user: ${{ secrets.NIGHTLIES_RSYNC_USER }}

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -80,7 +80,7 @@ jobs:
           upload: true
           switches: --archive --compress --update --delete --progress --relative
           local_path: target/nightly-docs/./docs/pekko/${{ github.ref_name }}-snapshot # The intermediate dot is to show `--relative` which paths to operate on
-          remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/pekko/
+          remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/pekko/${{ github.ref_name }}-snapshot
           remote_host: ${{ secrets.NIGHTLIES_RSYNC_HOST }}
           remote_port: ${{ secrets.NIGHTLIES_RSYNC_PORT }}
           remote_user: ${{ secrets.NIGHTLIES_RSYNC_USER }}

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           upload: true
           switches: --archive --compress --update --delete --progress --relative
-          local_path: target/nightly-docs/./docs/pekko/ # The intermediate dot is to show `--relative` which paths to operate on
+          local_path: target/nightly-docs/./docs/pekko/${{ github.ref_name }}-snapshot # The intermediate dot is to show `--relative` which paths to operate on
           remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/pekko/
           remote_host: ${{ secrets.NIGHTLIES_RSYNC_HOST }}
           remote_port: ${{ secrets.NIGHTLIES_RSYNC_PORT }}


### PR DESCRIPTION
the new publish-1.0-docs CI job deleted the 'main-snapshot' dir on the nightlies site
* note the `--delete` in the rsync command
* this delete is generally useful because we might remove doc files or rename them and we don't want to leave the old copy behind

I think this change will stop the 2 jobs interfering with each other
* the nightly job that publishes main-snapshot docs
* the on demand job that publishes 1.0.0 docs 