### PR TITLE
Add testQuickUntilPassed

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ See https://pekko.apache.org for the documentation including the API docs. The d
     - `sbt +compile` will compile for all supported versions of Scala
 - `sbt test` will compile the code and run the unit tests
 - `sbt testQuick` similar to test but when repeated in shell mode will only run failing tests
+- `sbt testQuickUntilPassed` similar to testQuick but will loop until tests pass.
 - `sbt package` will build the jars
     - the jars will built into target dirs of the various modules
     - for the the 'actor' module, the jar will be built to `actor/target/scala-2.13/`

--- a/project/PekkoBuild.scala
+++ b/project/PekkoBuild.scala
@@ -292,6 +292,7 @@ object PekkoBuild {
         UsefulTask("", "testOnly *.AnySpec", "Only run a selected test"),
         UsefulTask("", "testQuick *.AnySpec",
           "Only run a selected test. When run multiple times will only run previously failing tests (shell mode only)"),
+        UsefulTask("", "testQuickUntilPassed", "Runs all tests in a continuous loop until all tests pass"),
         UsefulTask("", "publishLocal", "Publish current snapshot version to local ~/.ivy2 repo"),
         UsefulTask("", "verifyCodeStyle", "Verify code style"),
         UsefulTask("", "applyCodeStyle", "Apply code style"),

--- a/project/TestQuickUntilPassed.scala
+++ b/project/TestQuickUntilPassed.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import sbt._
+import sbt.Keys._
+import sbt.plugins.JvmPlugin
+
+object TestQuickUntilPassed extends AutoPlugin {
+  override def requires = JvmPlugin
+
+  override def trigger = allRequirements
+
+  object autoImport {
+    val testQuickUntilPassed = inputKey[Unit]("runs testQuick continuously until it passes")
+  }
+
+  import autoImport._
+
+  private def testQuickRecursive(input: String): Def.Initialize[Task[Unit]] = Def.taskDyn {
+    (Test / testQuick).toTask(input).result.value match {
+      case Inc(cause) =>
+        testQuickRecursive(input)
+      case Value(value) =>
+        Def.task(())
+    }
+  }
+
+  override lazy val projectSettings = {
+    testQuickUntilPassed := {
+      // TODO Figure out a way to pass input from testQuickUntilPassed into testQuickRecursive
+      testQuickRecursive("").value
+    }
+  }
+
+}


### PR DESCRIPTION
Adds a variant of `testQuick` called `testQuickUntilPassed` which runs `testQuick` in a loop until all tests pass. This is intended to be used by the release process to account for some tests being flaky