### PR TITLE
POC =act Make use of externalSubmit to yield.

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/actor/ActorSystemSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/ActorSystemSpec.scala
@@ -99,8 +99,9 @@ object ActorSystemSpec {
       override protected[pekko] def registerForExecution(
           mbox: Mailbox,
           hasMessageHint: Boolean,
-          hasSystemMessageHint: Boolean): Boolean = {
-        val ret = super.registerForExecution(mbox, hasMessageHint, hasSystemMessageHint)
+          hasSystemMessageHint: Boolean,
+          needYield: Boolean): Boolean = {
+        val ret = super.registerForExecution(mbox, hasMessageHint, hasSystemMessageHint, needYield)
         doneIt.switchOn {
           TestKit.awaitCond(mbox.actor.actor != null, 1.second)
           mbox.actor.actor match {

--- a/actor/src/main/scala/org/apache/pekko/dispatch/BalancingDispatcher.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/BalancingDispatcher.scala
@@ -106,7 +106,7 @@ private[pekko] class BalancingDispatcher(
 
   override protected[pekko] def dispatch(receiver: ActorCell, invocation: Envelope) = {
     messageQueue.enqueue(receiver.self, invocation)
-    if (!registerForExecution(receiver.mailbox, false, false)) teamWork()
+    if (!registerForExecution(receiver.mailbox, false, false, false)) teamWork()
   }
 
   protected def teamWork(): Unit =
@@ -118,7 +118,7 @@ private[pekko] class BalancingDispatcher(
             case lm: LoadMetrics => !lm.atFullThrottle()
             case _               => true
           })
-          && !registerForExecution(i.next.mailbox, false, false))
+          && !registerForExecution(i.next.mailbox, false, false, true))
           scheduleOne(i)
 
       scheduleOne()

--- a/actor/src/main/scala/org/apache/pekko/dispatch/Mailbox.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/Mailbox.scala
@@ -242,7 +242,7 @@ private[pekko] abstract class Mailbox(val messageQueue: MessageQueue)
       }
     } finally {
       setAsIdle() // Volatile write, needed here
-      dispatcher.registerForExecution(this, false, false)
+      dispatcher.registerForExecution(this, false, false, true)
     }
   }
 

--- a/project/JdkOptions.scala
+++ b/project/JdkOptions.scala
@@ -38,6 +38,8 @@ object JdkOptions extends AutoPlugin {
     if (isJdk17orHigher) {
       // for aeron
       "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED" ::
+      // for fork join pool
+      "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED" ::
       // for LevelDB
       "--add-opens=java.base/java.nio=ALL-UNNAMED" :: Nil
     } else Nil

--- a/testkit/src/main/scala/org/apache/pekko/testkit/CallingThreadDispatcher.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/CallingThreadDispatcher.scala
@@ -177,7 +177,8 @@ class CallingThreadDispatcher(_configurator: MessageDispatcherConfigurator) exte
   protected[pekko] override def registerForExecution(
       mbox: Mailbox,
       hasMessageHint: Boolean,
-      hasSystemMessageHint: Boolean): Boolean = false
+      hasSystemMessageHint: Boolean,
+      needYield: Boolean): Boolean = false
 
   protected[pekko] override def shutdownTimeout = 1 second
 


### PR DESCRIPTION
refs: https://github.com/apache/incubator-pekko/issues/661

Some previous work done by @jrudolph 

The Current VirtualThrad in JDK 21 making use of the `externalSubmit`
```java
if (s == YIELDING) {   // Thread.yield
            setState(RUNNABLE);

            // notify JVMTI that unmount has completed, thread is runnable
            notifyJvmtiUnmount(/*hide*/false);

            // external submit if there are no tasks in the local task queue
            if (currentThread() instanceof CarrierThread ct && ct.getQueuedTaskCount() == 0) {
                externalSubmitRunContinuation(ct.getPool());
            } else {
                submitRunContinuation();
            }
        }
```

I think this change will affect the performance.