### PR TITLE
feat: Immutable builder for interceptor and supervisor

### DIFF
--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/Behaviors.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/Behaviors.scala
@@ -170,6 +170,13 @@ object Behaviors {
     BehaviorImpl.intercept(behaviorInterceptor)(behavior)
 
   /**
+   * Immutable builder used for creating interceptor or supervisor of [[Behavior]] by 'chaining'.
+   * @tparam T the common superclass of all supported messages.
+   */
+  def interceptorBuilder[T](initialBehavior: Behavior[T]): InterceptorBuilder[T] =
+    InterceptorBuilder(initialBehavior)
+
+  /**
    * Behavior decorator that copies all received message to the designated
    * monitor [[pekko.actor.typed.ActorRef]] before invoking the wrapped behavior. The
    * wrapped behavior can evolve (i.e. return different behavior) without needing to be

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/InterceptorBuilder.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/InterceptorBuilder.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.actor.typed.scaladsl
+
+import org.apache.pekko
+import org.apache.pekko.actor.typed.Behavior
+import org.apache.pekko.actor.typed.BehaviorInterceptor
+import org.apache.pekko.actor.typed.SupervisorStrategy
+import org.apache.pekko.actor.typed.internal.BehaviorImpl
+import org.apache.pekko.actor.typed.scaladsl.Behaviors.Supervise
+import org.apache.pekko.actor.typed.scaladsl.Behaviors.ThrowableClassTag
+
+import scala.reflect.ClassTag
+import scala.reflect.classTag
+
+/**
+ * Immutable builder for [[pekko.actor.typed.scaladsl.Behaviors.intercept]]
+ */
+object InterceptorBuilder {
+  def apply[T](initialBehavior: Behavior[T]): InterceptorBuilder[T] = {
+    new InterceptorBuilder[T](initialBehavior)
+  }
+}
+
+class InterceptorBuilder[T](initialBehavior: Behavior[T]) {
+
+  private var currentBehavior: Behavior[T] = initialBehavior
+
+
+  /**
+   * Specify the [[SupervisorStrategy]] to be invoked when the wrapped behavior throws. The simple way of as [[Behaviors.supervise]]
+   */
+  def onFailure[Thr <: Throwable](strategy: SupervisorStrategy)(
+    implicit tag: ClassTag[Thr] = ThrowableClassTag): InterceptorBuilder[T] = {
+    currentBehavior = new Supervise[T](currentBehavior).onFailure(strategy)(classTag)
+    this
+  }
+
+  /**
+   * Intercept messages and signals for a `behavior` by first passing them to a [[pekko.actor.typed.BehaviorInterceptor]]
+   * The simple way of as [[Behaviors.intercept]]
+   */
+  def intercept[O](behaviorInterceptor: () => BehaviorInterceptor[O, T]): InterceptorBuilder[O] =
+    new InterceptorBuilder(BehaviorImpl.intercept(behaviorInterceptor)(currentBehavior))
+
+  /**
+   * Build the final Behavior from the current state of the builder
+   */
+  def build(): Behavior[T] = {
+    currentBehavior
+  }
+
+
+}


### PR DESCRIPTION
Draft because I haven't verified everything and I am not sure if this is the optimal approach.

Example usage could be like this:

```scala
val rawBehavior: Behavior[Command] = Behaviors.empty
val interceptor : BehaviorInterceptor[Command,Command] = ???
val monitorProbe = TestProbe[Command]("probe")

val behavior: Behavior[Command] = Behaviors.interceptorBuilder(rawBehavior)
  .onFailure[Exc1](SupervisorStrategy.restart.withStashCapacity(100))
  .onFailure[Exc2](SupervisorStrategy.restart.withStashCapacity(100))
  .intercept[Command](() => interceptor)
  .onFailure[Exc3](SupervisorStrategy.restart.withStashCapacity(100))
  .monitor(monitorProbe.ref)
  .build()
```