### PR TITLE
Use `recoverWith` instead of `recover` in `SnapshotSerializer` akka backwards compatibility

### DIFF
--- a/persistence/src/main/scala/org/apache/pekko/persistence/serialization/SnapshotSerializer.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/serialization/SnapshotSerializer.scala
@@ -115,7 +115,7 @@ class SnapshotSerializer(val system: ExtendedActorSystem) extends BaseSerializer
     // suggested in https://github.com/scullxbones/pekko-persistence-mongo/pull/14#issuecomment-1847223850
     serialization
       .deserialize(snapshotBytes, serializerId, manifest)
-      .recover {
+      .recoverWith {
         case _: NotSerializableException if manifest.startsWith("akka") =>
           serialization
             .deserialize(snapshotBytes, serializerId, manifest.replaceFirst("akka", "org.apache.pekko"))

--- a/persistence/src/test/scala/org/apache/pekko/persistence/serialization/SnapshotSerializerSpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/serialization/SnapshotSerializerSpec.scala
@@ -24,7 +24,6 @@ import pekko.serialization.SerializationExtension
 import pekko.testkit.PekkoSpec
 
 import java.util.Base64
-import scala.util.Success
 
 class SnapshotSerializerSpec extends PekkoSpec {
 
@@ -38,10 +37,8 @@ class SnapshotSerializerSpec extends PekkoSpec {
       val bytes = Base64.getDecoder.decode(data)
       val result = serialization.deserialize(bytes, classOf[Snapshot]).get
       val deserialized = result.data
-      deserialized shouldBe a[Success[_]]
-      val innerResult = deserialized.asInstanceOf[Success[_]].get
-      innerResult shouldBe a[PersistentFSMSnapshot[_]]
-      val persistentFSMSnapshot = innerResult.asInstanceOf[PersistentFSMSnapshot[_]]
+      deserialized shouldBe a[PersistentFSMSnapshot[_]]
+      val persistentFSMSnapshot = deserialized.asInstanceOf[PersistentFSMSnapshot[_]]
       persistentFSMSnapshot shouldEqual PersistentFSMSnapshot[String]("test-identifier", "test-data", None)
     }
   }


### PR DESCRIPTION
@pjfanning after taking another look I think this should make more sense, otherwise `snapshotFromBinary` can either return `T` or `Try[T]` (got bitten by `AnyRef` here..). I'm not sure why the previous version didn't blow up when testing this with real mongo and existing akka persistence snapshots.