### PR TITLE
Fix naming in generate doc check

### DIFF
--- a/.github/workflows/generate-doc-check.yml
+++ b/.github/workflows/generate-doc-check.yml
@@ -1,0 +1,53 @@
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Generate doc check
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  generate-doc-check:
+    name: Generate doc check
+    runs-on: ubuntu-20.04
+    if: github.repository == 'apache/incubator-pekko'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup Java 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v6
+
+      - name: Install Graphviz
+        run: |-
+          sudo apt-get install graphviz
+
+      - name: Compile docs for all Scala versions
+        run: sbt +compile:doc


### PR DESCRIPTION
(cherry picked from commit b558a28a434750c473d72974a9ffd2ae82e8118e)