### PR TITLE
=str Tweak the stream mapAsyncPartitioned operator

### DIFF
--- a/stream-typed-tests/src/test/scala/org/apache/pekko/stream/MapAsyncPartitionedSpec.scala
+++ b/stream-typed-tests/src/test/scala/org/apache/pekko/stream/MapAsyncPartitionedSpec.scala
@@ -63,8 +63,7 @@ private object MapAsyncPartitionedSpec {
           value = i.toString)
       }
 
-    def extractPartition(e: TestKeyValue): Int =
-      e.key
+    val partitioner: TestKeyValue => Int = kv => kv.key
 
     type Operation = TestKeyValue => Future[(Int, String)]
 
@@ -125,7 +124,7 @@ class MapAsyncPartitionedSpec
 
     val result =
       Source(elements)
-        .mapAsyncPartitionedUnordered(parallelism = 2)(extractPartition)(blockingOperation)
+        .mapAsyncPartitionedUnordered(parallelism = 2)(partitioner)(blockingOperation)
         .runWith(Sink.seq)
         .futureValue
         .map(_._2)
@@ -137,7 +136,7 @@ class MapAsyncPartitionedSpec
     forAll(minSuccessful(1000)) { (parallelism: Parallelism, elements: Seq[TestKeyValue]) =>
       val result =
         Source(elements.toIndexedSeq)
-          .mapAsyncPartitionedUnordered(parallelism.value)(extractPartition)(asyncOperation)
+          .mapAsyncPartitionedUnordered(parallelism.value)(partitioner)(asyncOperation)
           .runWith(Sink.seq)
           .futureValue
 
@@ -153,7 +152,7 @@ class MapAsyncPartitionedSpec
       val result =
         Source
           .fromIterator(() => elements.iterator)
-          .mapAsyncPartitionedUnordered(parallelism = 1)(extractPartition)(asyncOperation)
+          .mapAsyncPartitionedUnordered(parallelism = 1)(partitioner)(asyncOperation)
           .runWith(Sink.seq)
           .futureValue
 
@@ -169,7 +168,7 @@ class MapAsyncPartitionedSpec
       val result =
         Source
           .fromIterator(() => elements.iterator)
-          .mapAsyncPartitionedUnordered(parallelism.value)(extractPartition)(blockingOperation)
+          .mapAsyncPartitionedUnordered(parallelism.value)(partitioner)(blockingOperation)
           .runWith(Sink.seq)
           .futureValue
 
@@ -232,7 +231,7 @@ class MapAsyncPartitionedSpec
 
     val result =
       Source(elements)
-        .mapAsyncPartitionedUnordered(parallelism = 2)(extractPartition)(fun)
+        .mapAsyncPartitionedUnordered(parallelism = 2)(partitioner)(fun)
         .runWith(Sink.seq)
         .futureValue
 
@@ -244,7 +243,7 @@ class MapAsyncPartitionedSpec
       an[IllegalArgumentException] shouldBe thrownBy {
         Source(infiniteStream())
           .mapAsyncPartitionedUnordered(
-            parallelism = zeroOrNegativeParallelism)(extractPartition = identity)(f = (_, _) => Future.unit)
+            parallelism = zeroOrNegativeParallelism)(partitioner = identity)(f = (_, _) => Future.unit)
           .runWith(Sink.ignore)
           .futureValue
       }
@@ -272,7 +271,7 @@ class MapAsyncPartitionedSpec
 
     val result =
       Source(elements)
-        .mapAsyncPartitioned(parallelism = 2)(extractPartition)(processElement)
+        .mapAsyncPartitioned(parallelism = 2)(partitioner)(processElement)
         .runWith(Sink.seq)
         .futureValue
         .map(_._2)
@@ -289,7 +288,7 @@ class MapAsyncPartitionedSpec
     forAll(minSuccessful(1000)) { (parallelism: Parallelism, elements: Seq[TestKeyValue]) =>
       val result =
         Source(elements.toIndexedSeq)
-          .mapAsyncPartitioned(parallelism.value)(extractPartition)(asyncOperation)
+          .mapAsyncPartitioned(parallelism.value)(partitioner)(asyncOperation)
           .runWith(Sink.seq)
           .futureValue
 
@@ -305,7 +304,7 @@ class MapAsyncPartitionedSpec
       val result =
         Source
           .fromIterator(() => elements.iterator)
-          .mapAsyncPartitioned(parallelism = 1)(extractPartition)(asyncOperation)
+          .mapAsyncPartitioned(parallelism = 1)(partitioner)(asyncOperation)
           .runWith(Sink.seq)
           .futureValue
 
@@ -321,7 +320,7 @@ class MapAsyncPartitionedSpec
       val result =
         Source
           .fromIterator(() => elements.iterator)
-          .mapAsyncPartitioned(parallelism.value)(extractPartition)(blockingOperation)
+          .mapAsyncPartitioned(parallelism.value)(partitioner)(blockingOperation)
           .runWith(Sink.seq)
           .futureValue
 
@@ -384,7 +383,7 @@ class MapAsyncPartitionedSpec
 
     val result =
       Source(elements)
-        .mapAsyncPartitioned(parallelism = 2)(extractPartition)(fun)
+        .mapAsyncPartitioned(parallelism = 2)(partitioner)(fun)
         .runWith(Sink.seq)
         .futureValue
 
@@ -396,7 +395,7 @@ class MapAsyncPartitionedSpec
       an[IllegalArgumentException] shouldBe thrownBy {
         Source(infiniteStream())
           .mapAsyncPartitioned(
-            parallelism = zeroOrNegativeParallelism)(extractPartition = identity)(f = (_, _) => Future.unit)
+            parallelism = zeroOrNegativeParallelism)(partitioner = identity)(f = (_, _) => Future.unit)
           .runWith(Sink.ignore)
           .futureValue
       }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/Stages.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/Stages.scala
@@ -40,6 +40,8 @@ import pekko.stream.Attributes._
     val mapError = name("mapError")
     val mapAsync = name("mapAsync")
     val mapAsyncUnordered = name("mapAsyncUnordered")
+    val mapAsyncPartition = name("mapAsyncPartition")
+    val mapAsyncPartitionUnordered = name("mapAsyncPartitionUnordered")
     val ask = name("ask")
     val grouped = name("grouped")
     val groupedWithin = name("groupedWithin")

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -842,30 +842,68 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
   /**
    * Transforms this stream. Works very similarly to [[#mapAsync]] but with an additional
    * partition step before the transform step. The transform function receives the an individual
-   * stream entry and the calculated partition value for that entry.
+   * stream entry and the calculated partition value for that entry. The max parallelism of per partition is 1.
+   *
+   * The function `partitioner` is always invoked on the elements in the order they arrive.
+   * The function `f` is always invoked on the elements which in the same partition in the order they arrive.
+   *
+   * If the function `partitioner` or `f` throws an exception or if the [[CompletionStage]] is completed
+   * with failure and the supervision decision is [[pekko.stream.Supervision.Stop]]
+   * the stream will be completed with failure, otherwise the stream continues and the current element is dropped.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   *
+   * '''Emits when''' the Future returned by the provided function finishes for the next element in sequence
+   *
+   * '''Backpressures when''' the number of futures reaches the configured parallelism and the downstream
+   * backpressures
+   *
+   * '''Completes when''' upstream completes and all futures have been completed and all elements have been emitted
+   *
+   * '''Cancels when''' downstream cancels
    *
    * @since 1.1.0
    * @see [[#mapAsync]]
    * @see [[#mapAsyncPartitionedUnordered]]
    */
-  def mapAsyncPartitioned[T, P](parallelism: Int,
-      extractPartition: function.Function[Out, P],
+  def mapAsyncPartitioned[T, P](
+      parallelism: Int,
+      partitioner: function.Function[Out, P],
       f: function.Function2[Out, P, CompletionStage[T]]): Flow[In, T, Mat] =
-    MapAsyncPartitioned.mapFlowOrdered(delegate, parallelism)(extractPartition(_))(f(_, _).asScala).asJava
+    new Flow(delegate.mapAsyncPartitioned(parallelism)(partitioner(_))(f(_, _).asScala))
 
   /**
    * Transforms this stream. Works very similarly to [[#mapAsyncUnordered]] but with an additional
    * partition step before the transform step. The transform function receives the an individual
-   * stream entry and the calculated partition value for that entry.
+   * stream entry and the calculated partition value for that entry.The max parallelism of per partition is 1.
+   *
+   * The function `partitioner` is always invoked on the elements in the order they arrive.
+   * The function `f` is always invoked on the elements which in the same partition in the order they arrive.
+   *
+   * If the function `partitioner` or `f` throws an exception or if the [[CompletionStage]] is completed
+   * with failure and the supervision decision is [[pekko.stream.Supervision.Stop]]
+   * the stream will be completed with failure, otherwise the stream continues and the current element is dropped.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   *
+   * '''Emits when''' the Future returned by the provided function finishes and downstream available.
+   *
+   * '''Backpressures when''' the number of futures reaches the configured parallelism and the downstream
+   * backpressures
+   *
+   * '''Completes when''' upstream completes and all futures have been completed and all elements have been emitted
+   *
+   * '''Cancels when''' downstream cancels
    *
    * @since 1.1.0
    * @see [[#mapAsyncUnordered]]
    * @see [[#mapAsyncPartitioned]]
    */
-  def mapAsyncPartitionedUnordered[T, P](parallelism: Int,
-      extractPartition: function.Function[Out, P],
+  def mapAsyncPartitionedUnordered[T, P](
+      parallelism: Int,
+      partitioner: function.Function[Out, P],
       f: function.Function2[Out, P, CompletionStage[T]]): Flow[In, T, Mat] =
-    MapAsyncPartitioned.mapFlowUnordered(delegate, parallelism)(extractPartition(_))(f(_, _).asScala).asJava
+    new Flow(delegate.mapAsyncPartitionedUnordered(parallelism)(partitioner(_))(f(_, _).asScala))
 
   /**
    * Transform this stream by applying the given function to each of the elements

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/FlowWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/FlowWithContext.scala
@@ -173,39 +173,40 @@ final class FlowWithContext[In, CtxIn, Out, CtxOut, +Mat](
   def map[Out2](f: function.Function[Out, Out2]): FlowWithContext[In, CtxIn, Out2, CtxOut, Mat] =
     viaScala(_.map(f.apply))
 
+  /**
+   * Context-preserving variant of [[pekko.stream.javadsl.Flow.mapAsync]].
+   *
+   * @see [[pekko.stream.javadsl.Flow.mapAsync]]
+   */
   def mapAsync[Out2](
       parallelism: Int,
       f: function.Function[Out, CompletionStage[Out2]]): FlowWithContext[In, CtxIn, Out2, CtxOut, Mat] =
     viaScala(_.mapAsync[Out2](parallelism)(o => f.apply(o).asScala))
 
   /**
-   * Transforms this stream. Works very similarly to [[#mapAsync]] but with an additional
-   * partition step before the transform step. The transform function receives the an individual
-   * stream entry and the calculated partition value for that entry.
+   * Context-preserving variant of [[pekko.stream.javadsl.Flow.mapAsyncPartitioned]].
    *
    * @since 1.1.0
-   * @see [[#mapAsync]]
-   * @see [[#mapAsyncPartitionedUnordered]]
+   * @see [[pekko.stream.javadsl.Flow.mapAsyncPartitioned]]
    */
-  def mapAsyncPartitioned[Out2, P](parallelism: Int,
-      extractPartition: function.Function[Out, P],
+  def mapAsyncPartitioned[Out2, P](
+      parallelism: Int,
+      partitioner: function.Function[Out, P],
       f: function.Function2[Out, P, CompletionStage[Out2]]): FlowWithContext[In, CtxIn, Out2, CtxOut, Mat] = {
-    viaScala(_.mapAsyncPartitioned(parallelism)(extractPartition(_))(f(_, _).asScala))
+    viaScala(_.mapAsyncPartitioned(parallelism)(partitioner(_))(f(_, _).asScala))
   }
 
   /**
-   * Transforms this stream. Works very similarly to [[#mapAsyncUnordered]] but with an additional
-   * partition step before the transform step. The transform function receives the an individual
-   * stream entry and the calculated partition value for that entry.
+   * Context-preserving variant of [[pekko.stream.javadsl.Flow.mapAsyncPartitionedUnordered]].
    *
    * @since 1.1.0
-   * @see [[#mapAsyncUnordered]]
-   * @see [[#mapAsyncPartitioned]]
+   * @see [[pekko.stream.javadsl.Flow.mapAsyncPartitionedUnordered]]
    */
-  def mapAsyncPartitionedUnordered[Out2, P](parallelism: Int,
-      extractPartition: function.Function[Out, P],
+  def mapAsyncPartitionedUnordered[Out2, P](
+      parallelism: Int,
+      partitioner: function.Function[Out, P],
       f: function.Function2[Out, P, CompletionStage[Out2]]): FlowWithContext[In, CtxIn, Out2, CtxOut, Mat] = {
-    viaScala(_.mapAsyncPartitionedUnordered(parallelism)(extractPartition(_))(f(_, _).asScala))
+    viaScala(_.mapAsyncPartitionedUnordered(parallelism)(partitioner(_))(f(_, _).asScala))
   }
 
   /**

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -2496,32 +2496,68 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
   /**
    * Transforms this stream. Works very similarly to [[#mapAsync]] but with an additional
    * partition step before the transform step. The transform function receives the an individual
-   * stream entry and the calculated partition value for that entry.
+   * stream entry and the calculated partition value for that entry. The max parallelism of per partition is 1.
+   *
+   * The function `partitioner` is always invoked on the elements in the order they arrive.
+   * The function `f` is always invoked on the elements which in the same partition in the order they arrive.
+   *
+   * If the function `partitioner` or `f` throws an exception or if the [[CompletionStage]] is completed
+   * with failure and the supervision decision is [[pekko.stream.Supervision.Stop]]
+   * the stream will be completed with failure, otherwise the stream continues and the current element is dropped.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   *
+   * '''Emits when''' the Future returned by the provided function finishes for the next element in sequence
+   *
+   * '''Backpressures when''' the number of futures reaches the configured parallelism and the downstream
+   * backpressures
+   *
+   * '''Completes when''' upstream completes and all futures have been completed and all elements have been emitted
+   *
+   * '''Cancels when''' downstream cancels
    *
    * @since 1.1.0
    * @see [[#mapAsync]]
    * @see [[#mapAsyncPartitionedUnordered]]
    */
-  def mapAsyncPartitioned[T, P](parallelism: Int,
-      extractPartition: function.Function[Out, P],
+  def mapAsyncPartitioned[T, P](
+      parallelism: Int,
+      partitioner: function.Function[Out, P],
       f: function.Function2[Out, P, CompletionStage[T]]): javadsl.Source[T, Mat] =
-    MapAsyncPartitioned.mapSourceOrdered(delegate, parallelism)(extractPartition(_))(f(_,
-      _).asScala).asJava
+    new Source(delegate.mapAsyncPartitioned(parallelism)(partitioner(_))(f(_, _).asScala))
 
   /**
    * Transforms this stream. Works very similarly to [[#mapAsyncUnordered]] but with an additional
    * partition step before the transform step. The transform function receives the an individual
-   * stream entry and the calculated partition value for that entry.
+   * stream entry and the calculated partition value for that entry.The max parallelism of per partition is 1.
+   *
+   * The function `partitioner` is always invoked on the elements in the order they arrive.
+   * The function `f` is always invoked on the elements which in the same partition in the order they arrive.
+   *
+   * If the function `partitioner` or `f` throws an exception or if the [[CompletionStage]] is completed
+   * with failure and the supervision decision is [[pekko.stream.Supervision.Stop]]
+   * the stream will be completed with failure, otherwise the stream continues and the current element is dropped.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   *
+   * '''Emits when''' the Future returned by the provided function finishes and downstream available.
+   *
+   * '''Backpressures when''' the number of futures reaches the configured parallelism and the downstream
+   * backpressures
+   *
+   * '''Completes when''' upstream completes and all futures have been completed and all elements have been emitted
+   *
+   * '''Cancels when''' downstream cancels
    *
    * @since 1.1.0
    * @see [[#mapAsyncUnordered]]
    * @see [[#mapAsyncPartitioned]]
    */
-  def mapAsyncPartitionedUnordered[T, P](parallelism: Int,
-      extractPartition: function.Function[Out, P],
+  def mapAsyncPartitionedUnordered[T, P](
+      parallelism: Int,
+      partitioner: function.Function[Out, P],
       f: function.Function2[Out, P, CompletionStage[T]]): javadsl.Source[T, Mat] =
-    MapAsyncPartitioned.mapSourceUnordered(delegate, parallelism)(extractPartition(_))(f(_,
-      _).asScala).asJava
+    new Source(delegate.mapAsyncPartitionedUnordered(parallelism)(partitioner(_))(f(_, _).asScala))
 
   /**
    * Transform this stream by applying the given function to each of the elements

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SourceWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SourceWithContext.scala
@@ -169,44 +169,40 @@ final class SourceWithContext[+Out, +Ctx, +Mat](delegate: scaladsl.SourceWithCon
   def map[Out2](f: function.Function[Out, Out2]): SourceWithContext[Out2, Ctx, Mat] =
     viaScala(_.map(f.apply))
 
+  /**
+   * Context-preserving variant of [[pekko.stream.javadsl.Source.mapAsync]].
+   *
+   * @see [[pekko.stream.javadsl.Source.mapAsync]]
+   */
   def mapAsync[Out2](
       parallelism: Int,
       f: function.Function[Out, CompletionStage[Out2]]): SourceWithContext[Out2, Ctx, Mat] =
     viaScala(_.mapAsync[Out2](parallelism)(o => f.apply(o).asScala))
 
   /**
-   * Transforms this stream. Works very similarly to [[#mapAsync]] but with an additional
-   * partition step before the transform step. The transform function receives the an individual
-   * stream entry and the calculated partition value for that entry.
+   * Context-preserving variant of [[pekko.stream.javadsl.Source.mapAsyncPartitioned]].
    *
    * @since 1.1.0
-   * @see [[#mapAsync]]
-   * @see [[#mapAsyncPartitionedUnordered]]
+   * @see [[pekko.stream.javadsl.Source.mapAsyncPartitioned]]
    */
-  def mapAsyncPartitioned[Out2, P](parallelism: Int,
-      extractPartition: function.Function[Out, P],
+  def mapAsyncPartitioned[Out2, P](
+      parallelism: Int,
+      partitioner: function.Function[Out, P],
       f: function.Function2[Out, P, CompletionStage[Out2]]): SourceWithContext[Out2, Ctx, Mat] = {
-    MapAsyncPartitioned.mapSourceWithContextOrdered(delegate, parallelism)(extractPartition(_))(f(_,
-      _).asScala)
-      .asJava
+    viaScala(_.mapAsyncPartitioned(parallelism)(partitioner(_))(f(_, _).asScala))
   }
 
   /**
-   * Transforms this stream. Works very similarly to [[#mapAsyncUnordered]] but with an additional
-   * partition step before the transform step. The transform function receives the an individual
-   * stream entry and the calculated partition value for that entry.
+   * Context-preserving variant of [[pekko.stream.javadsl.Source.mapAsyncPartitionedUnordered]].
    *
    * @since 1.1.0
-   * @see [[#mapAsyncUnordered]]
-   * @see [[#mapAsyncPartitioned]]
+   * @see [[pekko.stream.javadsl.Source.mapAsyncPartitionedUnordered]]
    */
-  def mapAsyncPartitionedUnordered[Out2, P](parallelism: Int,
-      extractPartition: function.Function[Out, P],
-      f: function.Function2[Out, P, CompletionStage[Out2]]): SourceWithContext[Out2, Ctx, Mat] = {
-    MapAsyncPartitioned.mapSourceWithContextUnordered(delegate, parallelism)(extractPartition(_))(f(_,
-      _).asScala)
-      .asJava
-  }
+  def mapAsyncPartitionedUnordered[Out2, P](
+      parallelism: Int,
+      partitioner: function.Function[Out, P],
+      f: function.Function2[Out, P, CompletionStage[Out2]]): SourceWithContext[Out2, Ctx, Mat] =
+    viaScala(_.mapAsyncPartitionedUnordered(parallelism)(partitioner(_))(f(_, _).asScala))
 
   /**
    * Context-preserving variant of [[pekko.stream.javadsl.Source.mapConcat]].

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -349,6 +349,72 @@ class SubFlow[In, Out, Mat](
     new SubFlow(delegate.mapAsyncUnordered(parallelism)(x => f(x).asScala))
 
   /**
+   * Transforms this stream. Works very similarly to [[#mapAsync]] but with an additional
+   * partition step before the transform step. The transform function receives the an individual
+   * stream entry and the calculated partition value for that entry. The max parallelism of per partition is 1.
+   *
+   * The function `partitioner` is always invoked on the elements in the order they arrive.
+   * The function `f` is always invoked on the elements which in the same partition in the order they arrive.
+   *
+   * If the function `partitioner` or `f` throws an exception or if the [[CompletionStage]] is completed
+   * with failure and the supervision decision is [[pekko.stream.Supervision.Stop]]
+   * the stream will be completed with failure, otherwise the stream continues and the current element is dropped.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   *
+   * '''Emits when''' the Future returned by the provided function finishes for the next element in sequence
+   *
+   * '''Backpressures when''' the number of futures reaches the configured parallelism and the downstream
+   * backpressures
+   *
+   * '''Completes when''' upstream completes and all futures have been completed and all elements have been emitted
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @since 1.1.0
+   * @see [[#mapAsync]]
+   * @see [[#mapAsyncPartitionedUnordered]]
+   */
+  def mapAsyncPartitioned[T, P](
+      parallelism: Int,
+      partitioner: function.Function[Out, P],
+      f: function.Function2[Out, P, CompletionStage[T]]): SubFlow[In, T, Mat] =
+    new SubFlow(delegate.mapAsyncPartitioned(parallelism)(partitioner(_))(f(_, _).asScala))
+
+  /**
+   * Transforms this stream. Works very similarly to [[#mapAsyncUnordered]] but with an additional
+   * partition step before the transform step. The transform function receives the an individual
+   * stream entry and the calculated partition value for that entry.The max parallelism of per partition is 1.
+   *
+   * The function `partitioner` is always invoked on the elements in the order they arrive.
+   * The function `f` is always invoked on the elements which in the same partition in the order they arrive.
+   *
+   * If the function `partitioner` or `f` throws an exception or if the [[CompletionStage]] is completed
+   * with failure and the supervision decision is [[pekko.stream.Supervision.Stop]]
+   * the stream will be completed with failure, otherwise the stream continues and the current element is dropped.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   *
+   * '''Emits when''' the Future returned by the provided function finishes and downstream available.
+   *
+   * '''Backpressures when''' the number of futures reaches the configured parallelism and the downstream
+   * backpressures
+   *
+   * '''Completes when''' upstream completes and all futures have been completed and all elements have been emitted
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @since 1.1.0
+   * @see [[#mapAsyncUnordered]]
+   * @see [[#mapAsyncPartitioned]]
+   */
+  def mapAsyncPartitionedUnordered[T, P](
+      parallelism: Int,
+      partitioner: function.Function[Out, P],
+      f: function.Function2[Out, P, CompletionStage[T]]): SubFlow[In, T, Mat] =
+    new SubFlow(delegate.mapAsyncPartitionedUnordered(parallelism)(partitioner(_))(f(_, _).asScala))
+
+  /**
    * Only pass on those elements that satisfy the given predicate.
    *
    * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -340,6 +340,72 @@ class SubSource[Out, Mat](
     new SubSource(delegate.mapAsyncUnordered(parallelism)(x => f(x).asScala))
 
   /**
+   * Transforms this stream. Works very similarly to [[#mapAsync]] but with an additional
+   * partition step before the transform step. The transform function receives the an individual
+   * stream entry and the calculated partition value for that entry. The max parallelism of per partition is 1.
+   *
+   * The function `partitioner` is always invoked on the elements in the order they arrive.
+   * The function `f` is always invoked on the elements which in the same partition in the order they arrive.
+   *
+   * If the function `partitioner` or `f` throws an exception or if the [[CompletionStage]] is completed
+   * with failure and the supervision decision is [[pekko.stream.Supervision.Stop]]
+   * the stream will be completed with failure, otherwise the stream continues and the current element is dropped.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   *
+   * '''Emits when''' the Future returned by the provided function finishes for the next element in sequence
+   *
+   * '''Backpressures when''' the number of futures reaches the configured parallelism and the downstream
+   * backpressures
+   *
+   * '''Completes when''' upstream completes and all futures have been completed and all elements have been emitted
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @since 1.1.0
+   * @see [[#mapAsync]]
+   * @see [[#mapAsyncPartitionedUnordered]]
+   */
+  def mapAsyncPartitioned[T, P](
+      parallelism: Int,
+      partitioner: function.Function[Out, P],
+      f: function.Function2[Out, P, CompletionStage[T]]): SubSource[T, Mat] =
+    new SubSource(delegate.mapAsyncPartitioned(parallelism)(partitioner(_))(f(_, _).asScala))
+
+  /**
+   * Transforms this stream. Works very similarly to [[#mapAsyncUnordered]] but with an additional
+   * partition step before the transform step. The transform function receives the an individual
+   * stream entry and the calculated partition value for that entry.The max parallelism of per partition is 1.
+   *
+   * The function `partitioner` is always invoked on the elements in the order they arrive.
+   * The function `f` is always invoked on the elements which in the same partition in the order they arrive.
+   *
+   * If the function `partitioner` or `f` throws an exception or if the [[CompletionStage]] is completed
+   * with failure and the supervision decision is [[pekko.stream.Supervision.Stop]]
+   * the stream will be completed with failure, otherwise the stream continues and the current element is dropped.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   *
+   * '''Emits when''' the Future returned by the provided function finishes and downstream available.
+   *
+   * '''Backpressures when''' the number of futures reaches the configured parallelism and the downstream
+   * backpressures
+   *
+   * '''Completes when''' upstream completes and all futures have been completed and all elements have been emitted
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @since 1.1.0
+   * @see [[#mapAsyncUnordered]]
+   * @see [[#mapAsyncPartitioned]]
+   */
+  def mapAsyncPartitionedUnordered[T, P](
+      parallelism: Int,
+      partitioner: function.Function[Out, P],
+      f: function.Function2[Out, P, CompletionStage[T]]): SubSource[T, Mat] =
+    new SubSource(delegate.mapAsyncPartitionedUnordered(parallelism)(partitioner(_))(f(_, _).asScala))
+
+  /**
    * Only pass on those elements that satisfy the given predicate.
    *
    * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -164,36 +164,6 @@ final class Flow[-In, +Out, +Mat](
     new Flow(traversalBuilder.transformMat(f), shape)
 
   /**
-   * Transforms this stream. Works very similarly to [[#mapAsync]] but with an additional
-   * partition step before the transform step. The transform function receives the an individual
-   * stream entry and the calculated partition value for that entry.
-   *
-   * @since 1.1.0
-   * @see [[#mapAsync]]
-   * @see [[#mapAsyncPartitionedUnordered]]
-   */
-  def mapAsyncPartitioned[T, P](parallelism: Int)(
-      extractPartition: Out => P)(
-      f: (Out, P) => Future[T]): Flow[In, T, Mat] = {
-    MapAsyncPartitioned.mapFlowOrdered(this, parallelism)(extractPartition)(f)
-  }
-
-  /**
-   * Transforms this stream. Works very similarly to [[#mapAsyncUnordered]] but with an additional
-   * partition step before the transform step. The transform function receives the an individual
-   * stream entry and the calculated partition value for that entry.
-   *
-   * @since 1.1.0
-   * @see [[#mapAsyncUnordered]]
-   * @see [[#mapAsyncPartitioned]]
-   */
-  def mapAsyncPartitionedUnordered[T, P](parallelism: Int)(
-      extractPartition: Out => P)(
-      f: (Out, P) => Future[T]): Flow[In, T, Mat] = {
-    MapAsyncPartitioned.mapFlowUnordered(this, parallelism)(extractPartition)(f)
-  }
-
-  /**
    * Materializes this [[Flow]], immediately returning (1) its materialized value, and (2) a newly materialized [[Flow]].
    * The returned flow is partial materialized and do not support multiple times materialization.
    */
@@ -1172,6 +1142,81 @@ trait FlowOps[+Out, +Mat] {
    * @see [[#mapAsync]]
    */
   def mapAsyncUnordered[T](parallelism: Int)(f: Out => Future[T]): Repr[T] = via(MapAsyncUnordered(parallelism, f))
+
+  /**
+   * Transforms this stream. Works very similarly to [[#mapAsync]] but with an additional
+   * partition step before the transform step. The transform function receives the an individual
+   * stream entry and the calculated partition value for that entry. The max parallelism of per partition is 1.
+   *
+   * The function `partitioner` is always invoked on the elements in the order they arrive.
+   * The function `f` is always invoked on the elements which in the same partition in the order they arrive.
+   *
+   * If the function `partitioner` or `f` throws an exception or if the [[Future]] is completed
+   * with failure and the supervision decision is [[pekko.stream.Supervision.Stop]]
+   * the stream will be completed with failure, otherwise the stream continues and the current element is dropped.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   *
+   * '''Emits when''' the Future returned by the provided function finishes for the next element in sequence
+   *
+   * '''Backpressures when''' the number of futures reaches the configured parallelism and the downstream
+   * backpressures
+   *
+   * '''Completes when''' upstream completes and all futures have been completed and all elements have been emitted
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @since 1.1.0
+   * @see [[#mapAsync]]
+   * @see [[#mapAsyncPartitionedUnordered]]
+   */
+  def mapAsyncPartitioned[T, P](parallelism: Int)(
+      partitioner: Out => P)(
+      f: (Out, P) => Future[T]): Repr[T] = {
+    (if (parallelism == 1) {
+       via(MapAsyncUnordered(1, elem => f(elem, partitioner(elem))))
+     } else {
+       via(new MapAsyncPartitioned(parallelism, orderedOutput = true, partitioner, f))
+     })
+      .withAttributes(DefaultAttributes.mapAsyncPartition and SourceLocation.forLambda(f))
+  }
+
+  /**
+   * Transforms this stream. Works very similarly to [[#mapAsyncUnordered]] but with an additional
+   * partition step before the transform step. The transform function receives the an individual
+   * stream entry and the calculated partition value for that entry.The max parallelism of per partition is 1.
+   *
+   * The function `partitioner` is always invoked on the elements in the order they arrive.
+   * The function `f` is always invoked on the elements which in the same partition in the order they arrive.
+   *
+   * If the function `partitioner` or `f` throws an exception or if the [[Future]] is completed
+   * with failure and the supervision decision is [[pekko.stream.Supervision.Stop]]
+   * the stream will be completed with failure, otherwise the stream continues and the current element is dropped.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   *
+   * '''Emits when''' the Future returned by the provided function finishes and downstream available.
+   *
+   * '''Backpressures when''' the number of futures reaches the configured parallelism and the downstream
+   * backpressures
+   *
+   * '''Completes when''' upstream completes and all futures have been completed and all elements have been emitted
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @since 1.1.0
+   * @see [[#mapAsyncUnordered]]
+   * @see [[#mapAsyncPartitioned]]
+   */
+  def mapAsyncPartitionedUnordered[T, P](parallelism: Int)(
+      partitioner: Out => P)(
+      f: (Out, P) => Future[T]): Repr[T] = {
+    (if (parallelism == 1) {
+       via(MapAsyncUnordered(1, elem => f(elem, partitioner(elem))))
+     } else {
+       via(new MapAsyncPartitioned(parallelism, orderedOutput = false, partitioner, f))
+     }).withAttributes(DefaultAttributes.mapAsyncPartitionUnordered and SourceLocation.forLambda(f))
+  }
 
   /**
    * Use the `ask` pattern to send a request-reply message to the target `ref` actor.

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContext.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.stream.scaladsl
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.concurrent.Future
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.japi.Pair
@@ -89,36 +88,6 @@ final class FlowWithContext[-In, -CtxIn, +Out, +CtxOut, +Mat](delegate: Flow[(In
    */
   def mapMaterializedValue[Mat2](f: Mat => Mat2): FlowWithContext[In, CtxIn, Out, CtxOut, Mat2] =
     new FlowWithContext(delegate.mapMaterializedValue(f))
-
-  /**
-   * Transforms this stream. Works very similarly to [[#mapAsync]] but with an additional
-   * partition step before the transform step. The transform function receives the an individual
-   * stream entry and the calculated partition value for that entry.
-   *
-   * @since 1.1.0
-   * @see [[#mapAsync]]
-   * @see [[#mapAsyncPartitionedUnordered]]
-   */
-  def mapAsyncPartitioned[T, P](parallelism: Int)(
-      extractPartition: Out => P)(
-      f: (Out, P) => Future[T]): FlowWithContext[In, CtxIn, T, CtxOut, Mat] = {
-    MapAsyncPartitioned.mapFlowWithContextOrdered(this, parallelism)(extractPartition)(f)
-  }
-
-  /**
-   * Transforms this stream. Works very similarly to [[#mapAsyncUnordered]] but with an additional
-   * partition step before the transform step. The transform function receives the an individual
-   * stream entry and the calculated partition value for that entry.
-   *
-   * @since 1.1.0
-   * @see [[#mapAsyncUnordered]]
-   * @see [[#mapAsyncPartitioned]]
-   */
-  def mapAsyncPartitionedUnordered[T, P](parallelism: Int)(
-      extractPartition: Out => P)(
-      f: (Out, P) => Future[T]): FlowWithContext[In, CtxIn, T, CtxOut, Mat] = {
-    MapAsyncPartitioned.mapFlowWithContextUnordered(this, parallelism)(extractPartition)(f)
-  }
 
   def asFlow: Flow[(In, CtxIn), (Out, CtxOut), Mat] = delegate
 

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContextOps.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContextOps.scala
@@ -114,6 +114,36 @@ trait FlowWithContextOps[+Out, +Ctx, +Mat] {
     })
 
   /**
+   * Context-preserving variant of [[pekko.stream.scaladsl.FlowOps.mapAsyncPartitioned]].
+   *
+   * @since 1.1.0
+   * @see [[pekko.stream.scaladsl.FlowOps.mapAsyncPartitioned]]
+   */
+  def mapAsyncPartitioned[Out2, P](parallelism: Int)(
+      partitioner: Out => P)(
+      f: (Out, P) => Future[Out2]): Repr[Out2, Ctx] = {
+    via(flow[Out, Ctx].mapAsyncPartitioned(parallelism)(pair => partitioner(pair._1)) {
+      (pair, partition) =>
+        f(pair._1, partition).map((_, pair._2))(ExecutionContexts.parasitic)
+    })
+  }
+
+  /**
+   * Context-preserving variant of [[pekko.stream.scaladsl.FlowOps.mapAsyncPartitionedUnordered]].
+   *
+   * @since 1.1.0
+   * @see [[pekko.stream.scaladsl.FlowOps.mapAsyncPartitionedUnordered]]
+   */
+  def mapAsyncPartitionedUnordered[Out2, P](parallelism: Int)(
+      partitioner: Out => P)(
+      f: (Out, P) => Future[Out2]): Repr[Out2, Ctx] = {
+    via(flow[Out, Ctx].mapAsyncPartitionedUnordered(parallelism)(pair => partitioner(pair._1)) {
+      (pair, partition) =>
+        f(pair._1, partition).map((_, pair._2))(ExecutionContexts.parasitic)
+    })
+  }
+
+  /**
    * Context-preserving variant of [[pekko.stream.scaladsl.FlowOps.collect]].
    *
    * Note, that the context of elements that are filtered out is skipped as well.

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Source.scala
@@ -100,34 +100,6 @@ final class Source[+Out, +Mat](
     new Source[Out, Mat2](traversalBuilder.transformMat(f.asInstanceOf[Any => Any]), shape)
 
   /**
-   * Transforms this stream. Works very similarly to [[#mapAsync]] but with an additional
-   * partition step before the transform step. The transform function receives the an individual
-   * stream entry and the calculated partition value for that entry.
-   *
-   * @since 1.1.0
-   * @see [[#mapAsync]]
-   * @see [[#mapAsyncPartitionedUnordered]]
-   */
-  def mapAsyncPartitioned[T, P](parallelism: Int)(
-      extractPartition: Out => P)(f: (Out, P) => Future[T]): Source[T, Mat] = {
-    MapAsyncPartitioned.mapSourceOrdered(this, parallelism)(extractPartition)(f)
-  }
-
-  /**
-   * Transforms this stream. Works very similarly to [[#mapAsyncUnordered]] but with an additional
-   * partition step before the transform step. The transform function receives the an individual
-   * stream entry and the calculated partition value for that entry.
-   *
-   * @since 1.1.0
-   * @see [[#mapAsyncUnordered]]
-   * @see [[#mapAsyncPartitioned]]
-   */
-  def mapAsyncPartitionedUnordered[T, P](parallelism: Int)(
-      extractPartition: Out => P)(f: (Out, P) => Future[T]): Source[T, Mat] = {
-    MapAsyncPartitioned.mapSourceUnordered(this, parallelism)(extractPartition)(f)
-  }
-
-  /**
    * Materializes this Source, immediately returning (1) its materialized value, and (2) a new Source
    * that can be used to consume elements from the newly materialized Source.
    */

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/SourceWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/SourceWithContext.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.stream.scaladsl
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.concurrent.Future
 import org.apache.pekko
 import pekko.stream._
 
@@ -77,34 +76,6 @@ final class SourceWithContext[+Out, +Ctx, +Mat] private[stream] (delegate: Sourc
    */
   def mapMaterializedValue[Mat2](f: Mat => Mat2): SourceWithContext[Out, Ctx, Mat2] =
     new SourceWithContext(delegate.mapMaterializedValue(f))
-
-  /**
-   * Transforms this stream. Works very similarly to [[#mapAsync]] but with an additional
-   * partition step before the transform step. The transform function receives the an individual
-   * stream entry and the calculated partition value for that entry.
-   *
-   * @since 1.1.0
-   * @see [[#mapAsync]]
-   * @see [[#mapAsyncPartitionedUnordered]]
-   */
-  def mapAsyncPartitioned[T, P](parallelism: Int)(
-      extractPartition: Out => P)(f: (Out, P) => Future[T]): SourceWithContext[T, Ctx, Mat] = {
-    MapAsyncPartitioned.mapSourceWithContextOrdered(this, parallelism)(extractPartition)(f)
-  }
-
-  /**
-   * Transforms this stream. Works very similarly to [[#mapAsyncUnordered]] but with an additional
-   * partition step before the transform step. The transform function receives the an individual
-   * stream entry and the calculated partition value for that entry.
-   *
-   * @since 1.1.0
-   * @see [[#mapAsyncUnordered]]
-   * @see [[#mapAsyncPartitioned]]
-   */
-  def mapAsyncPartitionedUnordered[T, P](parallelism: Int)(
-      extractPartition: Out => P)(f: (Out, P) => Future[T]): SourceWithContext[T, Ctx, Mat] = {
-    MapAsyncPartitioned.mapSourceWithContextUnordered(this, parallelism)(extractPartition)(f)
-  }
 
   /**
    * Connect this [[pekko.stream.scaladsl.SourceWithContext]] to a [[pekko.stream.scaladsl.Sink]],


### PR DESCRIPTION
Motivation: 
1. Tweak the mapAsyncPartitioned  & mapAsyncPartitionedUnordered  document
2. Removed some methods which is used only once.
3. Add these method to SubSource and SubFlow.

refs: https://github.com/apache/incubator-pekko/pull/561