### PR TITLE
fix: reject zero and negative periodic tasks schedule

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/actor/SchedulerSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/SchedulerSpec.scala
@@ -770,12 +770,14 @@ class LightArrayRevolverSchedulerSpec extends PekkoSpec(SchedulerSpec.testConfRe
     @volatile var time: Long = start
     val sched = new LightArrayRevolverScheduler(config.withFallback(system.settings.config), log, tf) {
       override protected def clock(): Long = {
+        // println(s"clock=$time")
         time
       }
 
       override protected def getShutdownTimeout: FiniteDuration = (10 seconds).dilated
 
       override protected def waitNanos(ns: Long): Unit = {
+        // println(s"waiting $ns")
         prb.ref ! ns
         try time += (lbq.get match {
             case q: LinkedBlockingQueue[Long] => q.take()

--- a/actor-tests/src/test/scala/org/apache/pekko/actor/SchedulerSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/SchedulerSpec.scala
@@ -662,7 +662,7 @@ class LightArrayRevolverSchedulerSpec extends PekkoSpec(SchedulerSpec.testConfRe
     }
 
     "using scheduleAtFixedRate" must {
-      "reject periodic tasks scheduled with zero interval" taggedAs TimingTest in {
+      "fixed rate reject periodic tasks scheduled with zero interval" taggedAs TimingTest in {
         val zeroInterval = 0.seconds
         import system.dispatcher
         intercept[IllegalArgumentException] {
@@ -671,7 +671,7 @@ class LightArrayRevolverSchedulerSpec extends PekkoSpec(SchedulerSpec.testConfRe
         expectNoMessage(1.second)
       }
 
-      "reject periodic tasks scheduled with negative interval" taggedAs TimingTest in {
+      "fixed rate reject periodic tasks scheduled with negative interval" taggedAs TimingTest in {
         val negativeDelay = -1.seconds
         import system.dispatcher
         intercept[IllegalArgumentException] {
@@ -682,7 +682,7 @@ class LightArrayRevolverSchedulerSpec extends PekkoSpec(SchedulerSpec.testConfRe
     }
 
     "using scheduleWithFixedDelay" must {
-      "reject periodic tasks scheduled with zero interval" taggedAs TimingTest in {
+      "fixed delay reject periodic tasks scheduled with zero interval" taggedAs TimingTest in {
         val zeroInterval = 0.seconds
         import system.dispatcher
         intercept[IllegalArgumentException] {
@@ -691,7 +691,7 @@ class LightArrayRevolverSchedulerSpec extends PekkoSpec(SchedulerSpec.testConfRe
         expectNoMessage(1.second)
       }
 
-      "reject periodic tasks scheduled with negative interval" taggedAs TimingTest in {
+      "fixed delay reject periodic tasks scheduled with negative interval" taggedAs TimingTest in {
         val negativeDelay = -1.seconds
         import system.dispatcher
         intercept[IllegalArgumentException] {

--- a/actor/src/main/scala/org/apache/pekko/actor/LightArrayRevolverScheduler.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/LightArrayRevolverScheduler.scala
@@ -196,7 +196,7 @@ class LightArrayRevolverScheduler(config: Config, log: LoggingAdapter, threadFac
     }
 
   private def checkPeriod(delay: FiniteDuration): Unit =
-    if (delay.toNanos <= 0)
+    if (delay.length <= 0)
       throw new IllegalArgumentException(
         s"Task scheduled with [${delay.toSeconds}] seconds delay, which means creating an infinite loop. " +
         s"The expected delay must be greater than 0.")

--- a/actor/src/main/scala/org/apache/pekko/actor/LightArrayRevolverScheduler.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/LightArrayRevolverScheduler.scala
@@ -105,14 +105,20 @@ class LightArrayRevolverScheduler(config: Config, log: LoggingAdapter, threadFac
 
   override def scheduleWithFixedDelay(initialDelay: FiniteDuration, delay: FiniteDuration)(runnable: Runnable)(
       implicit executor: ExecutionContext): Cancellable = {
-    checkZeroPeriod(delay.toNanos)
+    if (delay.toNanos <= 0)
+      throw new IllegalArgumentException(
+        s"Task scheduled with [${delay.toSeconds}] seconds delay, which means creating an infinite loop. " +
+        s"The expected delay must be greater than 0.")
     checkMaxDelay(roundUp(delay).toNanos)
     super.scheduleWithFixedDelay(initialDelay, delay)(runnable)
   }
 
   override def schedule(initialDelay: FiniteDuration, delay: FiniteDuration, runnable: Runnable)(
       implicit executor: ExecutionContext): Cancellable = {
-    checkZeroPeriod(delay.toNanos)
+    if (delay.toNanos <= 0)
+      throw new IllegalArgumentException(
+        s"Task scheduled with [${delay.toSeconds}] seconds delay, which means creating an infinite loop. " +
+        s"The expected delay must be greater than 0.")
     checkMaxDelay(roundUp(delay).toNanos)
     new AtomicCancellable(InitialRepeatMarker) { self =>
       final override protected def scheduledFirst(): Cancellable =
@@ -201,11 +207,6 @@ class LightArrayRevolverScheduler(config: Config, log: LoggingAdapter, threadFac
       throw new IllegalArgumentException(
         s"Task scheduled with [${delayNanos.nanos.toSeconds}] seconds delay, " +
         s"which is too far in future, maximum delay is [${(tickNanos * Int.MaxValue).nanos.toSeconds - 1}] seconds")
-
-  private def checkZeroPeriod(delayNanos: Long): Unit =
-    if (delayNanos <= 0)
-      throw new IllegalArgumentException(
-        "Task scheduled with zero or negative period, which is create an an infinite loop")
 
   private val stopped = new AtomicReference[Promise[immutable.Seq[TimerTask]]]
   private def stop(): Future[immutable.Seq[TimerTask]] = {

--- a/actor/src/main/scala/org/apache/pekko/actor/LightArrayRevolverScheduler.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/LightArrayRevolverScheduler.scala
@@ -105,20 +105,14 @@ class LightArrayRevolverScheduler(config: Config, log: LoggingAdapter, threadFac
 
   override def scheduleWithFixedDelay(initialDelay: FiniteDuration, delay: FiniteDuration)(runnable: Runnable)(
       implicit executor: ExecutionContext): Cancellable = {
-    if (delay.toNanos <= 0)
-      throw new IllegalArgumentException(
-        s"Task scheduled with [${delay.toSeconds}] seconds delay, which means creating an infinite loop. " +
-        s"The expected delay must be greater than 0.")
+    checkPeriod(delay)
     checkMaxDelay(roundUp(delay).toNanos)
     super.scheduleWithFixedDelay(initialDelay, delay)(runnable)
   }
 
   override def schedule(initialDelay: FiniteDuration, delay: FiniteDuration, runnable: Runnable)(
       implicit executor: ExecutionContext): Cancellable = {
-    if (delay.toNanos <= 0)
-      throw new IllegalArgumentException(
-        s"Task scheduled with [${delay.toSeconds}] seconds delay, which means creating an infinite loop. " +
-        s"The expected delay must be greater than 0.")
+    checkPeriod(delay)
     checkMaxDelay(roundUp(delay).toNanos)
     new AtomicCancellable(InitialRepeatMarker) { self =>
       final override protected def scheduledFirst(): Cancellable =
@@ -200,6 +194,12 @@ class LightArrayRevolverScheduler(config: Config, log: LoggingAdapter, threadFac
         throw SchedulerException("cannot enqueue after timer shutdown")
       task
     }
+
+  private def checkPeriod(delay: FiniteDuration): Unit =
+    if (delay.toNanos <= 0)
+      throw new IllegalArgumentException(
+        s"Task scheduled with [${delay.toSeconds}] seconds delay, which means creating an infinite loop. " +
+        s"The expected delay must be greater than 0.")
 
   private def checkMaxDelay(delayNanos: Long): Unit =
     if (delayNanos / tickNanos > Int.MaxValue)

--- a/actor/src/main/scala/org/apache/pekko/actor/Scheduler.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/Scheduler.scala
@@ -75,8 +75,8 @@ trait Scheduler {
    * If the `Runnable` throws an exception the repeated scheduling is aborted,
    * i.e. the function will not be invoked any more.
    *
-   * @throws java.lang.IllegalArgumentException if the given delays exceed the maximum
-   * reach (calculated as: `delay / tickNanos > Int.MaxValue`).
+   * @throws java.lang.IllegalArgumentException if the given delays is zero, negative or exceed the maximum
+   * reach (calculated as: `delay / tickNanos > Int.MaxValue`)
    *
    * Note: For scheduling within actors `with Timers` should be preferred.
    */
@@ -116,7 +116,7 @@ trait Scheduler {
    * If the `Runnable` throws an exception the repeated scheduling is aborted,
    * i.e. the function will not be invoked any more.
    *
-   * @throws java.lang.IllegalArgumentException if the given delays exceed the maximum
+   * @throws java.lang.IllegalArgumentException if the given delays is zero, negative or exceed the maximum
    * reach (calculated as: `delay / tickNanos > Int.MaxValue`).
    *
    * Note: For scheduling within actors `AbstractActorWithTimers` should be preferred.
@@ -215,7 +215,7 @@ trait Scheduler {
    * If the `Runnable` throws an exception the repeated scheduling is aborted,
    * i.e. the function will not be invoked any more.
    *
-   * @throws java.lang.IllegalArgumentException if the given delays exceed the maximum
+   * @throws java.lang.IllegalArgumentException if the given delays is zero, negative or exceed the maximum
    * reach (calculated as: `delay / tickNanos > Int.MaxValue`).
    *
    * Note: For scheduling within actors `with Timers` should be preferred.
@@ -251,7 +251,7 @@ trait Scheduler {
    * If the `Runnable` throws an exception the repeated scheduling is aborted,
    * i.e. the function will not be invoked any more.
    *
-   * @throws java.lang.IllegalArgumentException if the given delays exceed the maximum
+   * @throws java.lang.IllegalArgumentException if the given delays is zero, negative or exceed the maximum
    * reach (calculated as: `delay / tickNanos > Int.MaxValue`).
    *
    * Note: For scheduling within actors `AbstractActorWithTimers` should be preferred.
@@ -415,7 +415,7 @@ trait Scheduler {
    * Scala API: Schedules a message to be sent once with a delay, i.e. a time period that has
    * to pass before the message is sent.
    *
-   * @throws java.lang.IllegalArgumentException if the given delays exceed the maximum
+   * @throws java.lang.IllegalArgumentException if the given delays is zero, negative or exceed the maximum
    * reach (calculated as: `delay / tickNanos > Int.MaxValue`).
    *
    * Note: For scheduling within actors `with Timers` should be preferred.
@@ -433,7 +433,7 @@ trait Scheduler {
    * Java API: Schedules a message to be sent once with a delay, i.e. a time period that has
    * to pass before the message is sent.
    *
-   * @throws java.lang.IllegalArgumentException if the given delays exceed the maximum
+   * @throws java.lang.IllegalArgumentException if the given delays is zero, negative or exceed the maximum
    * reach (calculated as: `delay / tickNanos > Int.MaxValue`).
    *
    * Note: For scheduling within actors `AbstractActorWithTimers` should be preferred.
@@ -452,7 +452,7 @@ trait Scheduler {
    * Scala API: Schedules a function to be run once with a delay, i.e. a time period that has
    * to pass before the function is run.
    *
-   * @throws java.lang.IllegalArgumentException if the given delays exceed the maximum
+   * @throws java.lang.IllegalArgumentException if the given delays is zero, negative or exceed the maximum
    * reach (calculated as: `delay / tickNanos > Int.MaxValue`).
    *
    * Note: For scheduling within actors `with Timers` should be preferred.
@@ -466,7 +466,7 @@ trait Scheduler {
    * Scala API: Schedules a Runnable to be run once with a delay, i.e. a time period that
    * has to pass before the runnable is executed.
    *
-   * @throws java.lang.IllegalArgumentException if the given delays exceed the maximum
+   * @throws java.lang.IllegalArgumentException if the given delays is zero, negative or exceed the maximum
    * reach (calculated as: `delay / tickNanos > Int.MaxValue`).
    *
    * Note: For scheduling within actors `with Timers` should be preferred.
@@ -477,7 +477,7 @@ trait Scheduler {
    * Java API: Schedules a Runnable to be run once with a delay, i.e. a time period that
    * has to pass before the runnable is executed.
    *
-   * @throws java.lang.IllegalArgumentException if the given delays exceed the maximum
+   * @throws java.lang.IllegalArgumentException if the given delays is zero, negative or exceed the maximum
    * reach (calculated as: `delay / tickNanos > Int.MaxValue`).
    *
    * Note: For scheduling within actors `AbstractActorWithTimers` should be preferred.

--- a/actor/src/main/scala/org/apache/pekko/actor/Scheduler.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/Scheduler.scala
@@ -76,7 +76,7 @@ trait Scheduler {
    * i.e. the function will not be invoked any more.
    *
    * @throws java.lang.IllegalArgumentException if the given delays is zero, negative or exceed the maximum
-   * reach (calculated as: `delay / tickNanos > Int.MaxValue`)
+   * reach (calculated as: `delay / tickNanos > Int.MaxValue`).
    *
    * Note: For scheduling within actors `with Timers` should be preferred.
    */


### PR DESCRIPTION
create a zero periodic tasks on scheduler will let scheduler busy and can not scheduler other task.

on jdk `ScheduledThreadPoolExecutor`, the zero period task currently is forrbidden.