### PR TITLE
revert some scaladoc changes because of scala 2.12 build issues

### DIFF
--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/ReplicatedEntityProvider.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/ReplicatedEntityProvider.scala
@@ -34,7 +34,7 @@ object ReplicatedEntityProvider {
   /**
    * Java API:
    *
-   * Provides full control over the [[ReplicatedEntity]] and the [[javadsl.Entity]]
+   * Provides full control over the [[ReplicatedEntity]] and the [[Entity]]
    * Most use cases can use the [[createPerDataCenter]] and [[createPerRole]]
    *
    * @tparam M The type of messages the replicated entity accepts
@@ -53,10 +53,10 @@ object ReplicatedEntityProvider {
   /**
    * Scala API:
    *
-   * Provides full control over the [[ReplicatedEntity]] and the [[scaladsl.Entity]]
+   * Provides full control over the [[ReplicatedEntity]] and the [[Entity]]
    * Most use cases can use the [[perDataCenter]] and [[perRole]]
    *
-   * @param typeName The type name used in the [[scaladsl.EntityTypeKey]]
+   * @param typeName The type name used in the [[EntityTypeKey]]
    * @tparam M The type of messages the replicated entity accepts
    */
   def apply[M: ClassTag](typeName: String, allReplicaIds: Set[ReplicaId])(
@@ -75,7 +75,7 @@ object ReplicatedEntityProvider {
   /**
    * Scala API
    *
-   * Create a [[ReplicatedEntityProvider]] that uses the defaults for [[scaladsl.Entity]] when running in
+   * Create a [[ReplicatedEntityProvider]] that uses the defaults for [[Entity]] when running in
    * ClusterSharding. A replica will be run per data center.
    */
   def perDataCenter[M: ClassTag, E](typeName: String, allReplicaIds: Set[ReplicaId])(
@@ -91,7 +91,7 @@ object ReplicatedEntityProvider {
   /**
    * Scala API
    *
-   * Create a [[ReplicatedEntityProvider]] that uses the defaults for [[scaladsl.Entity]] when running in
+   * Create a [[ReplicatedEntityProvider]] that uses the defaults for [[Entity]] when running in
    * ClusterSharding. The replicas in allReplicaIds should be roles used by nodes. A replica for each
    * entity will run on each role.
    */
@@ -108,7 +108,7 @@ object ReplicatedEntityProvider {
   /**
    * Java API
    *
-   * Create a [[ReplicatedEntityProvider]] that uses the defaults for [[scaladsl.Entity]] when running in
+   * Create a [[ReplicatedEntityProvider]] that uses the defaults for [[Entity]] when running in
    * ClusterSharding. A replica will be run per data center.
    */
   def createPerDataCenter[M](
@@ -128,7 +128,7 @@ object ReplicatedEntityProvider {
   /**
    * Java API
    *
-   * Create a [[ReplicatedEntityProvider]] that uses the defaults for [[scaladsl.Entity]] when running in
+   * Create a [[ReplicatedEntityProvider]] that uses the defaults for [[Entity]] when running in
    * ClusterSharding.
    *
    * Map replicas to roles and then there will be a replica per role e.g. to match to availability zones/racks

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/ShardingMessageExtractor.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/ShardingMessageExtractor.scala
@@ -118,7 +118,7 @@ abstract class HashCodeNoEnvelopeMessageExtractor[M](val numberOfShards: Int) ex
  *
  * @param entityId The business domain identifier of the entity.
  * @param message The message to be send to the entity.
- * @throws pekko.actor.InvalidMessageException if message is null.
+ * @throws `InvalidMessageException` if message is null.
  */
 final case class ShardingEnvelope[M](entityId: String, message: M) extends WrappedMessage {
   if (message == null) throw InvalidMessageException("[null] is not an allowed message")

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/ShardingConsumerController.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/ShardingConsumerController.scala
@@ -33,13 +33,13 @@ import pekko.cluster.sharding.typed.delivery.internal.ShardingConsumerController
  * `ShardingConsumerController` is the entity that is initialized in `ClusterSharding`. It will manage
  * the lifecycle and message delivery to the destination consumer actor.
  *
- * The destination consumer actor will start the flow by sending an initial [[pekko.actor.typed.delivery.ConsumerController.Start]]
+ * The destination consumer actor will start the flow by sending an initial [[ConsumerController.Start]]
  * message via the `ActorRef` provided in the factory function of the consumer `Behavior`.
  * The `ActorRef` in the `Start` message is typically constructed as a message adapter to map the
- * [[pekko.actor.typed.delivery.ConsumerController.Delivery]] to the protocol of the consumer actor.
+ * [[ConsumerController.Delivery]] to the protocol of the consumer actor.
  *
- * Received messages from the producer are wrapped in [[pekko.actor.typed.delivery.ConsumerController.Delivery]] when sent to the consumer,
- * which is supposed to reply with [[pekko.actor.typed.delivery.ConsumerController.Confirmed]] when it has processed the message.
+ * Received messages from the producer are wrapped in [[ConsumerController.Delivery]] when sent to the consumer,
+ * which is supposed to reply with [[ConsumerController.Confirmed]] when it has processed the message.
  * Next message from a specific producer is not delivered until the previous is confirmed. However, since
  * there can be several producers, e.g. one per node, sending to the same destination entity there can be
  * several `Delivery` in flight at the same time.

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/ShardingProducerController.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/ShardingProducerController.scala
@@ -76,7 +76,7 @@ import pekko.util.OptionConverters._
  * Until sent messages have been confirmed the `ShardingProducerController` keeps them in memory to be able to
  * resend them. If the JVM of the `ShardingProducerController` crashes those unconfirmed messages are lost.
  * To make sure the messages can be delivered also in that scenario the `ShardingProducerController` can be
- * used with a [[pekko.actor.typed.delivery.DurableProducerQueue]]. Then the unconfirmed messages are stored in a durable way so
+ * used with a [[DurableProducerQueue]]. Then the unconfirmed messages are stored in a durable way so
  * that they can be redelivered when the producer is started again. An implementation of the
  * `DurableProducerQueue` is provided by `EventSourcedProducerQueue` in `pekko-persistence-typed`.
  *

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/javadsl/ClusterSharding.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/javadsl/ClusterSharding.scala
@@ -439,13 +439,13 @@ object EntityTypeKey {
 /**
  * A reference to an sharded Entity, which allows `ActorRef`-like usage.
  *
- * An [[EntityRef]] is NOT an [[pekko.actor.typed.ActorRef ActorRef]]–by design–in order to be explicit about the fact that the life-cycle
+ * An [[EntityRef]] is NOT an [[ActorRef]]–by design–in order to be explicit about the fact that the life-cycle
  * of a sharded Entity is very different than a plain Actor. Most notably, this is shown by features of Entities
  * such as re-balancing (an active Entity to a different node) or passivation. Both of which are aimed to be completely
  * transparent to users of such Entity. In other words, if this were to be a plain ActorRef, it would be possible to
  * apply DeathWatch to it, which in turn would then trigger when the sharded Actor stopped, breaking the illusion that
  * Entity refs are "always there". Please note that while not encouraged, it is possible to expose an Actor's `self`
- * [[pekko.actor.typed.ActorRef ActorRef]] and watch it in case such notification is desired.
+ * [[ActorRef]] and watch it in case such notification is desired.
  *
  * Not for user extension.
  */

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/scaladsl/ClusterSharding.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/scaladsl/ClusterSharding.scala
@@ -416,13 +416,13 @@ object EntityTypeKey {
 /**
  * A reference to an sharded Entity, which allows `ActorRef`-like usage.
  *
- * An [[EntityRef]] is NOT an [[pekko.actor.typed.ActorRef ActorRef]]–by design–in order to be explicit about the fact that the life-cycle
+ * An [[EntityRef]] is NOT an [[ActorRef]]–by design–in order to be explicit about the fact that the life-cycle
  * of a sharded Entity is very different than a plain Actors. Most notably, this is shown by features of Entities
  * such as re-balancing (an active Entity to a different node) or passivation. Both of which are aimed to be completely
  * transparent to users of such Entity. In other words, if this were to be a plain ActorRef, it would be possible to
  * apply DeathWatch to it, which in turn would then trigger when the sharded Actor stopped, breaking the illusion that
  * Entity refs are "always there". Please note that while not encouraged, it is possible to expose an Actor's `self`
- * [[pekko.actor.typed.ActorRef ActorRef]] and watch it in case such notification is desired.
+ * [[ActorRef]] and watch it in case such notification is desired.
  * Not for user extension.
  */
 @DoNotInherit trait EntityRef[-M] extends RecipientRef[M] { this: InternalRecipientRef[M] =>
@@ -544,7 +544,7 @@ object ClusterShardingSetup {
 }
 
 /**
- * Can be used in [[pekko.actor.setup.ActorSystemSetup]] when starting the [[pekko.actor.typed.ActorSystem]]
+ * Can be used in [[pekko.actor.setup.ActorSystemSetup]] when starting the [[ActorSystem]]
  * to replace the default implementation of the [[ClusterSharding]] extension. Intended
  * for tests that need to replace extension with stub/mock implementations.
  */

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/testkit/javadsl/EntityRef.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/testkit/javadsl/EntityRef.scala
@@ -20,7 +20,7 @@ import pekko.cluster.sharding.typed.javadsl.EntityRef
 import pekko.cluster.sharding.typed.javadsl.EntityTypeKey
 
 /**
- * For testing purposes this `EntityRef` can be used in place of a real [[pekko.cluster.sharding.typed.javadsl.EntityRef]].
+ * For testing purposes this `EntityRef` can be used in place of a real [[EntityRef]].
  * It forwards all messages to the `probe`.
  */
 object TestEntityRef {

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/testkit/scaladsl/EntityRef.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/testkit/scaladsl/EntityRef.scala
@@ -20,7 +20,7 @@ import pekko.cluster.sharding.typed.scaladsl.EntityRef
 import pekko.cluster.sharding.typed.scaladsl.EntityTypeKey
 
 /**
- * For testing purposes this `EntityRef` can be used in place of a real [[pekko.cluster.sharding.typed.scaladsl.EntityRef]].
+ * For testing purposes this `EntityRef` can be used in place of a real [[EntityRef]].
  * It forwards all messages to the `probe`.
  */
 object TestEntityRef {


### PR DESCRIPTION
I've tested this and this revert allows me to publish the pekko-cluster-sharding-typed jar locally while it fails without this revert.

Reverts part of #682 