### PR TITLE
[DRAFT] protobuf-java 3.21

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,7 +29,7 @@ object Dependencies {
   // https://github.com/real-logic/aeron/blob/1.x.y/build.gradle
   val agronaVersion = "1.19.2"
   val nettyVersion = "4.1.100.Final"
-  val protobufJavaVersion = "3.19.6"
+  val protobufJavaVersion = "3.21.12"
   val logbackVersion = "1.3.11"
 
   val jacksonCoreVersion = "2.14.3"


### PR DESCRIPTION
causes 1 test to fail with
```
2023-10-21T05:57:40.8811437Z 2023-10-21 05:57:32,513 ERROR org.apache.pekko.actor.ActorSystemImpl SECURITY - Uncaught error from thread [DataCenterReplicatedShardingSpec-pekko.remote.default-remote-dispatcher-11]: java.nio.ByteBuffer.position(I)Ljava/nio/ByteBuffer;, shutting down JVM since 'pekko.jvm-exit-on-fatal-error' is enabled for ActorSystem[DataCenterReplicatedShardingSpec] MDC: {pekkoUid=-3772597020781846367, sourceThread=DataCenterReplicatedShardingSpec-pekko.remote.default-remote-dispatcher-11, sourceActorSystem=DataCenterReplicatedShardingSpec, pekkoAddress=pekko://DataCenterReplicatedShardingSpec@10.1.0.186:44831, pekkoSource=org.apache.pekko.actor.ActorSystemImpl(DataCenterReplicatedShardingSpec), pekkoTimestamp=05:57:32.512UTC}
2023-10-21T05:57:40.8817348Z java.lang.NoSuchMethodError: java.nio.ByteBuffer.position(I)Ljava/nio/ByteBuffer;
2023-10-21T05:57:40.8818918Z 	at org.apache.pekko.protobufv3.internal.CodedOutputStream$UnsafeDirectNioEncoder.writeStringNoTag(CodedOutputStream.java:2153)
2023-10-21T05:57:40.8820839Z 	at org.apache.pekko.protobufv3.internal.CodedOutputStream$UnsafeDirectNioEncoder.writeString(CodedOutputStream.java:1922)
2023-10-21T05:57:40.8822551Z 	at org.apache.pekko.protobufv3.internal.GeneratedMessageV3.writeString(GeneratedMessageV3.java:3195)
2023-10-21T05:57:40.8824395Z 	at org.apache.pekko.cluster.sharding.typed.internal.protobuf.ShardingMessages$ShardingEnvelope.writeTo(ShardingMessages.java:260)
2023-10-21T05:57:40.8826308Z 	at org.apache.pekko.cluster.sharding.typed.internal.ShardingSerializer.toBinary(ShardingSerializer.scala:76)
2023-10-21T05:57:40.8827885Z 	at org.apache.pekko.remote.MessageSerializer$.serializeForArtery(MessageSerializer.scala:97)
2023-10-21T05:57:40.8829159Z 	at org.apache.pekko.remote.artery.Encoder$$anon$1.onPush(Codecs.scala:157)
2023-10-21T05:57:40.8830455Z 	at org.apache.pekko.stream.impl.fusing.GraphInterpreter.processPush(GraphInterpreter.scala:556)
2023-10-21T05:57:40.8831922Z 	at org.apache.pekko.stream.impl.fusing.GraphInterpreter.execute(GraphInterpreter.scala:434)
2023-10-21T05:57:40.8833496Z 	at org.apache.pekko.stream.impl.fusing.GraphInterpreterShell.runBatch(ActorGraphInterpreter.scala:662)
2023-10-21T05:57:40.8835179Z 	at org.apache.pekko.stream.impl.fusing.GraphInterpreterShell$AsyncInput.execute(ActorGraphInterpreter.scala:532)
2023-10-21T05:57:40.8836899Z 	at org.apache.pekko.stream.impl.fusing.GraphInterpreterShell.processEvent(ActorGraphInterpreter.scala:637)
2023-10-21T05:57:40.8838981Z 	at org.apache.pekko.stream.impl.fusing.ActorGraphInterpreter.org$apache$pekko$stream$impl$fusing$ActorGraphInterpreter$$processEvent(ActorGraphInterpreter.scala:813)
2023-10
```