### PR TITLE
Update branch in publish-1.0-docs.yml

### DIFF
--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -31,11 +31,12 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.repository == 'apache/incubator-pekko'
     steps:
-      # TODO we will need to change to a 1.0 branch or a release tag
+      # TODO we will need to change to use a release tag in future
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: 1.0.x
 
       - name: Setup Java 11
         uses: actions/setup-java@v3

--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -54,20 +54,20 @@ jobs:
       # TODO come up with a better way to control the version, possibly based on git tags
       - name: Build Documentation
         run: |-
-          sbt -Dpekko.genjavadoc.enabled=true "set ThisBuild / version := \"1.0.0\"; docs/paradox; unidoc"
+          sbt -Dpekko.genjavadoc.enabled=true "set ThisBuild / version := \"1.0.1\"; docs/paradox; unidoc"
 
       # Create directory structure upfront since rsync does not create intermediate directories otherwise
       - name: Create directory structure
         run: |-
-          mkdir -p target/nightly-docs/docs/pekko/1.0.0/
+          mkdir -p target/nightly-docs/docs/pekko/1.0.1/
           mkdir -p target/nightly-docs/docs/pekko/1.0/
-          cp -r docs/target/paradox/site/main/ target/nightly-docs/docs/pekko/1.0.0/docs
+          cp -r docs/target/paradox/site/main/ target/nightly-docs/docs/pekko/1.0.1/docs
           cp -r docs/target/paradox/site/main/ target/nightly-docs/docs/pekko/1.0/docs
           rm -r docs/target/paradox/site/main/
-          cp -r target/scala-2.13/unidoc target/nightly-docs/docs/pekko/1.0.0/api
+          cp -r target/scala-2.13/unidoc target/nightly-docs/docs/pekko/1.0.1/api
           cp -r target/scala-2.13/unidoc target/nightly-docs/docs/pekko/1.0/api
           rm -r target/scala-2.13/unidoc
-          cp -r target/javaunidoc target/nightly-docs/docs/pekko/1.0.0/japi
+          cp -r target/javaunidoc target/nightly-docs/docs/pekko/1.0.1/japi
           cp -r target/javaunidoc target/nightly-docs/docs/pekko/1.0/japi
           rm -r target/javaunidoc
 
@@ -76,7 +76,7 @@ jobs:
         with:
           upload: true
           switches: --archive --compress --update --delete --progress --relative
-          local_path: target/nightly-docs/./docs/pekko/1.0.0 # The intermediate dot is to show `--relative` which paths to operate on
+          local_path: target/nightly-docs/./docs/pekko/1.0.1 # The intermediate dot is to show `--relative` which paths to operate on
           remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/pekko
           remote_host: ${{ secrets.NIGHTLIES_RSYNC_HOST }}
           remote_port: ${{ secrets.NIGHTLIES_RSYNC_PORT }}


### PR DESCRIPTION
* will need to backport/cherry-pick to `1.0.x` branch
* the advantage of having this checked-in as opposed to having a GitHub CI parameter (that can be entered when running the task) is that changes need peer review