### PR TITLE
Remove org.apache.pekko package from sbt build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,6 @@
  */
 
 import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCheckResolver
-import org.apache.pekko._
 
 ThisBuild / scalafixScalaBinaryVersion := scalaBinaryVersion.value
 
@@ -47,8 +46,8 @@ addCommandAlias(
 
 addCommandAlias(name = "sortImports", value = ";scalafixEnable; scalafixAll SortImports; scalafmtAll")
 
-import org.apache.pekko.PekkoBuild._
-import com.typesafe.sbt.MultiJvmPlugin.MultiJvmKeys.MultiJvm
+import PekkoBuild._
+import MultiJvmPlugin.MultiJvmKeys.MultiJvm
 import com.typesafe.tools.mima.plugin.MimaPlugin
 import sbt.Keys.{ initialCommands, parallelExecution }
 import spray.boilerplate.BoilerplatePlugin

--- a/project/AddLogTimestamps.scala
+++ b/project/AddLogTimestamps.scala
@@ -11,15 +11,13 @@
  * Copyright (C) 2019-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import java.io.PrintWriter
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import sbt.{ Def, _ }
 import Keys._
-import sbt.internal.{ AppenderSupplier, LogManager }
+import sbt.internal.LogManager
 import sbt.internal.util.ConsoleOut
 
 object AddLogTimestamps extends AutoPlugin {

--- a/project/AutomaticModuleName.scala
+++ b/project/AutomaticModuleName.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2016-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import sbt.{ Def, _ }
 import sbt.Keys._
 

--- a/project/CliOptions.scala
+++ b/project/CliOptions.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 case class CliOption[T](private val value: T) {
   def get: T = value
 }

--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -11,14 +11,13 @@
  * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
 import de.heikoseeberger.sbtheader.{ CommentCreator, HeaderPlugin, NewLine }
-import com.typesafe.sbt.MultiJvmPlugin.MultiJvmKeys._
 import org.apache.commons.lang3.StringUtils
 import sbt.Keys._
 import sbt._
+
+import MultiJvmPlugin.MultiJvmKeys._
 
 trait CopyrightHeader extends AutoPlugin {
 

--- a/project/CopyrightHeaderForBoilerplate.scala
+++ b/project/CopyrightHeaderForBoilerplate.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2019-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import de.heikoseeberger.sbtheader.HeaderPlugin
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
 import sbt.Keys.sourceDirectory

--- a/project/CopyrightHeaderForBuild.scala
+++ b/project/CopyrightHeaderForBuild.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2019-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{ headerMappings, headerSources, HeaderFileType }
 import sbt.Keys.baseDirectory
 import sbt.{ inConfig, Compile, Def, PluginTrigger, Test, _ }

--- a/project/CopyrightHeaderForJdk9.scala
+++ b/project/CopyrightHeaderForJdk9.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2019-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.headerSources
 import sbt.Keys.sourceDirectory
 import sbt.{ Compile, Def, Test, _ }

--- a/project/CopyrightHeaderForProtobuf.scala
+++ b/project/CopyrightHeaderForProtobuf.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2019-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{ headerMappings, headerSources, HeaderFileType }
 import sbt.Keys.sourceDirectory
 import sbt.{ inConfig, Compile, Def, Test, _ }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2016-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import sbt._
 import Keys._
 import scala.language.implicitConversions

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import sbt._
 import sbtunidoc.BaseUnidocPlugin.autoImport.{ unidoc, unidocAllSources, unidocProjectFilter }
 import sbtunidoc.JavaUnidocPlugin.autoImport.JavaUnidoc

--- a/project/GitHub.scala
+++ b/project/GitHub.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2016-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 object GitHub {
 
   def envTokenOrThrow: Option[String] =

--- a/project/JavaFormatter.scala
+++ b/project/JavaFormatter.scala
@@ -11,7 +11,6 @@
  * Copyright (C) 2019-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-import org.apache.pekko.ProjectFileIgnoreSupport
 import com.lightbend.sbt.JavaFormatterPlugin
 import sbt.{ AutoPlugin, PluginTrigger, Plugins }
 

--- a/project/Jdk9.scala
+++ b/project/Jdk9.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2017-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import sbt._
 import sbt.Keys._
 

--- a/project/JdkOptions.scala
+++ b/project/JdkOptions.scala
@@ -11,12 +11,8 @@
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import java.io.File
 
-import scala.annotation.tailrec
-import scala.collection.immutable.ListMap
 import sbt._
 import sbt.librarymanagement.SemanticSelector
 import sbt.librarymanagement.VersionNumber

--- a/project/Jvm.scala
+++ b/project/Jvm.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package com.typesafe.sbt.multijvm
-
 import java.io.File
 import java.lang.{ ProcessBuilder => JProcessBuilder }
 

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import scala.collection.immutable
 import sbt._
 import sbt.Keys._

--- a/project/MultiNode.scala
+++ b/project/MultiNode.scala
@@ -11,12 +11,10 @@
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
+import TestExtras.Filter.Keys._
+import MultiJvmPlugin.MultiJvmKeys.multiJvmCreateLogger
+import MultiJvmPlugin.MultiJvmKeys._
 
-import org.apache.pekko.TestExtras.Filter.Keys._
-import com.typesafe.sbt.MultiJvmPlugin.MultiJvmKeys.multiJvmCreateLogger
-import com.typesafe.sbt.{ MultiJvmPlugin => SbtMultiJvm }
-import com.typesafe.sbt.MultiJvmPlugin.MultiJvmKeys._
 import sbt.{ Def, _ }
 import sbt.Keys._
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
@@ -74,7 +72,7 @@ object MultiNode extends AutoPlugin {
   private val anyConfigsInThisProject = ScopeFilter(configurations = inAnyConfiguration)
 
   private val multiJvmSettings =
-    SbtMultiJvm.multiJvmSettings ++
+    MultiJvmPlugin.multiJvmSettings ++
     inConfig(MultiJvm)(scalafmtConfigSettings) ++
     Seq(
       // Hack because 'provided' dependencies by default are not picked up by the multi-jvm plugin:

--- a/project/OSGi.scala
+++ b/project/OSGi.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2016-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import com.typesafe.sbt.osgi.OsgiKeys
 import com.typesafe.sbt.osgi.SbtOsgi._
 import sbt._

--- a/project/Paradox.scala
+++ b/project/Paradox.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2019-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import com.lightbend.paradox.sbt.ParadoxPlugin
 import com.lightbend.paradox.sbt.ParadoxPlugin.autoImport._
 import com.lightbend.paradox.apidoc.ApidocPlugin

--- a/project/ParadoxBrowse.scala
+++ b/project/ParadoxBrowse.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import com.lightbend.paradox.sbt.ParadoxPlugin
 import com.lightbend.paradox.sbt.ParadoxPlugin.autoImport._
 import sbt.Keys._

--- a/project/PekkoBuild.scala
+++ b/project/PekkoBuild.scala
@@ -11,11 +11,10 @@
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
+import JdkOptions.autoImport._
+import MultiJvmPlugin.autoImport.MultiJvm
 
-import org.apache.pekko.JdkOptions.autoImport._
 import com.lightbend.paradox.projectinfo.ParadoxProjectInfoPluginKeys._
-import com.typesafe.sbt.MultiJvmPlugin.autoImport.MultiJvm
 import sbt.Def
 import sbt.Keys._
 import sbt._

--- a/project/PekkoDisciplinePlugin.scala
+++ b/project/PekkoDisciplinePlugin.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2019-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import sbt._
 import Keys.{ scalacOptions, _ }
 import sbt.plugins.JvmPlugin

--- a/project/ProjectFileIgnoreSupport.scala
+++ b/project/ProjectFileIgnoreSupport.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2019-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import java.io.File
 
 import com.typesafe.config.ConfigFactory

--- a/project/Protobuf.scala
+++ b/project/Protobuf.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import java.io.File
 import java.io.PrintWriter
 

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import sbt._
 import sbt.Keys._
 import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin

--- a/project/SbtMultiJvm.scala
+++ b/project/SbtMultiJvm.scala
@@ -11,9 +11,6 @@
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package com.typesafe.sbt
-
-import com.typesafe.sbt.multijvm.{ Jvm, JvmLogger }
 import scala.sys.process.Process
 import sjsonnew.BasicJsonProtocol._
 import sbt._

--- a/project/ScalaFixExtraRulesPlugin.scala
+++ b/project/ScalaFixExtraRulesPlugin.scala
@@ -11,9 +11,7 @@
  * Copyright (C) 2020-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
-import sbt.{ AutoPlugin, PluginTrigger, Plugins, ScalafixSupport }
+import sbt.{ AutoPlugin, PluginTrigger, Plugins }
 import scalafix.sbt.ScalafixPlugin
 
 object ScalaFixExtraRulesPlugin extends AutoPlugin with ScalafixSupport {

--- a/project/ScalaFixForJdk9Plugin.scala
+++ b/project/ScalaFixForJdk9Plugin.scala
@@ -11,10 +11,9 @@
  * Copyright (C) 2020-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
-import sbt.{ AutoPlugin, PluginTrigger, Plugins, ScalafixSupport }
+import sbt.{ AutoPlugin, PluginTrigger, Plugins }
 import scalafix.sbt.ScalafixPlugin
+
 object ScalaFixForJdk9Plugin extends AutoPlugin with ScalafixSupport {
   override def trigger: PluginTrigger = allRequirements
   import Jdk9._

--- a/project/ScalafixForMultiNodePlugin.scala
+++ b/project/ScalafixForMultiNodePlugin.scala
@@ -11,10 +11,7 @@
  * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
-import com.typesafe.sbt.MultiJvmPlugin
-import sbt.{ inConfig, AutoPlugin, Def, PluginTrigger, Plugins, ScalafixSupport, Setting }
+import sbt.{ inConfig, AutoPlugin, Def, PluginTrigger, Plugins, Setting }
 import scalafix.sbt.ScalafixPlugin
 import scalafix.sbt.ScalafixPlugin.autoImport.scalafixConfigSettings
 

--- a/project/ScalafixIgnoreFilePlugin.scala
+++ b/project/ScalafixIgnoreFilePlugin.scala
@@ -11,10 +11,8 @@
  * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import sbt.plugins.JvmPlugin
-import sbt.{ AutoPlugin, PluginTrigger, Plugins, ScalafixSupport }
+import sbt.{ AutoPlugin, PluginTrigger, Plugins }
 import scalafix.sbt.ScalafixPlugin
 
 object ScalafixIgnoreFilePlugin extends AutoPlugin with ScalafixSupport {

--- a/project/ScalafixSupport.scala
+++ b/project/ScalafixSupport.scala
@@ -11,11 +11,9 @@
  * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package sbt
-import Keys.baseDirectory
+import sbt._
 
-import org.apache.pekko.ProjectFileIgnoreSupport
-import sbt.Keys.unmanagedSources
+import Keys._
 
 trait ScalafixSupport {
   private val ignoreConfigFileName: String = ".scalafix.conf"
@@ -32,13 +30,9 @@ trait ScalafixSupport {
     }
   }
 
-  import sbt.Keys._
-
   def addProjectCommandsIfAbsent(alias: String, value: String): Def.Setting[Seq[Command]] = {
     commands := {
-      val currentCommands = commands.value.collect {
-        case command: SimpleCommand => command.name
-      }.toSet
+      val currentCommands = commands.value.flatMap(_.nameOption).toSet
       val isPresent = currentCommands(alias)
       if (isPresent)
         commands.value
@@ -49,10 +43,7 @@ trait ScalafixSupport {
 
   def updateProjectCommands(alias: String, value: String): Def.Setting[Seq[Command]] = {
     commands := {
-      commands.value.filterNot {
-        case command: SimpleCommand => command.name == alias
-        case _                      => false
-      } :+ BasicCommands.newAlias(name = alias, value = value)
+      commands.value.filterNot(_.nameOption.contains("alias")) :+ BasicCommands.newAlias(name = alias, value = value)
     }
   }
 }

--- a/project/SigarLoader.scala
+++ b/project/SigarLoader.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import sbt._
 import sbt.Keys._
 

--- a/project/TestExtras.scala
+++ b/project/TestExtras.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2016-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import sbt.Keys._
 import sbt._
 

--- a/project/ValidatePullRequest.scala
+++ b/project/ValidatePullRequest.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import com.hpe.sbt.ValidatePullRequest
 import com.hpe.sbt.ValidatePullRequest.PathGlobFilter
 import com.lightbend.paradox.sbt.ParadoxPlugin
@@ -87,7 +85,7 @@ object PekkoValidatePullRequest extends AutoPlugin {
  */
 object MultiNodeWithPrValidation extends AutoPlugin {
   import PekkoValidatePullRequest._
-  import com.typesafe.sbt.MultiJvmPlugin.MultiJvmKeys.MultiJvm
+  import MultiJvmPlugin.MultiJvmKeys.MultiJvm
 
   override def trigger = allRequirements
   override def requires = PekkoValidatePullRequest && MultiNode

--- a/project/VersionGenerator.scala
+++ b/project/VersionGenerator.scala
@@ -11,8 +11,6 @@
  * Copyright (C) 2016-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko
-
 import sbt._
 import sbt.Keys._
 


### PR DESCRIPTION
The main goal of this PR is to both remove the `package org.apache.pekko` from sbt build source files (i.e. sources in `project`) and hence also clean up the imports. The reason/s for doing this are

* The `package org.apache.pekko` in sbt build source files are not needed since they are not going to appear in any JVM binary, these files are **only** for loading the sbt build
* The use of the `package org.apache.pekko` was entirely inconsistent, some sbt build source files had it and others didn't
* The source files in `project` didn't follow the idiomatic scala/java build convention (i.e. the source files should be placed in the `org/apache/pekko` dir structure. Removing the package altogether is far less disruptive solution

In addition there were cases where the `package sbt` was used but not really needed because a better solution existed (see comments).