### PR TITLE
=test Reschedule the reconnect when exception caught.

### DIFF
--- a/multi-node-testkit/src/main/scala/org/apache/pekko/remote/testconductor/Player.scala
+++ b/multi-node-testkit/src/main/scala/org/apache/pekko/remote/testconductor/Player.scala
@@ -352,6 +352,7 @@ private[pekko] class PlayerHandler(
     cause match {
       case _: ConnectException if reconnects > 0 =>
         reconnects -= 1
+        scheduleReconnect()
       case e => fsm ! ConnectionFailure(e.getMessage)
     }
   }


### PR DESCRIPTION
Lost it in the last pr https://github.com/apache/incubator-pekko/pull/549.

But as we do a `sync()` when connect, so this will never reached.