### PR TITLE
Add more ignored dependencies to .scala-steward.conf

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -11,6 +11,8 @@ updates.ignore = [
   { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-jsr310" }
   { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-jdk8" }
   { groupId = "com.google.protobuf", artifactId = "protobuf-java" }
+  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox-project-info" }
+  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox "}
   { groupId = "com.typesafe", artifactId = "ssl-config-core" }
   { groupId = "com.typesafe.sbt", artifactId = "sbt-osgi" }
   { groupId = "org.agrona", artifactId = "agrona" }


### PR DESCRIPTION
These cannot be updated until we drop JDK 8