### PR TITLE
Remove invalid comment

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,8 +37,6 @@ object Dependencies {
 
   val scala212Version = "2.12.18"
   val scala213Version = "2.13.12"
-  // To get the fix for https://github.com/lampepfl/dotty/issues/13106
-  // and restored static forwarders
   val scala3Version = "3.3.1"
   val allScalaVersions = Seq(scala213Version, scala212Version, scala3Version)
 


### PR DESCRIPTION
This no longer applies (I think its leftover from when Akka used to use dotty nightly/pre-release versions to get around bugs).