### PR TITLE
Properly cleanup state after SharedLeveldbJournalSpec exits

### DIFF
--- a/persistence/src/test/scala/org/apache/pekko/persistence/PersistenceSpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/PersistenceSpec.scala
@@ -89,7 +89,8 @@ object PersistenceSpec {
 
 trait Cleanup { this: PekkoSpec =>
   val storageLocations =
-    List("pekko.persistence.snapshot-store.local.dir").map(s => new File(system.settings.config.getString(s)))
+    List("pekko.persistence.snapshot-store.local.dir",
+      "pekko.persistence.journal.leveldb-shared.store.dir").map(s => new File(system.settings.config.getString(s)))
 
   override protected def atStartup(): Unit = {
     storageLocations.foreach(FileUtils.deleteDirectory)


### PR DESCRIPTION
The `persistence-shared/src/test/scala/org/apache/pekko/persistence/journal/leveldb/SharedLeveldbJournalSpec.scala` test currently fails if its run more then once because state that is stored in a local temp folder is not cleaned up after the test completes.

You can replicate this locally by doing the following

* run `persistence-shared/test` locally once, it should pass
* run `persistence-shared/test` second time, it should fail and continue to fail

If you apply this change then the tests continue to pass.