### PR TITLE
Update LineNumberSpec because it fails after Scala 3.3.1 upgrade

### DIFF
--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -28,7 +28,7 @@ jobs:
           - persistence/test persistence-shared/test persistence-query/test persistence-typed/test persistence-testkit/test persistence-tck/test persistence-typed-tests/test
           - pki/test slf4j/test
           - serialization-jackson/test
-          - stream/test stream-testkit/test stream-tests/test stream-typed/test
+          - stream/test stream-testkit/test stream-tests/test stream-typed/test stream-typed-tests/test
           - stream-tests-tck/test
           - remote/test remote-tests/test protobuf-v3/test
       fail-fast: true

--- a/actor-tests/src/test/scala-3/org/apache/pekko/util/LineNumberSpec.scala
+++ b/actor-tests/src/test/scala-3/org/apache/pekko/util/LineNumberSpec.scala
@@ -30,7 +30,7 @@ class LineNumberSpec extends PekkoSpec {
 
       "work for larger functions" in {
         val result = LineNumbers(twoline)
-        result should ===(SourceFileLines("LineNumberSpecCodeForScala.scala", 24, 26))
+        result should ===(SourceFileLines("LineNumberSpecCodeForScala.scala", 25, 26))
       }
 
       "work for partial functions" in {
@@ -39,7 +39,7 @@ class LineNumberSpec extends PekkoSpec {
 
       "work for `def`" in {
         val result = LineNumbers(method("foo"))
-        result should ===(SourceFileLines("LineNumberSpecCodeForScala.scala", 34, 36))
+        result should ===(SourceFileLines("LineNumberSpecCodeForScala.scala", 35, 36))
       }
 
     }


### PR DESCRIPTION
see https://github.com/apache/incubator-pekko/issues/663