### PR TITLE
Remove sonatype commands that shouldn't be run in release process

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,12 @@ ThisBuild / versionScheme := Some(VersionScheme.SemVerSpec)
 sourceDistName := "apache-pekko"
 sourceDistIncubating := true
 
+commands := commands.value.filterNot { command =>
+  command.nameOption.exists { name =>
+    name.contains("sonatypeRelease") || name.contains("sonatypeBundleRelease")
+  }
+}
+
 enablePlugins(
   UnidocRoot,
   UnidocWithPrValidation,


### PR DESCRIPTION
As documented in https://github.com/apache/incubator-pekko-site/wiki/Pekko-Release-Process#deploy-the-jars-to-apache-maven-repository-staging there are commands that shouldn't be executed. This PR removes these commands (which are brought in by sbt-sonatype) so release managers cannot accidentally execute them as part of release process.