### PR TITLE
remove `@since` annotations with old Akka version numbers (#536)

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/actor/FSM.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/FSM.scala
@@ -954,8 +954,6 @@ trait FSM[S, D] extends Actor with Listeners with ActorLogging {
 /**
  * Stackable trait for [[pekko.actor.FSM]] which adds a rolling event log and
  * debug logging capabilities (analogous to [[pekko.event.LoggingReceive]]).
- *
- * @since 1.2
  */
 trait LoggingFSM[S, D] extends FSM[S, D] { this: Actor =>
 

--- a/actor/src/main/scala/org/apache/pekko/routing/MurmurHash.scala
+++ b/actor/src/main/scala/org/apache/pekko/routing/MurmurHash.scala
@@ -28,8 +28,6 @@
  *  tuples).
  *
  *  @author  Rex Kerr
- *  @version 2.9
- *  @since   2.9
  */
 package org.apache.pekko.routing
 

--- a/testkit/src/main/scala/org/apache/pekko/testkit/CallingThreadDispatcher.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/CallingThreadDispatcher.scala
@@ -159,8 +159,6 @@ object CallingThreadDispatcher {
  * different thread) are scooped up into the current thread-local queue which
  * is then executed. It is possible to suspend an actor from within its call
  * stack.
- *
- * @since 1.1
  */
 class CallingThreadDispatcher(_configurator: MessageDispatcherConfigurator) extends MessageDispatcher(_configurator) {
   import CallingThreadDispatcher._

--- a/testkit/src/main/scala/org/apache/pekko/testkit/TestActorRef.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/TestActorRef.scala
@@ -29,8 +29,6 @@ import pekko.pattern.ask
  * This special ActorRef is exclusively for use during unit testing in a single-threaded environment. Therefore, it
  * overrides the dispatcher to CallingThreadDispatcher and sets the receiveTimeout to None. Otherwise,
  * it acts just like a normal ActorRef. You may retrieve a reference to the underlying actor to test internal logic.
- *
- * @since 1.1
  */
 @nowarn // 'early initializers' are deprecated on 2.13 and will be replaced with trait parameters on 2.14. https://github.com/akka/akka/issues/26753
 class TestActorRef[T <: Actor](_system: ActorSystem, _props: Props, _supervisor: ActorRef, name: String)

--- a/testkit/src/main/scala/org/apache/pekko/testkit/TestFSMRef.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/TestFSMRef.scala
@@ -40,8 +40,6 @@ import pekko.actor._
  * assert (fsm.stateName == 2)
  * assert (fsm.underlyingActor.getLog == IndexedSeq(FSMLogEntry(1, null, "hallo")))
  * </code></pre>
- *
- * @since 1.2
  */
 class TestFSMRef[S, D, T <: Actor](system: ActorSystem, props: Props, supervisor: ActorRef, name: String)(
     implicit ev: T <:< FSM[S, D])

--- a/testkit/src/main/scala/org/apache/pekko/testkit/TestKit.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/TestKit.scala
@@ -977,8 +977,6 @@ trait TestKitBase {
  * It should be noted that for CI servers and the like all maximum Durations
  * are scaled using their Duration.dilated method, which uses the
  * TestKitExtension.Settings.TestTimeFactor settable via pekko.conf entry "pekko.test.timefactor".
- *
- * @since 1.1
  */
 @nowarn // 'early initializers' are deprecated on 2.13 and will be replaced with trait parameters on 2.14. https://github.com/akka/akka/issues/26753
 class TestKit(_system: ActorSystem) extends TestKitBase {


### PR DESCRIPTION
cherry pick of https://github.com/apache/incubator-pekko/commit/3c0672bac227ed49e7f426ecac5f092fa99dc2f3