### PR TITLE
protobuf-java 3.19.6

### DIFF
--- a/legal/pekko-protobuf-v3-jar-license.txt
+++ b/legal/pekko-protobuf-v3-jar-license.txt
@@ -202,6 +202,6 @@
 
 ---------------
 
-pekko-protobuf-v3 contains the sources of Google protobuf 3.16.3 runtime support,
+pekko-protobuf-v3 contains the sources of Google protobuf 3.19.6 runtime support,
 moved into the source package `org.apache.pekko.protobufv3.internal` so as to avoid version conflicts.
 For license information see COPYING.protobuf

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
   val agronaVersion = "1.15.1"
   val nettyVersion = "3.10.6.Final"
   val netty4Version = "4.1.96.Final"
-  val protobufJavaVersion = "3.16.3"
+  val protobufJavaVersion = "3.19.6"
   val logbackVersion = "1.2.11"
 
   val jacksonCoreVersion = "2.14.3"


### PR DESCRIPTION
* try to use a newer jar - we use newer versions of protobuf-java already in grpc and connectors projects
* Using the latest protobuf-java jars have caused issues when testing in other repos - so the aim is to try to do smaller upgrades and see how they work out as we test them across the ecosystem