### PR TITLE
Enable wiki

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -22,7 +22,7 @@ github:
 
   features:
     # Enable wiki for documentation
-    wiki: false
+    wiki: true
     # Enable issue management
     issues: true
     # Enable projects for project management boards


### PR DESCRIPTION
Enables wiki (needed to add testing notes specific to Pekko core).