### PR TITLE
enable mima check

### DIFF
--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -30,11 +30,11 @@ jobs:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0

--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -42,29 +42,13 @@ jobs:
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts
 
-      # compile code instead of doing mima check (until we re-enable mima check)
       - name: Compile code
         run: sbt "+~ ${{ matrix.scalaVersion }} Test/compile"
 
-      # disable mima check until first pekko release is done
-      #- name: Report MiMa Binary Issues
-      #  run: sbt "+~ ${{ matrix.scalaVersion }} mimaReportBinaryIssues"
+      - name: Report MiMa Binary Issues
+        run: |-
+          sbt "+~ ${{ matrix.scalaVersion }} mimaReportBinaryIssues"
 
-      #- name: Check correct MiMa filter directories
-      #  run: sbt checkMimaFilterDirectories
-
-      # comment out email actions until we have an email address to use (and we need to get INFRA to whitelist dawidd6/action-send-mail)
-      #- name: Email on failure
-      #  if: ${{ failure() }}
-      #  uses: dawidd6/action-send-mail@v3
-      #  with:
-      #    server_address: smtp.gmail.com
-      #    server_port: 465
-      #    username: ${{secrets.MAIL_USERNAME}}
-      #    password: ${{secrets.MAIL_PASSWORD}}
-      #    subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-      #    to: akka.official@gmail.com
-      #    from: Akka CI (GHActions)
-      #    body: |
-      #      Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-      #      https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      - name: Check correct MiMa filter directories
+        run: |
+          sbt checkMimaFilterDirectories

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -51,10 +51,9 @@ jobs:
         run: |-
           sudo apt-get install graphviz
 
-#      disable mima check until first pekko release is done
-#      - name: Report MIMA incompatibility issues
-#        run: |-
-#          sbt +mimaReportBinaryIssues
+      - name: Report MIMA incompatibility issues
+        run: |-
+          sbt +mimaReportBinaryIssues
 
       - name: Publish to Apache Maven repo
         env:

--- a/actor-typed/src/main/mima-filters/1.0.x.backwards.excludes/jfr.excludes
+++ b/actor-typed/src/main/mima-filters/1.0.x.backwards.excludes/jfr.excludes
@@ -1,0 +1,2 @@
+# JDK9+ classes for JFR
+ProblemFilters.exclude[Problem]("org.apache.pekko.actor.typed.internal.jfr.*")

--- a/cluster-sharding/src/main/mima-filters/1.0.x.backwards.excludes/jdk-11-specific-classes.excludes
+++ b/cluster-sharding/src/main/mima-filters/1.0.x.backwards.excludes/jdk-11-specific-classes.excludes
@@ -1,0 +1,5 @@
+# Java9+ API's will have to be always filtered until we have these classes in our normal build flow
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.stream.javadsl.JavaFlowSupport*")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.stream.scaladsl.JavaFlowSupport*")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.stream.impl.JavaFlow*")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.stream.impl.Rs*")

--- a/cluster-sharding/src/main/mima-filters/1.0.x.backwards.excludes/jdk-11-specific-classes.excludes
+++ b/cluster-sharding/src/main/mima-filters/1.0.x.backwards.excludes/jdk-11-specific-classes.excludes
@@ -1,5 +1,7 @@
-# Java9+ API's will have to be always filtered until we have these classes in our normal build flow
-ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.stream.javadsl.JavaFlowSupport*")
-ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.stream.scaladsl.JavaFlowSupport*")
-ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.stream.impl.JavaFlow*")
-ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.stream.impl.Rs*")
+# Java 11 only flight recorder classes
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.cluster.sharding.internal.jfr.Passivate")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.cluster.sharding.internal.jfr.RememberEntityWrite")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.cluster.sharding.internal.jfr.JFRShardingFlightRecorder")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.cluster.sharding.internal.jfr.RememberEntityAdd")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.cluster.sharding.internal.jfr.RememberEntityRemove")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.cluster.sharding.internal.jfr.PassivateRestart")

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -21,8 +21,7 @@ import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport._
 
 object MiMa extends AutoPlugin {
 
-  private val latestPatchOf25 = 32
-  private val latestPatchOf26 = 20
+  private val latestPatchOf10 = 0
 
   override def requires = MimaPlugin
   override def trigger = allRequirements
@@ -37,10 +36,10 @@ object MiMa extends AutoPlugin {
 
   def checkFilterDirectories(moduleRoot: File): Unit = {
     val nextVersionFilterDir =
-      moduleRoot / "src" / "main" / "mima-filters" / s"2.6.${latestPatchOf26 + 1}.backwards.excludes"
+      moduleRoot / "src" / "main" / "mima-filters" / s"1.0.${latestPatchOf10 + 1}.backwards.excludes"
     if (nextVersionFilterDir.exists()) {
       throw new IllegalArgumentException(s"Incorrect mima filter directory exists: '$nextVersionFilterDir' " +
-        s"should be with number from current release '${moduleRoot / "src" / "main" / "mima-filters" / s"2.6.$latestPatchOf26.backwards.excludes"}")
+        s"should be with number from current release '${moduleRoot / "src" / "main" / "mima-filters" / s"1.0.$latestPatchOf10.backwards.excludes"}")
     }
   }
 
@@ -53,39 +52,16 @@ object MiMa extends AutoPlugin {
       Set.empty
     } else {
       val versions: Seq[String] = {
-        val firstPatchOf25 =
-          if (scalaBinaryVersion.startsWith("2.13")) 25
-          else if (projectName.contains("discovery")) 19
-          else if (projectName.contains("coordination")) 22
-          else 0
+        val firstPatchOf10 = 0
 
-        val akka25Previous =
-          if (!(projectName.contains("typed") || projectName.contains("jackson"))) {
-            // 2.5.18 is the only release built with Scala 2.12.7, which due to
-            // https://github.com/scala/bug/issues/11207 produced many more
-            // static methods than expected. These are hard to filter out, so
-            // we exclude it here and rely on the checks for 2.5.17 and 2.5.19.
-            // Additionally, 2.5.30 had some problems related to
-            // https://github.com/akka/akka/issues/28807
-            expandVersions(2, 5, ((firstPatchOf25 to latestPatchOf25).toSet - 18 - 30).toList)
-          } else {
-            Nil
-          }
-        val akka26Previous = expandVersions(2, 6, 0 to latestPatchOf26)
+        val pekko10Previous = expandVersions(1, 0, 0 to latestPatchOf10)
 
-        akka25Previous ++ akka26Previous
+        pekko10Previous
       }
-
-      val akka25PromotedArtifacts = Set("pekko-distributed-data")
 
       // check against all binary compatible artifacts
       versions.map { v =>
-        val adjustedProjectName =
-          if (akka25PromotedArtifacts(projectName) && v.startsWith("2.4"))
-            projectName + "-experimental"
-          else
-            projectName
-        organization %% adjustedProjectName % v
+        organization %% projectName % v
       }.toSet
     }
   }

--- a/remote/src/main/mima-filters/1.0.x.backwards.excludes/jdk11-specific-classes.backwards.excludes
+++ b/remote/src/main/mima-filters/1.0.x.backwards.excludes/jdk11-specific-classes.backwards.excludes
@@ -1,7 +1,2 @@
-# Java 11 only flight recorder classes
-ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.cluster.sharding.internal.jfr.Passivate")
-ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.cluster.sharding.internal.jfr.RememberEntityWrite")
-ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.cluster.sharding.internal.jfr.JFRShardingFlightRecorder")
-ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.cluster.sharding.internal.jfr.RememberEntityAdd")
-ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.cluster.sharding.internal.jfr.RememberEntityRemove")
-ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.cluster.sharding.internal.jfr.PassivateRestart")
+# Java11+ API's will have to be always filtered until we have these classes in our normal build flow
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.remote.artery.jfr.*")

--- a/remote/src/main/mima-filters/1.0.x.backwards.excludes/jdk11-specific-classes.backwards.excludes
+++ b/remote/src/main/mima-filters/1.0.x.backwards.excludes/jdk11-specific-classes.backwards.excludes
@@ -1,0 +1,7 @@
+# Java 11 only flight recorder classes
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.cluster.sharding.internal.jfr.Passivate")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.cluster.sharding.internal.jfr.RememberEntityWrite")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.cluster.sharding.internal.jfr.JFRShardingFlightRecorder")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.cluster.sharding.internal.jfr.RememberEntityAdd")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.cluster.sharding.internal.jfr.RememberEntityRemove")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.cluster.sharding.internal.jfr.PassivateRestart")

--- a/stream/src/main/mima-filters/1.0.x.backwards.excludes/28324-jdk9-specific-classes.backwards.excludes
+++ b/stream/src/main/mima-filters/1.0.x.backwards.excludes/28324-jdk9-specific-classes.backwards.excludes
@@ -1,2 +1,5 @@
-# Java11+ API's will have to be always filtered until we have these classes in our normal build flow
-ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.remote.artery.jfr.*")
+# Java9+ API's will have to be always filtered until we have these classes in our normal build flow
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.stream.javadsl.JavaFlowSupport*")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.stream.scaladsl.JavaFlowSupport*")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.stream.impl.JavaFlow*")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.stream.impl.Rs*")

--- a/stream/src/main/mima-filters/1.0.x.backwards.excludes/28324-jdk9-specific-classes.backwards.excludes
+++ b/stream/src/main/mima-filters/1.0.x.backwards.excludes/28324-jdk9-specific-classes.backwards.excludes
@@ -1,0 +1,2 @@
+# Java11+ API's will have to be always filtered until we have these classes in our normal build flow
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.remote.artery.jfr.*")


### PR DESCRIPTION
* Copied some excludes files from Akka 2.6
* It appears that the mima check does not factor in some build logic that adds the Java9+ classes to pekko jars
* so mima check incorrectly thinks the classes built for Java9+ are missing from the locally built modules