### PR TITLE
Use fetch tags from latest checkout action

### DIFF
--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -20,10 +20,10 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
+          fetch-tags: 0
 
       - name: Setup Java 11
         uses: actions/setup-java@v3

--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -16,10 +16,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
@@ -42,10 +43,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
+          fetch-tags: 0
 
       - name: Setup Java 8
         uses: actions/setup-java@v3

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -8,5 +8,5 @@ jobs:
     name: Update Dependency Graph
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: scalacenter/sbt-dependency-submission@v2

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Java 8
         uses: actions/setup-java@v3

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository == 'apache/incubator-pekko'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Checkout GitHub merge
         if: github.event.pull_request

--- a/.github/workflows/nightly-builds-aeron.yml
+++ b/.github/workflows/nightly-builds-aeron.yml
@@ -21,10 +21,11 @@ jobs:
           - cluster/test cluster-typed/test
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Java 11
         uses: actions/setup-java@v3

--- a/.github/workflows/nightly-builds-latest-jdks.yml
+++ b/.github/workflows/nightly-builds-latest-jdks.yml
@@ -12,9 +12,10 @@ jobs:
     if: github.repository == 'apache/incubator-pekko'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Java 20
         uses: actions/setup-java@v3
@@ -68,10 +69,11 @@ jobs:
           - cluster-typed/test cluster-sharding-typed/test
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Java 20
         uses: actions/setup-java@v3
@@ -112,9 +114,10 @@ jobs:
         javaVersion: [20]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Java ${{ matrix.javaVersion }}
         uses: actions/setup-java@v3

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -14,9 +14,10 @@ jobs:
     if: github.repository == 'apache/incubator-pekko'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Java 11
         uses: actions/setup-java@v3
@@ -86,10 +87,11 @@ jobs:
           - cluster-typed/test cluster-sharding-typed/test
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Java 11
         uses: actions/setup-java@v3
@@ -146,9 +148,10 @@ jobs:
         javaVersion: [8, 11, 17]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Java ${{ matrix.javaVersion }}
         uses: actions/setup-java@v3

--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -33,9 +33,10 @@ jobs:
     steps:
       # TODO we will need to change to use a release tag in future
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
           ref: 1.0.x
 
       - name: Setup Java 11

--- a/.github/workflows/publish-1.0-nightly.yml
+++ b/.github/workflows/publish-1.0-nightly.yml
@@ -34,9 +34,10 @@ jobs:
     if: github.repository == 'apache/incubator-pekko'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
           ref: 1.0.x
 
       - name: Setup Java 11

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -34,9 +34,10 @@ jobs:
     if: github.repository == 'apache/incubator-pekko'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Java 11
         uses: actions/setup-java@v3

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -34,9 +34,10 @@ jobs:
       fail-fast: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Java 11
         uses: actions/setup-java@v3

--- a/.github/workflows/scala3-compile.yml
+++ b/.github/workflows/scala3-compile.yml
@@ -32,9 +32,10 @@ jobs:
       fail-fast: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Java 11
         uses: actions/setup-java@v3

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -16,9 +16,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Java 11
         uses: actions/setup-java@v3
@@ -56,19 +57,3 @@ jobs:
           report_paths: '**/target/test-reports/TEST-*.xml'
           fail_if_no_tests: false
           skip_publishing: true
-
-      # comment out email actions until we have an email address to use (and we need to get INFRA to whitelist dawidd6/action-send-mail)
-      #- name: Email on failure
-      #  if: ${{ failure() }}
-      #  uses: dawidd6/action-send-mail@v3
-      #  with:
-      #    server_address: smtp.gmail.com
-      #    server_port: 465
-      #    username: ${{secrets.MAIL_USERNAME}}
-      #    password: ${{secrets.MAIL_PASSWORD}}
-      #    subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-      #    to: akka.official@gmail.com
-      #    from: Akka CI (GHActions)
-      #    body: |
-      #      Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-      #      https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}


### PR DESCRIPTION
The latest version of the checkout github actions now supports a `fetch-tags` flag which does as described, i.e. it will fetch all of our tags which removes the various workarounds that was used before (i.e. manually running `git fetch` command) etc etc, see https://github.com/actions/checkout/pull/579

This will also help in the erroneous errors that we get in CI, i.e. 

```
[error] Failed to derive version from git tags. Maybe run `git fetch --unshallow` or `git fetch upstream` on a fresh git clone from a fork? Derived version: 0.0.0+1-337943bd-SNAPSHOT`
```