### PR TITLE
add Akka path parsing tests

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/actor/ActorPathSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/ActorPathSpec.scala
@@ -32,6 +32,21 @@ class ActorPathSpec extends AnyWordSpec with Matchers {
       ActorPath.fromString(remote).toString should ===(remote)
     }
 
+    "support parsing remote akka paths" in {
+      val remote = "akka://my_sys@host:1234/some/ref"
+      ActorPath.fromString(remote).toString should ===(remote)
+    }
+
+    "support parsing AddressFromURIString" in {
+      val remote = "pekko://my_sys@host:1234"
+      AddressFromURIString(remote) should ===(Address("pekko", "my_sys", Some("host"), Some(1234)))
+    }
+
+    "support parsing akka AddressFromURIString" in {
+      val remote = "akka://my_sys@host:1234"
+      AddressFromURIString(remote) should ===(Address("akka", "my_sys", Some("host"), Some(1234)))
+    }
+
     "throw exception upon malformed paths" in {
       intercept[MalformedURLException] { ActorPath.fromString("") }
       intercept[MalformedURLException] { ActorPath.fromString("://hallo") }


### PR DESCRIPTION
relates to https://github.com/apache/incubator-pekko/pull/765

These tests prove that Pekko doesn't actively check the URI scheme - at least at the initial URI parsing point.