### PR TITLE
Add external javadoc links

### DIFF
--- a/persistence/src/main/scala/org/apache/pekko/persistence/Persistence.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/Persistence.scala
@@ -128,9 +128,9 @@ trait RuntimePluginConfig {
 
   /**
    * Additional configuration of the journal plugin servicing this persistent actor.
-   * When empty, the whole configuration of the journal plugin will be taken from the [[Config]] loaded into the
+   * When empty, the whole configuration of the journal plugin will be taken from the [[com.typesafe.config.Config]] loaded into the
    * [[ActorSystem]].
-   * When configured, the journal plugin configuration will be taken from this [[Config]] merged with the [[Config]]
+   * When configured, the journal plugin configuration will be taken from this [[com.typesafe.config.Config]] merged with the [[com.typesafe.config.Config]]
    * loaded into the [[ActorSystem]].
    *
    * @return an additional configuration used to configure the journal plugin.
@@ -139,9 +139,9 @@ trait RuntimePluginConfig {
 
   /**
    * Additional configuration of the snapshot plugin servicing this persistent actor.
-   * When empty, the whole configuration of the snapshot plugin will be taken from the [[Config]] loaded into the
+   * When empty, the whole configuration of the snapshot plugin will be taken from the [[com.typesafe.config.Config]] loaded into the
    * [[ActorSystem]].
-   * When configured, the snapshot plugin configuration will be taken from this [[Config]] merged with the [[Config]]
+   * When configured, the snapshot plugin configuration will be taken from this [[com.typesafe.config.Config]] merged with the [[com.typesafe.config.Config]]
    * loaded into the [[ActorSystem]].
    *
    * @return an additional configuration used to configure the snapshot plugin.

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -155,7 +155,11 @@ object UnidocRoot extends AutoPlugin {
         ScalaUnidoc / unidocProjectFilter := unidocRootProjectFilter(unidocRootIgnoreProjects.value),
         JavaUnidoc / unidocProjectFilter := unidocRootProjectFilter(unidocRootIgnoreProjects.value),
         Compile / doc / apiMappings ++= {
-          val entries: Seq[Attributed[File]] = (LocalProject("slf4j") / Compile / fullClasspath).value
+          val entries: Seq[Attributed[File]] =
+            (LocalProject("slf4j") / Compile / fullClasspath).value ++
+            (LocalProject("persistence") / Compile / fullClasspath).value ++
+            (LocalProject("remote") / Compile / fullClasspath).value ++
+            (LocalProject("stream") / Compile / fullClasspath).value
 
           def mappingsFor(organization: String, names: List[String], location: String,
               revision: String => String = identity): Seq[(File, URL)] = {
@@ -167,8 +171,14 @@ object UnidocRoot extends AutoPlugin {
             } yield entry.data -> url(location.format(module.revision))
           }
 
-          val mappings: Seq[(File, URL)] =
-            mappingsFor("org.slf4j", List("slf4j-api"), "https://www.javadoc.io/doc/org.slf4j/slf4j-api/%s/")
+          val mappings: Seq[(File, URL)] = {
+            mappingsFor("org.slf4j", List("slf4j-api"), "https://www.javadoc.io/doc/org.slf4j/slf4j-api/%s/") ++
+            mappingsFor("com.typesafe", List("config"), "https://www.javadoc.io/doc/com.typesafe/config/%s/") ++
+            mappingsFor("io.aeron", List("aeron-client", "aeron-driver"),
+              "https://www.javadoc.io/doc/io.aeron/aeron-all/%s/") ++
+            mappingsFor("org.reactivestreams", List("reactive-streams"),
+              "https://www.javadoc.io/doc/org.reactivestreams/reactive-streams/%s/")
+          }
 
           mappings.toMap
         },
@@ -200,6 +210,7 @@ object UnidocRoot extends AutoPlugin {
 object BootstrapGenjavadoc extends AutoPlugin {
 
   override def trigger = allRequirements
+
   override def requires =
     UnidocRoot.CliOptions.genjavadocEnabled
       .ifTrue {

--- a/remote/src/main/java/org/apache/pekko/remote/artery/aeron/AeronErrorLog.java
+++ b/remote/src/main/java/org/apache/pekko/remote/artery/aeron/AeronErrorLog.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * <p>Application to print out errors recorded in the command-and-control (cnc) file is maintained
  * by media driver in shared memory. This application reads the cnc file and prints the distinct
- * errors. Layout of the cnc file is described in {@link CncFileDescriptor}.
+ * errors. Layout of the cnc file is described in {@link io.aeron.CncFileDescriptor}.
  */
 public class AeronErrorLog {
   final MappedByteBuffer cncByteBuffer;


### PR DESCRIPTION
Refs #353 

I added mappings to an external javadoc to solve warning logs which scaladoc's links to external java library cause.

* `com.typesafe` is linked from `persistence/src/main/scala/org/apache/pekko/persistence/Persistence.scala`
* `io.aeron` is linked from `remote/src/main/java/org/apache/pekko/remote/artery/aeron/AeronErrorLog.java`
* `org.reactivestreams` is linked from `stream/src/main/scala/org/apache/pekko/stream/javadsl/Sink.scala` and `stream/src/main/scala/org/apache/pekko/stream/scaladsl/Sink.scala`