### PR TITLE
Set default timefactor for ActorsLeakSpec so it can pass locally

### DIFF
--- a/remote/src/test/scala/org/apache/pekko/remote/classic/ActorsLeakSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/classic/ActorsLeakSpec.scala
@@ -41,6 +41,7 @@ object ActorsLeakSpec {
        pekko.remote.classic.quarantine-after-silence = 3 s
        pekko.remote.use-unsafe-remote-features-outside-cluster = on
        pekko.test.filter-leeway = 12 s
+       pekko.test.timefactor = 2
        # test is using Java serialization and not priority to rewrite
        pekko.actor.allow-java-serialization = on
        pekko.actor.warn-about-java-serializer-usage = off


### PR DESCRIPTION
After doing some extensive testing (talking about 30+ test runs) it turns out that `ActorsLeakSpec` cannot pass locally unless you set `pekko.test.timefactor = 2` which is what is set in CI (see https://github.com/apache/incubator-pekko/blob/88bf6329f193eedd45091f4f9a515943bd8ecb23/.github/workflows/nightly-builds.yml#L168-L175).
