### PR TITLE
fix up some docs with version numbers that are Akka versions

### DIFF
--- a/cluster-sharding/src/main/resources/reference.conf
+++ b/cluster-sharding/src/main/resources/reference.conf
@@ -279,7 +279,7 @@ pekko.cluster.sharding {
 
   # Settings for LeastShardAllocationStrategy.
   #
-  # A new rebalance algorithm was included in Pekko 2.6.10. It can reach optimal balance in
+  # A new rebalance algorithm was included in Akka 2.6.10. It can reach optimal balance in
   # less rebalance rounds (typically 1 or 2 rounds). The amount of shards to rebalance in each
   # round can still be limited to make it progress slower. For backwards compatibility,
   # the new algorithm is not enabled by default. Enable the new algorithm by setting

--- a/cluster/src/main/resources/reference.conf
+++ b/cluster/src/main/resources/reference.conf
@@ -363,7 +363,7 @@ pekko {
     # Use members with all specified roles, or all members if undefined or empty.
     use-roles = []
 
-    # Deprecated, since Pekko 2.5.4, replaced by use-roles
+    # Deprecated, since Akka 2.5.4, replaced by use-roles
     # Use members with specified role, or all members if undefined or empty.
     use-role = ""
   }

--- a/docs/src/main/paradox/supervision-classic.md
+++ b/docs/src/main/paradox/supervision-classic.md
@@ -76,7 +76,7 @@ user-created actors, the guardian named `"/user"`. Actors created using
 `system.actorOf()` are children of this actor. This means that when this
 guardian terminates, all normal actors in the system will be shutdown, too. It
 also means that this guardian’s supervisor strategy determines how the
-top-level normal actors are supervised. Since Pekko 2.1 it is possible to
+top-level normal actors are supervised. Since Akka 2.1 it is possible to
 configure this using the setting `pekko.actor.guardian-supervisor-strategy`,
 which takes the fully-qualified class-name of a
 `SupervisorStrategyConfigurator`. When the guardian escalates a failure,

--- a/docs/src/main/paradox/testing.md
+++ b/docs/src/main/paradox/testing.md
@@ -813,7 +813,7 @@ to the @ref:[reference configuration](general/configuration-reference.md#config-
 
 Ray Roestenburg's example code from his blog, which unfortunately is only available on
 [web archive](https://web.archive.org/web/20180114133958/http://roestenburg.agilesquad.com/2011/02/unit-testing-akka-actors-with-testkit_12.html),
-adapted to work with Pekko 2.x.
+adapted to work with Akka 2.x.
 
 @@snip [TestKitUsageSpec.scala](/docs/src/test/scala/docs/testkit/TestKitUsageSpec.scala) { #testkit-usage }
 

--- a/remote/src/main/resources/reference.conf
+++ b/remote/src/main/resources/reference.conf
@@ -691,18 +691,6 @@ pekko {
           # the passive side will also request and verify a certificate from the connecting peer.
           #
           # To prevent man-in-the-middle attacks this setting is enabled by default.
-          #
-          # Note: Nodes that are configured with this setting to 'on' might not be able to receive messages from nodes that
-          # run on older versions of pekko-remote. This is because in versions of Pekko < 2.4.12 the active side of the remoting
-          # connection will not send over certificates even if asked.
-          #
-          # However, starting with Pekko 2.4.12, even with this setting "off", the active side (TLS client side)
-          # will use the given key-store to send over a certificate if asked. A rolling upgrade from versions of
-          # Pekko < 2.4.12 can therefore work like this:
-          #   - upgrade all nodes to a Pekko version >= 2.4.12, in the best case the latest version, but keep this setting at "off"
-          #   - then switch this flag to "on" and do again a rolling upgrade of all nodes
-          # The first step ensures that all nodes will send over a certificate when asked to. The second
-          # step will ensure that all nodes finally enforce the secure checking of client certificates.
           require-mutual-authentication = on
         }
       }

--- a/serialization-jackson/src/main/resources/reference.conf
+++ b/serialization-jackson/src/main/resources/reference.conf
@@ -196,7 +196,7 @@ pekko.serialization.jackson {
   jackson-cbor {}
 
   # Issue #28918 for compatibility with data serialized with JacksonCborSerializer in
-  # Pekko 2.6.4 or earlier, which was plain JSON format.
+  # Akka 2.6.4 or earlier, which was plain JSON format.
   jackson-cbor-264 = ${pekko.serialization.jackson.jackson-cbor}
 
 }
@@ -223,7 +223,7 @@ pekko.actor {
     jackson-cbor = "org.apache.pekko.serialization.jackson.JacksonCborSerializer"
 
     # Issue #28918 for compatibility with data serialized with JacksonCborSerializer in
-    # Pekko 2.6.4 or earlier, which was plain JSON format.
+    # Akka 2.6.4 or earlier, which was plain JSON format.
     jackson-cbor-264 = "org.apache.pekko.serialization.jackson.JacksonJsonSerializer"
   }
   serialization-identifiers {
@@ -231,7 +231,7 @@ pekko.actor {
     jackson-cbor = 33
 
     # Issue #28918 for compatibility with data serialized with JacksonCborSerializer in
-    # Pekko 2.6.4 or earlier, which was plain JSON format.
+    # Akka 2.6.4 or earlier, which was plain JSON format.
     jackson-cbor-264 = 32
   }
   serialization-bindings {

--- a/stream/src/main/resources/reference.conf
+++ b/stream/src/main/resources/reference.conf
@@ -52,7 +52,7 @@ pekko {
       # Enable automatic fusing of all graphs that are run. For short-lived streams
       # this may cause an initial runtime overhead, but most of the time fusing is
       # desirable since it reduces the number of Actors that are created.
-      # Deprecated, since Pekko 2.5.0, setting does not have any effect.
+      # Deprecated, since Akka 2.5.0, setting does not have any effect.
       auto-fusing = on
 
       # Those stream elements which have explicit buffers (like mapAsync, mapAsyncUnordered,


### PR DESCRIPTION
* also removes some Akka migration docs that are not relevant to Pekko users - our migration guide says that we expect users migrating from Akka to first upgrade to Akka 2.6.20 and to follow through on any necessary Akka migrations.