### PR TITLE
=sbt Bump sbt to 1.9.4 (1.0.x branch)

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.9.4


### PR DESCRIPTION
cherry pick e6ebc66db87c8281541bdc5f42c1c9836e9ab322

backport due to CVE fix in sbt 1.9.4