### PR TITLE
use slf4j v2

### DIFF
--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/StubbedActorContext.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/StubbedActorContext.scala
@@ -17,14 +17,14 @@ import org.apache.pekko
 import pekko.actor.testkit.typed.CapturedLogEvent
 import pekko.actor.typed._
 import pekko.actor.typed.internal._
-import pekko.actor.{ ActorPath, ActorRefProvider, InvalidMessageException }
+import pekko.actor.{ActorPath, ActorRefProvider, InvalidMessageException}
 import pekko.annotation.InternalApi
 import pekko.util.Helpers
-import pekko.{ actor => classic }
-import org.slf4j.Logger
-import org.slf4j.helpers.{ MessageFormatter, SubstituteLoggerFactory }
+import pekko.{actor => classic}
+import org.slf4j.{Logger, Marker}
+import org.slf4j.helpers.{MessageFormatter, SubstituteLoggerFactory}
 
-import java.util.concurrent.ThreadLocalRandom.{ current => rnd }
+import java.util.concurrent.ThreadLocalRandom.{current => rnd}
 import scala.collection.immutable.TreeMap
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration.FiniteDuration
@@ -242,13 +242,15 @@ private[pekko] final class FunctionRef[-T](override val path: ActorPath, send: (
     substituteLoggerFactory.getEventQueue
       .iterator()
       .asScala
-      .map { evt =>
+      .map { evt => {
+        val marker: Option[Marker] = Option(evt.getMarkers).flatMap(_.asScala.headOption)
         CapturedLogEvent(
           level = evt.getLevel,
           message = MessageFormatter.arrayFormat(evt.getMessage, evt.getArgumentArray).getMessage,
           cause = Option(evt.getThrowable),
-          marker = Option(evt.getMarker))
-      }
+          marker = marker)
+
+      }}
       .toList
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
     .withRank(KeyRanks.Invisible) // avoid 'unused key' warning
 
   val junitVersion = "4.13.2"
-  val slf4jVersion = "1.7.36"
+  val slf4jVersion = "2.0.9"
   // check agrona version when updating this
   val aeronVersion = "1.42.1"
   // needs to be inline with the aeron version, check
@@ -30,7 +30,7 @@ object Dependencies {
   val agronaVersion = "1.19.2"
   val nettyVersion = "4.1.100.Final"
   val protobufJavaVersion = "3.19.6"
-  val logbackVersion = "1.2.12"
+  val logbackVersion = "1.3.11"
 
   val jacksonCoreVersion = "2.14.3"
   val jacksonDatabindVersion = jacksonCoreVersion


### PR DESCRIPTION
* more complicated than #733 
* need logback 1.3 because it supports slf4j 2 and jsk 8 (logback 1.4 drops jdk 8 support)