### PR TITLE
Remove javafmtOnCompile and check in CI

### DIFF
--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -11,6 +11,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-code-style:
+    name: Check / Code Style
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.1.0
+        with:
+          # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
+          fetch-depth: 0
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Setup Java 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 8
+
+      - name: Code style check
+        run: |-
+          cp .jvmopts-ci .jvmopts
+          sbt \
+          -Dsbt.override.build.repos=false \
+          -Dsbt.log.noformat=false \
+          javafmtCheckAll
   pull-request-validation:
     name: Check / Tests
     runs-on: ubuntu-20.04

--- a/build.sbt
+++ b/build.sbt
@@ -37,8 +37,8 @@ enablePlugins(
   JavaFormatterPlugin)
 disablePlugins(MimaPlugin)
 
-addCommandAlias("verifyCodeStyle", "scalafmtCheckAll; scalafmtSbtCheck; headerCheckAll")
-addCommandAlias("applyCodeStyle", "headerCreateAll; scalafmtAll; scalafmtSbt")
+addCommandAlias("verifyCodeStyle", "scalafmtCheckAll; scalafmtSbtCheck; javafmtCheckAll; headerCheckAll")
+addCommandAlias("applyCodeStyle", "headerCreateAll; scalafmtAll; scalafmtSbt; javafmtAll")
 
 addCommandAlias(
   name = "fixall",

--- a/project/JavaFormatter.scala
+++ b/project/JavaFormatter.scala
@@ -23,8 +23,6 @@ object JavaFormatter extends AutoPlugin {
   private val ignoreConfigFileName: String = ".sbt-java-formatter.conf"
   private val descriptor: String = "sbt-java-formatter"
 
-  private val formatOnCompile = !sys.props.contains("pekko.no.discipline")
-
   import JavaFormatterPlugin.autoImport._
   import sbt.Keys._
   import sbt._
@@ -38,6 +36,5 @@ object JavaFormatter extends AutoPlugin {
           new ProjectFileIgnoreSupport((ThisBuild / baseDirectory).value / ignoreConfigFileName, descriptor)
         val simpleFileFilter = new SimpleFileFilter(file => ignoreSupport.isIgnoredByFileOrPackages(file))
         simpleFileFilter || (javafmt / excludeFilter).value
-      },
-      javafmtOnCompile := formatOnCompile)
+      })
 }


### PR DESCRIPTION
Currently Pekko formats java code on compile which has the unforunate consequence of formatting the entire codebase even when just running due to us generating Scala source code on compile, i.e.

```
pekko > cluster/MultiJvm/test
[info] Formatting 1 Java source...
[info] Reformatted 0 Java sources
[info] 3 file(s) merged using strategy 'Rename' (Run the task at debug level to see the details)
[info] 2 file(s) merged using strategy 'Discard' (Run the task at debug level to see the details)
[info] Built: /home/mdedetrich/github/incubator-pekko/protobuf-v3/target/scala-2.13/pekko-protobuf-v3-assembly-1.0.0+26-ad512ebf-SNAPSHOT.jar
[info] Jar hash: e4c3375316507c107622553eab40d960cae9e132
[info] Formatting 3 Java sources...
[info] Reformatted 0 Java sources
[info] Formatting 2 Java sources...
[info] Reformatted 0 Java sources
[info] Formatting 23 Java sources...
[info] Reformatted 0 Java sources
[info] Formatting 3 Java sources...
[info] Reformatted 0 Java sources
[info] Formatting 4 Java sources...
[info] Reformatted 0 Java sources
[info] Formatting 27 Java sources...
[info] Reformatted 0 Java sources
[info] Formatting 1 Java source...
[info] Reformatted 0 Java sources
[info] Formatting 20 Java sources...
[info] Reformatted 0 Java sources
[info] Generating 'FanInShapeN.scala'
[info] Generating 'FanOutShapeN.scala'
[info] Generating 'GraphApply.scala'
[info] Generating 'UnzipWithApply.scala'
[info] Generating 'ZipLatestWithApply.scala'
[info] Generating 'ZipWithApply.scala'
[info] Generating 'ZipLatestWith.scala'
[info] Generating 'UnzipWith.scala'
[info] Generating 'GraphCreate.scala'
[info] Generating 'ZipWith.scala'
[info] Generating 'Tuples.scala'
[info] Generating 'Functions.scala'
```

Also in general Pekko projects have moved away from formatting code on compile since we are checking that code is formatted in CI.
