### PR TITLE
=str Optimize concat for javadsl.Source.empty.

### DIFF
--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
@@ -288,6 +288,17 @@ public class SourceTest extends StreamTest {
   }
 
   @Test
+  public void mustBeAbleToConcatEmptySource() {
+    Source.from(Arrays.asList("A", "B", "C"))
+        .concat(Source.empty())
+        .runWith(TestSink.probe(system), system)
+        .ensureSubscription()
+        .request(3)
+        .expectNext("A", "B", "C")
+        .expectComplete();
+  }
+
+  @Test
   public void mustBeAbleToUseConcatAll() {
     final Source<Integer, NotUsed> sourceA = Source.from(Arrays.asList(1, 2, 3));
     final Source<Integer, NotUsed> sourceB = Source.from(Arrays.asList(4, 5, 6));

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -3302,7 +3302,7 @@ trait FlowOps[+Out, +Mat] {
 
   private def internalConcat[U >: Out, Mat2](that: Graph[SourceShape[U], Mat2], detached: Boolean): Repr[U] =
     that match {
-      case source if source eq Source.empty => this.asInstanceOf[Repr[U]]
+      case source if TraversalBuilder.isEmptySource(source) => this.asInstanceOf[Repr[U]]
       case other =>
         TraversalBuilder.getSingleSource(other) match {
           case OptionVal.Some(singleSource) =>


### PR DESCRIPTION
It was only optimized for scaladsl, now works for javadsl too.