### PR TITLE
turn off static imports format for java formatter.

### DIFF
--- a/actor-typed-tests/src/test/java/jdocs/org/apache/pekko/typed/AggregatorTest.java
+++ b/actor-typed-tests/src/test/java/jdocs/org/apache/pekko/typed/AggregatorTest.java
@@ -36,10 +36,12 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+// format: off
 import static jdocs.org.apache.pekko.typed.AggregatorTest.IllustrateUsage.HotelCustomer;
 import static jdocs.org.apache.pekko.typed.AggregatorTest.IllustrateUsage.Hotel1;
 import static jdocs.org.apache.pekko.typed.AggregatorTest.IllustrateUsage.Hotel2;
 import static org.junit.Assert.assertEquals;
+// format: on
 
 public class AggregatorTest extends JUnitSuite {
   @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource();

--- a/actor-typed-tests/src/test/java/org/apache/pekko/actor/typed/javadsl/ActorContextPipeToSelfTest.java
+++ b/actor-typed-tests/src/test/java/org/apache/pekko/actor/typed/javadsl/ActorContextPipeToSelfTest.java
@@ -30,8 +30,10 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+// format: off
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.*;
+// format: on
 
 public final class ActorContextPipeToSelfTest extends JUnitSuite {
 

--- a/cluster-sharding-typed/src/test/java/org/apache/pekko/cluster/sharding/typed/ReplicatedShardingTest.java
+++ b/cluster-sharding-typed/src/test/java/org/apache/pekko/cluster/sharding/typed/ReplicatedShardingTest.java
@@ -42,8 +42,10 @@ import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
+// format: off
 import static org.apache.pekko.cluster.sharding.typed.ReplicatedShardingTest.ProxyActor.ALL_REPLICAS;
 import static org.junit.Assert.assertEquals;
+// format: on
 
 public class ReplicatedShardingTest extends JUnitSuite {
 

--- a/persistence-typed-tests/src/test/java/jdocs/org/apache/pekko/persistence/typed/ReplicatedAuctionExampleTest.java
+++ b/persistence-typed-tests/src/test/java/jdocs/org/apache/pekko/persistence/typed/ReplicatedAuctionExampleTest.java
@@ -48,9 +48,11 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+// format: off
 import static jdocs.org.apache.pekko.persistence.typed.AuctionEntity.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+// format: on
 
 public class ReplicatedAuctionExampleTest extends JUnitSuite {
   @ClassRule


### PR DESCRIPTION
refs: https://github.com/apache/incubator-pekko/pull/723 & https://github.com/apache/incubator-pekko/pull/593

Update: When I run the format on Windows, there are `314` files change, so better to leave it in this pr.
