### PR TITLE
Having `@deprecated` and `@Deprecated` annotations on same function breaks scala3 build

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -800,7 +800,6 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * '''Cancels when''' downstream cancels
    */
   @deprecated("Use `statefulMap` with `mapConcat` instead.", "1.0.2")
-  @Deprecated
   def statefulMapConcat[T](
       f: function.Creator[function.Function[Out, java.lang.Iterable[T]]]): javadsl.Flow[In, T, Mat] =
     new Flow(delegate.statefulMapConcat { () =>

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -2453,7 +2453,6 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * '''Cancels when''' downstream cancels
    */
   @deprecated("Use `statefulMap` with `mapConcat` instead.", "1.0.2")
-  @Deprecated
   def statefulMapConcat[T](f: function.Creator[function.Function[Out, java.lang.Iterable[T]]]): javadsl.Source[T, Mat] =
     new Source(delegate.statefulMapConcat { () =>
       val fun = f.create()

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -274,7 +274,6 @@ class SubFlow[In, Out, Mat](
    * '''Cancels when''' downstream cancels
    */
   @deprecated("Use `statefulMap` with `mapConcat` instead.", "1.0.2")
-  @Deprecated
   def statefulMapConcat[T](f: function.Creator[function.Function[Out, java.lang.Iterable[T]]]): SubFlow[In, T, Mat] =
     new SubFlow(delegate.statefulMapConcat { () =>
       val fun = f.create()

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -265,7 +265,6 @@ class SubSource[Out, Mat](
    * '''Cancels when''' downstream cancels
    */
   @deprecated("Use `statefulMap` with `mapConcat` instead.", "1.0.2")
-  @Deprecated
   def statefulMapConcat[T](f: function.Creator[function.Function[Out, java.lang.Iterable[T]]]): SubSource[T, Mat] =
     new SubSource(delegate.statefulMapConcat { () =>
       val fun = f.create()


### PR DESCRIPTION
* cherry pick 46c38f6b01e2c62beef115c1868c202a8696d335
* same build issue is happening in nightly publish build for main and 1.0.cx branches (#625)
