### PR TITLE
Also check Scala 3 artifacts in MiMa

### DIFF
--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -18,11 +18,6 @@ jobs:
     if: github.repository == 'apache/incubator-pekko'
     strategy:
       fail-fast: false
-      matrix:
-        # The versions of scala specified here are only used as `+~...`
-        # which ignores the PATCH portion of the version id. These Scala versions don't need
-        # to be fully defined here then since Pekko build handles which patch version will be used.
-        scalaVersion: [ "2.12", "2.13" ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -43,11 +38,11 @@ jobs:
         run: cp .jvmopts-ci .jvmopts
 
       - name: Compile code
-        run: sbt "+~ ${{ matrix.scalaVersion }} Test/compile"
+        run: sbt +compile
 
       - name: Report MiMa Binary Issues
         run: |-
-          sbt "+~ ${{ matrix.scalaVersion }} mimaReportBinaryIssues"
+          sbt +mimaReportBinaryIssues
 
       - name: Check correct MiMa filter directories
         run: |

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -29,7 +29,7 @@ object MiMa extends AutoPlugin {
 
   override val projectSettings = Seq(
     mimaReportSignatureProblems := true,
-    mimaPreviousArtifacts := pekkoPreviousArtifacts(name.value, organization.value, scalaBinaryVersion.value),
+    mimaPreviousArtifacts := pekkoPreviousArtifacts(name.value, organization.value),
     checkMimaFilterDirectories := checkFilterDirectories(baseDirectory.value))
 
   def checkFilterDirectories(moduleRoot: File): Unit = {
@@ -43,25 +43,19 @@ object MiMa extends AutoPlugin {
 
   def pekkoPreviousArtifacts(
       projectName: String,
-      organization: String,
-      scalaBinaryVersion: String): Set[sbt.ModuleID] = {
-    if (scalaBinaryVersion.startsWith("3")) {
-      // No binary compatibility for 3.0 artifacts for now - experimental
-      Set.empty
-    } else {
-      val versions: Seq[String] = {
-        val firstPatchOf10 = 0
+      organization: String): Set[sbt.ModuleID] = {
+    val versions: Seq[String] = {
+      val firstPatchOf10 = 0
 
-        val pekko10Previous = expandVersions(1, 0, 0 to latestPatchOf10)
+      val pekko10Previous = expandVersions(1, 0, 0 to latestPatchOf10)
 
-        pekko10Previous
-      }
-
-      // check against all binary compatible artifacts
-      versions.map { v =>
-        organization %% projectName % v
-      }.toSet
+      pekko10Previous
     }
+
+    // check against all binary compatible artifacts
+    versions.map { v =>
+      organization %% projectName % v
+    }.toSet
   }
 
   private def expandVersions(major: Int, minor: Int, patches: immutable.Seq[Int]): immutable.Seq[String] =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,7 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.33")
 // sbt-osgi 0.9.5 is available but breaks including jdk9-only classes
 // sbt-osgi 0.9.6 is available but breaks populating pekko-protobuf-v3
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.4")
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.3")
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")


### PR DESCRIPTION
While MiMa may not have worked on really early versions of Scala 3, its reported to be working fine with Scala 3.3 and I can also confirm this when adding MiMa to pekko-streams-circe (see https://github.com/mdedetrich/pekko-streams-circe/pull/13)

Resolves: https://github.com/apache/incubator-pekko/issues/493