### PR TITLE
=str code clean up in Sliding.

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
@@ -903,7 +903,7 @@ private[stream] object Collect {
           if (buf.size == n) {
             push(out, buf)
           } else pull(in)
-        } else if (step > n) {
+        } else {
           if (buf.size == step) {
             buf = buf.drop(step)
           }


### PR DESCRIPTION
remove unnecessary condition because the opposite check has already been checked - so `else` is enough