### PR TITLE
fix managerName to use `pekko`

### DIFF
--- a/remote/src/main/resources/reference.conf
+++ b/remote/src/main/resources/reference.conf
@@ -267,6 +267,8 @@ pekko {
 
       ### Configuration for classic remoting. Classic remoting is deprecated, use artery.
 
+      # Used as part of the Actor name for the Protocol Manager.
+      manager-name-prefix = "pekkoprotocolmanager"
 
       # If set to a nonempty string remoting will use the given dispatcher for
       # its internal actors otherwise the default dispatcher is used. Please note

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/PekkoProtocolTransport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/PekkoProtocolTransport.scala
@@ -136,7 +136,7 @@ private[remote] class PekkoProtocolTransport(
   }
 
   override val maximumOverhead: Int = PekkoProtocolTransport.PekkoOverhead
-  protected def managerName = s"akkaprotocolmanager.${wrappedTransport.schemeIdentifier}${UniqueId.getAndIncrement}"
+  protected def managerName = s"pekkoprotocolmanager.${wrappedTransport.schemeIdentifier}${UniqueId.getAndIncrement}"
   protected def managerProps = {
     val wt = wrappedTransport
     val s = settings

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/PekkoProtocolTransport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/PekkoProtocolTransport.scala
@@ -138,7 +138,8 @@ private[remote] class PekkoProtocolTransport(
   }
 
   override val maximumOverhead: Int = PekkoProtocolTransport.PekkoOverhead
-  protected def managerName = s"${settings.ManagerNamePrefix}.${wrappedTransport.schemeIdentifier}${UniqueId.getAndIncrement}"
+  protected def managerName =
+    s"${settings.ManagerNamePrefix}.${wrappedTransport.schemeIdentifier}${UniqueId.getAndIncrement}"
   protected def managerProps = {
     val wt = wrappedTransport
     val s = settings

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/PekkoProtocolTransport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/PekkoProtocolTransport.scala
@@ -69,6 +69,8 @@ private[remote] class PekkoProtocolSettings(config: Config) {
         .getMillisDuration("pekko.remote.classic.handshake-timeout")
         .requiring(_ > Duration.Zero, "handshake-timeout must be > 0")
   }
+
+  val ManagerNamePrefix: String = config.getString("pekko.remote.classic.manager-name-prefix")
 }
 
 @nowarn("msg=deprecated")
@@ -136,7 +138,7 @@ private[remote] class PekkoProtocolTransport(
   }
 
   override val maximumOverhead: Int = PekkoProtocolTransport.PekkoOverhead
-  protected def managerName = s"pekkoprotocolmanager.${wrappedTransport.schemeIdentifier}${UniqueId.getAndIncrement}"
+  protected def managerName = s"${settings.ManagerNamePrefix}.${wrappedTransport.schemeIdentifier}${UniqueId.getAndIncrement}"
   protected def managerProps = {
     val wt = wrappedTransport
     val s = settings


### PR DESCRIPTION
another stray reference to akka

I've made the value configurable, just in case this causes unforeseen issues. Users shouldn't need to change the value.

I have tested with a cluster of 2 Pekko remote actors instances on 2 different remote actor-systems - both configured with different managerNames. The remote actors worked fine together.

The manager name only seems to affect the name of the manager actor instances but not in a way that affects messaging them.