### PR TITLE
disable -Werror when using Java 20

### DIFF
--- a/project/PekkoDisciplinePlugin.scala
+++ b/project/PekkoDisciplinePlugin.scala
@@ -91,6 +91,11 @@ object PekkoDisciplinePlugin extends AutoPlugin {
     ),
     Compile / doc / scalacOptions := Seq())
 
+  // ignore Scala compile warnings for Java 20+
+  lazy val jvmIgnoreWarnings = {
+    System.getProperty("java.version").startsWith("2")
+  }
+
   /**
    * We are a little less strict in docs
    */
@@ -115,11 +120,10 @@ object PekkoDisciplinePlugin extends AutoPlugin {
         Compile / scalacOptions ++= Seq("-Xfatal-warnings"),
         Test / scalacOptions --= testUndiscipline,
         Compile / javacOptions ++= (
-          if (scalaVersion.value.startsWith("3.")) {
-            Seq()
+          if (jvmIgnoreWarnings || scalaVersion.value.startsWith("3.") || nonFatalJavaWarningsFor(name.value)) {
+            Seq.empty
           } else {
-            if (!nonFatalJavaWarningsFor(name.value)) Seq("-Werror", "-Xlint:deprecation", "-Xlint:unchecked")
-            else Seq.empty
+            Seq("-Werror", "-Xlint:deprecation", "-Xlint:unchecked")
           }
         ),
         Compile / doc / javacOptions := Seq("-Xdoclint:none"),


### PR DESCRIPTION
* relates to https://github.com/apache/incubator-pekko/issues/430
* Java 19 is not LTS and Java 20 is latest non-LTS release
* the compiler warnings leading to build failing (-Werror does this) is the main problem with using a new JDK to build Pekko