### PR TITLE
=str Avoid subMaterialization when the provided recover source is empty.

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowRecoverWithSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowRecoverWithSpec.scala
@@ -49,6 +49,19 @@ class FlowRecoverWithSpec extends StreamSpec {
         .expectComplete()
     }
 
+    "recover with empty source" in {
+      Source(1 to 4)
+        .map { a =>
+          if (a == 3) throw ex else a
+        }
+        .recoverWith { case _: Throwable => Source.empty }
+        .runWith(TestSink[Int]())
+        .request(2)
+        .expectNextN(1 to 2)
+        .request(1)
+        .expectComplete()
+    }
+
     "cancel substream if parent is terminated when there is a handler" in {
       Source(1 to 4)
         .map { a =>

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/TraversalBuilder.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/TraversalBuilder.scala
@@ -379,6 +379,16 @@ import pekko.util.unused
         }
     }
   }
+
+  /**
+   * Test if a Graph is an empty Source.
+   */
+  def isEmptySource(graph: Graph[SourceShape[_], _]): Boolean = graph match {
+    case source: scaladsl.Source[_, _] if source eq scaladsl.Source.empty => true
+    case source: javadsl.Source[_, _] if source eq javadsl.Source.empty() => true
+    case _                                                                => false
+  }
+
 }
 
 /**


### PR DESCRIPTION
perf: avoid subMaterialization  when source is empty.