### PR TITLE
=test Change from `Akka` extension to `Pekko` extension in scaladoc.

### DIFF
--- a/multi-node-testkit/src/main/scala/org/apache/pekko/remote/testconductor/Extension.scala
+++ b/multi-node-testkit/src/main/scala/org/apache/pekko/remote/testconductor/Extension.scala
@@ -50,7 +50,7 @@ object TestConductor extends ExtensionId[TestConductorExt] with ExtensionIdProvi
 
 /**
  * This binds together the [[pekko.remote.testconductor.Conductor]] and
- * [[pekko.remote.testconductor.Player]] roles inside an Akka
+ * [[pekko.remote.testconductor.Player]] roles inside a Pekko
  * [[pekko.actor.Extension]]. Please follow the aforementioned links for
  * more information.
  *


### PR DESCRIPTION
It should be `Pekko` now.