### PR TITLE
Make unidoc generate external javadoc links

### DIFF
--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -156,7 +156,25 @@ object UnidocRoot extends AutoPlugin {
       Seq(
         ScalaUnidoc / unidocProjectFilter := unidocRootProjectFilter(unidocRootIgnoreProjects.value),
         JavaUnidoc / unidocProjectFilter := unidocRootProjectFilter(unidocRootIgnoreProjects.value),
-        ScalaUnidoc / apiMappings := (Compile / doc / apiMappings).value) ++
+        ScalaUnidoc / apiMappings := (Compile / doc / apiMappings).value,
+        ScalaUnidoc / apiMappings ++= {
+          val entries: Seq[Attributed[File]] = (LocalProject("slf4j") / Compile / fullClasspath).value
+
+          def mappingsFor(organization: String, names: List[String], location: String,
+              revision: String => String = identity): Seq[(File, URL)] = {
+            for {
+              entry: Attributed[File] <- entries
+              module: ModuleID <- entry.get(moduleID.key)
+              if module.organization == organization
+              if names.exists(module.name.startsWith)
+            } yield entry.data -> url(location.format(module.revision))
+          }
+
+          val mappings: Seq[(File, URL)] =
+            mappingsFor("org.slf4j", List("slf4j-api"), "https://www.javadoc.io/doc/org.slf4j/slf4j-api/%s/")
+
+          mappings.toMap
+        }) ++
       UnidocRoot.CliOptions.genjavadocEnabled
         .ifTrue(Seq(JavaUnidoc / unidocAllSources ~= { v =>
           v.map(


### PR DESCRIPTION
Refs #353 

I added a mapping from a claspath to an external javadoc url to solve warning logs which scaladoc's references to slf4j library causes.