### PR TITLE
Update typesafe:config to 1.4.3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,7 +58,7 @@ object Dependencies {
   object Compile {
     // Compile
 
-    val config = "com.typesafe" % "config" % "1.4.2"
+    val config = "com.typesafe" % "config" % "1.4.3"
     val netty = "io.netty" % "netty" % nettyVersion
 
     val scalaReflect = ScalaVersionDependentModuleID.versioned("org.scala-lang" % "scala-reflect" % _)


### PR DESCRIPTION
cherry pick 00c6bac1a70d2e0dc0408a4699d136d599855462

needed for this new method https://github.com/lightbend/config/pull/798

see https://akka.io/security/akka-cve-2023-45865.html
