### PR TITLE
sbt-assembly 2.1.3

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.3")
 
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.7.0")
 addSbtPlugin("com.lightbend.sbt" % "sbt-bill-of-materials" % "1.0.2")


### PR DESCRIPTION
* relates to #685 
* upgrading will probably not fix the zip64 issue but it is better for us to be using latest release if any future patches are made