### PR TITLE
GH Workflows: Separate validateCompile step from validatePullRequest:…

### DIFF
--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -59,6 +59,21 @@ jobs:
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts
 
+      - name: sbt validateCompile
+        run: |-
+          sbt \
+          -Dpekko.mima.enabled=false \
+          -Dpekko.test.multi-in-test=false \
+          -Dpekko.test.timefactor=2 \
+          -Dpekko.actor.testkit.typed.timefactor=2 \
+          -Dpekko.test.tags.exclude=gh-exclude,timing \
+          -Dpekko.cluster.assert=on \
+          -Dsbt.override.build.repos=false \
+          -Dpekko.test.multi-node=false \
+          -Dsbt.log.noformat=false \
+          -Dpekko.log.timestamps=true \
+          validateCompile
+
       - name: sbt validatePullRequest
         run: |-
           sbt \
@@ -72,4 +87,4 @@ jobs:
           -Dpekko.test.multi-node=false \
           -Dsbt.log.noformat=false \
           -Dpekko.log.timestamps=true \
-          validateCompile validatePullRequest
+          validatePullRequest


### PR DESCRIPTION
… (#300)

This will make the source of errors in steps clearer, without adding any extra pipeline time.

steps in github jobs are dependent on one another, so the build files can be passed onto prValidation without the need for PR validation to compile again

(cherry picked from commit d51b7b30def6ab70c718cf2491df01fb207aa4bb)