### PR TITLE
=build Use zulu in nightly build to test jdk21.

### DIFF
--- a/.github/workflows/nightly-builds-latest-jdks.yml
+++ b/.github/workflows/nightly-builds-latest-jdks.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Java 21
         uses: actions/setup-java@v3
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: 21
 
       - name: Cache Coursier cache
@@ -78,7 +78,7 @@ jobs:
       - name: Setup Java 21
         uses: actions/setup-java@v3
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: 21
 
       - name: Cache Coursier cache
@@ -122,7 +122,7 @@ jobs:
       - name: Setup Java ${{ matrix.javaVersion }}
         uses: actions/setup-java@v3
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: ${{ matrix.javaVersion }}
 
       - name: Cache Coursier cache


### PR DESCRIPTION
There is no jdk21 temurin release for now, so I have to switch to zulu or oracle :(