### PR TITLE
=str Resort the OnNext extractor order.

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/impl/FanIn.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/FanIn.scala
@@ -245,8 +245,6 @@ import pekko.util.unused
     // FIXME: Eliminate re-wraps
     def subreceive: SubReceive =
       new SubReceive({
-        case OnSubscribe(id, subscription) =>
-          inputs(id).subreceive(ActorSubscriberMessage.OnSubscribe(subscription))
         case OnNext(id, elem) =>
           if (marked(id) && !pending(id)) markedPending += 1
           pending(id, on = true)
@@ -263,6 +261,8 @@ import pekko.util.unused
           if (!receivedInput && isAllCompleted()) onCompleteWhenNoInput()
         case OnError(id, e) =>
           onError(id, e)
+        case OnSubscribe(id, subscription) =>
+          inputs(id).subreceive(ActorSubscriberMessage.OnSubscribe(subscription))
       })
 
   }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/StreamOfStreams.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/StreamOfStreams.scala
@@ -842,9 +842,9 @@ import pekko.util.ccompat.JavaConverters._
 
     override def preStart(): Unit = {
       val ourOwnCallback = getAsyncCallback[ActorSubscriberMessage] {
+        case ActorSubscriberMessage.OnNext(elem) => push(out, elem.asInstanceOf[T])
         case ActorSubscriberMessage.OnComplete   => completeStage()
         case ActorSubscriberMessage.OnError(ex)  => failStage(ex)
-        case ActorSubscriberMessage.OnNext(elem) => push(out, elem.asInstanceOf[T])
       }
       setCB(ourOwnCallback)
     }


### PR DESCRIPTION
Motivotion:
Resort the extractor order for better performance.
