### PR TITLE
Update Netty to 4.1.100.final

### DIFF
--- a/docs/src/main/paradox/additional/osgi.md
+++ b/docs/src/main/paradox/additional/osgi.md
@@ -16,7 +16,7 @@ To use Apache Pekko in OSGi, you must add the following dependency in your proje
 ## Background
 
 [OSGi](https://www.osgi.org/resources/where-to-start/) is a mature packaging and deployment standard for component-based systems. It
-has similar capabilities as [Project Jigsaw](https://openjdk.java.net/projects/jigsaw/) (originally scheduled for JDK 1.8), but has far stronger facilities to
+has similar capabilities as [Project Jigsaw](https://openjdk.org/projects/jigsaw/) (originally scheduled for JDK 1.8), but has far stronger facilities to
 support legacy Java code. This is to say that while Jigsaw-ready modules require significant changes to most source files
 and on occasion to the structure of the overall application, OSGi can be used to modularize almost any Java code as far
 back as JDK 1.2, usually with no changes at all to the binaries.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,7 +28,7 @@ object Dependencies {
   // needs to be inline with the aeron version, check
   // https://github.com/real-logic/aeron/blob/1.x.y/build.gradle
   val agronaVersion = "1.19.2"
-  val nettyVersion = "4.1.98.Final"
+  val nettyVersion = "4.1.99.Final"
   val protobufJavaVersion = "3.19.6"
   val logbackVersion = "1.2.11"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,7 +28,7 @@ object Dependencies {
   // needs to be inline with the aeron version, check
   // https://github.com/real-logic/aeron/blob/1.x.y/build.gradle
   val agronaVersion = "1.19.2"
-  val nettyVersion = "4.1.99.Final"
+  val nettyVersion = "4.1.100.Final"
   val protobufJavaVersion = "3.19.6"
   val logbackVersion = "1.2.11"
 


### PR DESCRIPTION
## Motivation

Netty 4.1.98.Final was an unsafe version:

- crash the JVM when using JDK21+
- HTTP/2 Rapid Reset Attack 

## References

- https://mail.openjdk.org/pipermail/hotspot-gc-dev/2023-September/043696.html
- https://netty.io/news/2023/09/21/4-1-99-Final.html
- https://nvd.nist.gov/vuln/detail/CVE-2023-44487
- https://netty.io/news/2023/10/10/4-1-100-Final.html