### PR TITLE
fix: keep stashBuffer when exception throw again #669

### DIFF
--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/SupervisionSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/SupervisionSpec.scala
@@ -1161,7 +1161,8 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       }
     }
 
-    "ensure unhandled message retention during consecutive restarts" in new FailingRestartBackoffTestSetup(cntValue = 5) {
+    "ensure unhandled message retention during consecutive restarts" in new FailingRestartBackoffTestSetup(
+      cntValue = 5) {
       val exception = new RuntimeException("mockException")
       val msg: Throw = Throw(exception)
       val ref = spawn(behv)

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/SupervisionSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/SupervisionSpec.scala
@@ -311,8 +311,13 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       }
 
       override def onMessage(message: Command): Behavior[Command] = {
-        monitor ! Pong(0)
-        Behaviors.same
+        message match {
+          case Ping(i) =>
+            monitor ! Pong(i)
+            Behaviors.same
+          // ignore others.
+          case _ => Behaviors.same
+        }
       }
     }
 
@@ -330,8 +335,8 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       probe.expectMessage(ReceivedSignal(PostStop))
       probe.expectMessage(Started)
       // expect no message lost
-      probe.expectMessage(Pong(0))
-      probe.expectMessage(Pong(0))
+      probe.expectMessage(Pong(1))
+      probe.expectMessage(Pong(2))
     }
   }
 

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/SupervisionSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/SupervisionSpec.scala
@@ -1161,7 +1161,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       }
     }
 
-    "not msg lost on restart multiple times" in new FailingRestartBackoffTestSetup(cntValue = 5) {
+    "ensure unhandled message retention during consecutive restarts" in new FailingRestartBackoffTestSetup(cntValue = 5) {
       val exception = new RuntimeException("mockException")
       val msg: Throw = Throw(exception)
       val ref = spawn(behv)

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/SupervisionSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/SupervisionSpec.scala
@@ -1174,11 +1174,11 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       }
     }
 
-    "ensure unhandled message retention during multiple exception when restart" in {
+    "ensure unhandled message retention during unstash exception when restart" in {
       testMessageRetentionWhenMultipleException(SupervisorStrategy.restart.withStashCapacity(4))
     }
 
-    "ensure unhandled message retention during multiple exception when backoff" in {
+    "ensure unhandled message retention during unstash exception when backoff" in {
       testMessageRetentionWhenMultipleException(SupervisorStrategy.restartWithBackoff(10.millis, 10.millis,
         0).withStashCapacity(4))
     }

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/Supervision.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/Supervision.scala
@@ -119,7 +119,6 @@ private abstract class AbstractSupervisor[I, Thr <: Throwable](strategy: Supervi
 
   def dropped(ctx: TypedActorContext[_], signalOrMessage: Any): Unit = {
     import pekko.actor.typed.scaladsl.adapter._
-    // TODO change the description of reason, because the additional case of message loss.
     ctx.asScala.system.toClassic.eventStream
       .publish(Dropped(signalOrMessage, s"Stash is full in [${getClass.getSimpleName}]", ctx.asScala.self.toClassic))
   }
@@ -334,13 +333,6 @@ private class RestartSupervisor[T, Thr <: Throwable: ClassTag](initial: Behavior
     case NonFatal(t) if isInstanceOfTheThrowableClass(t) =>
       ctx.asScala.cancelAllTimers()
       if (strategy.maxRestarts != -1 && restartCount >= strategy.maxRestarts && deadlineHasTimeLeft) {
-        // publishing the Dropper event before stop, not sure if it is necessary, but it may serve to cover some test case.
-        if (restartingInProgress.isDefined) {
-          val (stashBuffer, _) = restartingInProgress.get
-          stashBuffer.foreach(msg => {
-            dropped(ctx, msg)
-          })
-        }
         strategy match {
           case _: Restart => throw t
           case _: Backoff =>


### PR DESCRIPTION
References #669

after investigate, the reason why message log is `Supervisor` clear stash immediately(L401) while actor restart, no matter the new actor failure again or not.

It is no issue on classic BackoffOnRestartSupervisor, because they don't have StashBuffer. 

https://github.com/apache/incubator-pekko/blob/e94e7b971b74eeadc05a5b3dc28d1e17c434ad7f/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/Supervision.scala#L397-L411