### PR TITLE
small change to allow pekko-actor-testkit-typed to work with slf4j-api v2

### DIFF
--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -90,3 +90,6 @@ jobs:
           -Dsbt.log.noformat=false \
           -Dpekko.log.timestamps=true \
           validatePullRequest
+
+      - name: sbt actor-typed-tests/test (with slf4j2)
+        run: sbt -Dpekko.test.slf4j2=true actor-typed-tests/test

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/StubbedActorContext.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/StubbedActorContext.scala
@@ -21,7 +21,7 @@ import pekko.actor.{ ActorPath, ActorRefProvider, InvalidMessageException }
 import pekko.annotation.InternalApi
 import pekko.util.Helpers
 import pekko.{ actor => classic }
-import org.slf4j.Logger
+import org.slf4j.{ Logger, Marker }
 import org.slf4j.helpers.{ MessageFormatter, SubstituteLoggerFactory }
 
 import java.util.concurrent.ThreadLocalRandom.{ current => rnd }
@@ -243,11 +243,17 @@ private[pekko] final class FunctionRef[-T](override val path: ActorPath, send: (
       .iterator()
       .asScala
       .map { evt =>
+        val marker: Option[Marker] =
+          try {
+            Option(evt.getMarker)
+          } catch {
+            case _: NoSuchMethodError => None // evt.getMarker was replaced in slf4j v2 with evt.getMarkers
+          }
         CapturedLogEvent(
           level = evt.getLevel,
           message = MessageFormatter.arrayFormat(evt.getMessage, evt.getArgumentArray).getMessage,
           cause = Option(evt.getThrowable),
-          marker = Option(evt.getMarker))
+          marker = marker)
       }
       .toList
   }

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/StubbedActorContext.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/StubbedActorContext.scala
@@ -265,7 +265,7 @@ private[pekko] final class FunctionRef[-T](override val path: ActorPath, send: (
     try {
       val method = classOf[SubstituteLoggingEvent].getMethod("getMarkers")
       val markers = method.invoke(evt).asInstanceOf[java.util.List[Marker]]
-      if (markers.isEmpty) None else Some(markers.get(0))
+      if (markers == null || markers.isEmpty) None else Some(markers.get(0))
     } catch {
       case _: NoSuchMethodException => None
     }

--- a/build.sbt
+++ b/build.sbt
@@ -586,6 +586,7 @@ lazy val actorTestkitTyped = pekkoModule("actor-testkit-typed")
 lazy val actorTypedTests = pekkoModule("actor-typed-tests")
   .dependsOn(actorTyped % "compile->CompileJdk9", actorTestkitTyped % "compile->compile;test->test", actor)
   .settings(PekkoBuild.mayChangeSettings)
+  .settings(Dependencies.actorTypedTestSlf4j2)
   .disablePlugins(MimaPlugin)
   .enablePlugins(NoPublish)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -265,6 +265,14 @@ object Dependencies {
     Provided.scalatest.value,
     TestDependencies.scalatestJUnit.value)
 
+  val actorTypedTestSlf4j2 = if (java.lang.Boolean.getBoolean("pekko.test.slf4j2")) {
+    Seq(dependencyOverrides ++= Seq(
+        "org.slf4j" % "slf4j-api" % "2.0.9",
+        "ch.qos.logback" % "logback-classic" % "1.3.11" % Test))
+  } else {
+    Seq.empty
+  }
+
   val pki = l ++=
     Seq(
       asnOne,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -267,8 +267,8 @@ object Dependencies {
 
   val actorTypedTestSlf4j2 = if (java.lang.Boolean.getBoolean("pekko.test.slf4j2")) {
     Seq(dependencyOverrides ++= Seq(
-        "org.slf4j" % "slf4j-api" % "2.0.9",
-        "ch.qos.logback" % "logback-classic" % "1.3.11" % Test))
+      "org.slf4j" % "slf4j-api" % "2.0.9",
+      "ch.qos.logback" % "logback-classic" % "1.3.11" % Test))
   } else {
     Seq.empty
   }


### PR DESCRIPTION
Pekko main branch (future pekko 1.1.0 dev line) already uses slf4j-api v2 and we had to react to a breaking change with the slf4j LoggingEvent getMarker method being replaced with a getMarkers method - see #748

Since testkit is only used in testing, I think we can live with a solution that ignores the Marker on LoggingEvent if the getMarker method is missing.

TestAppender change in #748 is not needed because the ILoggingEvent class still has a getMarker method (just deprecated).
https://logback.qos.ch/apidocs/ch/qos/logback/classic/spi/ILoggingEvent.html
