### PR TITLE
chore: javadoc link and typo fixes

### DIFF
--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/AskPattern.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/AskPattern.scala
@@ -76,7 +76,7 @@ object AskPattern {
      * val f: Future[Reply] = target ? (replyTo => Request("hello", replyTo))
      * }}}
      *
-     * Note: it is preferrable to use the non-symbolic ask method as it easier allows for wildcards for
+     * Note: it is preferable to use the non-symbolic ask method as it easier allows for wildcards for
      * the `replyTo: ActorRef`.
      *
      * @tparam Res The response protocol, what the other actor sends back
@@ -115,7 +115,7 @@ object AskPattern {
      */
     @nowarn("msg=never used")
     def ask[Res](replyTo: ActorRef[Res] => Req)(implicit timeout: Timeout, scheduler: Scheduler): Future[Res] = {
-      // We do not currently use the implicit sched, but want to require it
+      // We do not currently use the implicit scheduler, but want to require it
       // because it might be needed when we move to a 'native' typed runtime, see #24219
       ref match {
         case a: InternalRecipientRef[Req] => askClassic[Req, Res](a, timeout, replyTo)

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/Routers.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/Routers.scala
@@ -185,5 +185,5 @@ trait PoolRouter[T] extends Behavior[T] {
   /**
    * Any message that the predicate returns true for will be broadcast to all routees.
    */
-  def withBroadcastPredicate(pred: T => Boolean): PoolRouter[T]
+  def withBroadcastPredicate(predicate: T => Boolean): PoolRouter[T]
 }

--- a/stream-typed/src/main/scala/org/apache/pekko/stream/typed/javadsl/ActorFlow.scala
+++ b/stream-typed/src/main/scala/org/apache/pekko/stream/typed/javadsl/ActorFlow.scala
@@ -49,7 +49,7 @@ object ActorFlow {
    * The operator fails with an [[pekko.stream.WatchedActorTerminatedException]] if the target actor is terminated,
    * or with an [[java.util.concurrent.TimeoutException]] in case the ask exceeds the timeout passed in.
    *
-   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   * Adheres to the [[pekko.stream.ActorAttributes.SupervisionStrategy]] attribute.
    *
    * '''Emits when''' the futures (in submission order) created by the ask pattern internally are completed
    *
@@ -105,7 +105,7 @@ object ActorFlow {
    * The operator fails with an [[pekko.stream.WatchedActorTerminatedException]] if the target actor is terminated,
    * or with an [[java.util.concurrent.TimeoutException]] in case the ask exceeds the timeout passed in.
    *
-   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   * Adheres to the [[pekko.stream.ActorAttributes.SupervisionStrategy]] attribute.
    *
    * '''Emits when''' the futures (in submission order) created by the ask pattern internally are completed
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -250,7 +250,7 @@ class SubSource[Out, Mat](
    * as they are illegal as stream elements - according to the Reactive Streams specification.
    *
    * This operator doesn't handle upstream's completion signal since the state kept in the closure can be lost.
-   * Use [[FlowOps.statefulMap]] instead.
+   * Use [[pekko.stream.scaladsl.FlowOps.statefulMap]] instead.
    *
    * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -250,7 +250,7 @@ class SubSource[Out, Mat](
    * as they are illegal as stream elements - according to the Reactive Streams specification.
    *
    * This operator doesn't handle upstream's completion signal since the state kept in the closure can be lost.
-   * Use [[pekko.stream.scaladsl.FlowOps.statefulMap]] instead.
+   * Use [[pekko.stream.javadsl.Flow.statefulMap]] instead.
    *
    * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
    *


### PR DESCRIPTION
As described in the title, resolve some javadoc linking issues that cannot be properly addressed within the IDE.