### PR TITLE
exclude bcpkix-jdk15on

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -168,7 +168,8 @@ object Dependencies {
       val jimfs = "com.google.jimfs" % "jimfs" % "1.3.0" % Test
 
       // docker utils
-      val dockerClient = "com.spotify" % "docker-client" % "8.16.0" % Test
+      val dockerClient = ("com.spotify" % "docker-client" % "8.16.0" % Test)
+        .exclude("org.bouncycastle", "bcpkix-jdk15on")
 
       val jackson = Def.setting {
         Seq(


### PR DESCRIPTION
We import bcpkix-jdk18on explicitly instead - bcpkix-jdk15on is outdated.

It also has CVEs and is causing security alerts on our project. https://github.com/apache/incubator-pekko/security/dependabot/53 and https://github.com/apache/incubator-pekko/security/dependabot/92