### PR TITLE
Also publish API version of docs

### DIFF
--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -56,19 +56,38 @@ jobs:
           sbt -Dpekko.genjavadoc.enabled=true "set ThisBuild / version := \"1.0.0\"; docs/paradox; unidoc"
 
       # Create directory structure upfront since rsync does not create intermediate directories otherwise
-      - name: Create nightly directory structure
+      - name: Create directory structure
         run: |-
           mkdir -p target/nightly-docs/docs/pekko/1.0.0/
-          mv docs/target/paradox/site/main/ target/nightly-docs/docs/pekko/1.0.0/docs
-          mv target/scala-2.13/unidoc target/nightly-docs/docs/pekko/1.0.0/api
-          mv target/javaunidoc target/nightly-docs/docs/pekko/1.0.0/japi
+          mkdir -p target/nightly-docs/docs/pekko/1.0/
+          cp docs/target/paradox/site/main/ target/nightly-docs/docs/pekko/1.0.0/docs
+          cp docs/target/paradox/site/main/ target/nightly-docs/docs/pekko/1.0/docs
+          rm -r docs/target/paradox/site/main/
+          cp target/scala-2.13/unidoc target/nightly-docs/docs/pekko/1.0.0/api
+          cp target/scala-2.13/unidoc target/nightly-docs/docs/pekko/1.0/api
+          rm -r target/scala-2.13/unidoc
+          cp target/javaunidoc target/nightly-docs/docs/pekko/1.0.0/japi
+          cp target/javaunidoc target/nightly-docs/docs/pekko/1.0/japi
+          rm -r target/javaunidoc
 
-      - name: Upload nightly docs
+      - name: Upload nightly docs patch version
         uses: ./.github/actions/sync-nightlies
         with:
           upload: true
           switches: --archive --compress --update --delete --progress --relative
           local_path: target/nightly-docs/./docs/pekko/1.0.0 # The intermediate dot is to show `--relative` which paths to operate on
+          remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/pekko
+          remote_host: ${{ secrets.NIGHTLIES_RSYNC_HOST }}
+          remote_port: ${{ secrets.NIGHTLIES_RSYNC_PORT }}
+          remote_user: ${{ secrets.NIGHTLIES_RSYNC_USER }}
+          remote_key: ${{ secrets.NIGHTLIES_RSYNC_KEY }}
+
+      - name: Upload nightly docs api version
+        uses: ./.github/actions/sync-nightlies
+        with:
+          upload: true
+          switches: --archive --compress --update --delete --progress --relative
+          local_path: target/nightly-docs/./docs/pekko/1.0 # The intermediate dot is to show `--relative` which paths to operate on
           remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/pekko
           remote_host: ${{ secrets.NIGHTLIES_RSYNC_HOST }}
           remote_port: ${{ secrets.NIGHTLIES_RSYNC_PORT }}


### PR DESCRIPTION
Not the most ideal solution, but it will work for now and we can look into fixing this later. This will publish docs into both `1.0.0` and `1.0` since other Pekko modules usually don't care about linking to patch versions (i.e. pekko-http).

Update to `.htaccess` is here https://github.com/apache/incubator-pekko-site/pull/12