### PR TITLE
fix broken vavr link

### DIFF
--- a/docs/src/main/paradox/typed/style-guide.md
+++ b/docs/src/main/paradox/typed/style-guide.md
@@ -467,7 +467,7 @@ be good to know that it's optional in case you would prefer a different approach
 * direct processing because there is only one message type
 * if or switch statements
 * annotation processor
-* [Vavr Pattern Matching DSL](https://www.vavr.io/vavr-docs/#_pattern_matching)
+* [Vavr Pattern Matching DSL](https://docs.vavr.io/#_pattern_matching)
 * pattern matching since JDK 14 ([JEP 305](https://openjdk.java.net/jeps/305))
 
 In `Behaviors` there are `receive`, `receiveMessage` and `receiveSignal` factory methods that takes functions


### PR DESCRIPTION
* relates to https://github.com/vavr-io/vavr/issues/2756
* we may need to remove vavr from the docs altogether but let's just fix the link for now - to keep the link validator checks happy
