### PR TITLE
Fix remaining missing inline statements/annotations

### DIFF
--- a/actor/src/main/mima-filters/1.1.0.backwards.excludes/java-duration-converters.excludes
+++ b/actor/src/main/mima-filters/1.1.0.backwards.excludes/java-duration-converters.excludes
@@ -1,0 +1,4 @@
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.util.JavaDurationConverters#JavaDurationOps.asScala$extension")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.util.JavaDurationConverters#JavaDurationOps.asScala")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.util.JavaDurationConverters#ScalaDurationOps.asJava$extension")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.util.JavaDurationConverters#ScalaDurationOps.asJava")

--- a/actor/src/main/scala-2.13/org/apache/pekko/compat/PartialFunction.scala
+++ b/actor/src/main/scala-2.13/org/apache/pekko/compat/PartialFunction.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package org.apache.pekko.compat
+
+import org.apache.pekko.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ *
+ * Compatibility wrapper for `scala.PartialFunction` to be able to compile the same code
+ * against Scala 2.12, 2.13, 3.0
+ *
+ * Remove these classes as soon as support for Scala 2.12 is dropped!
+ */
+@InternalApi private[pekko] object PartialFunction {
+
+  @inline def fromFunction[A, B](f: A => B): scala.PartialFunction[A, B] =
+    scala.PartialFunction.fromFunction(f)
+
+}

--- a/actor/src/main/scala-2.13/org/apache/pekko/dispatch/internal/SameThreadExecutionContext.scala
+++ b/actor/src/main/scala-2.13/org/apache/pekko/dispatch/internal/SameThreadExecutionContext.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package org.apache.pekko.dispatch.internal
+
+import scala.concurrent.ExecutionContext
+
+import org.apache.pekko
+import pekko.annotation.InternalApi
+
+/**
+ * Factory to create same thread ec. Not intended to be called from any other site than to create [[pekko.dispatch.ExecutionContexts#parasitic]]
+ *
+ * INTERNAL API
+ */
+@InternalApi
+private[dispatch] object SameThreadExecutionContext {
+  @inline def apply(): ExecutionContext = ExecutionContext.parasitic
+}

--- a/actor/src/main/scala-2/org/apache/pekko/util/JavaDurationConverters.scala
+++ b/actor/src/main/scala-2/org/apache/pekko/util/JavaDurationConverters.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package org.apache.pekko.util
+import java.time.{ Duration => JDuration }
+
+import scala.concurrent.duration.{ Duration, FiniteDuration }
+
+import org.apache.pekko.annotation.InternalStableApi
+
+/**
+ * INTERNAL API
+ */
+@InternalStableApi
+private[pekko] object JavaDurationConverters {
+  @inline def asFiniteDuration(duration: JDuration): FiniteDuration = duration.asScala
+
+  final implicit class JavaDurationOps(val self: JDuration) extends AnyVal {
+    @inline def asScala: FiniteDuration = Duration.fromNanos(self.toNanos)
+  }
+
+  final implicit class ScalaDurationOps(val self: Duration) extends AnyVal {
+    @inline def asJava: JDuration = JDuration.ofNanos(self.toNanos)
+  }
+}

--- a/actor/src/main/scala-3/org/apache/pekko/compat/PartialFunction.scala
+++ b/actor/src/main/scala-3/org/apache/pekko/compat/PartialFunction.scala
@@ -25,8 +25,7 @@ import org.apache.pekko.annotation.InternalApi
  */
 @InternalApi private[pekko] object PartialFunction {
 
-  def fromFunction[A, B](f: (A) => B): scala.PartialFunction[A, B] = {
+  inline def fromFunction[A, B](f: A => B): scala.PartialFunction[A, B] =
     scala.PartialFunction.fromFunction(f)
-  }
 
 }

--- a/actor/src/main/scala-3/org/apache/pekko/dispatch/internal/SameThreadExecutionContext.scala
+++ b/actor/src/main/scala-3/org/apache/pekko/dispatch/internal/SameThreadExecutionContext.scala
@@ -25,5 +25,5 @@ import pekko.annotation.InternalApi
  */
 @InternalApi
 private[dispatch] object SameThreadExecutionContext {
-  def apply(): ExecutionContext = ExecutionContext.parasitic
+  inline def apply(): ExecutionContext = ExecutionContext.parasitic
 }

--- a/actor/src/main/scala-3/org/apache/pekko/util/FutureConverters.scala
+++ b/actor/src/main/scala-3/org/apache/pekko/util/FutureConverters.scala
@@ -23,15 +23,23 @@ import scala.concurrent.Future
 private[pekko] object FutureConverters {
   import scala.jdk.javaapi
 
+  // Ideally this should have the Scala 3 inline keyword but then Java sources are
+  // unable to call this method, see https://github.com/lampepfl/dotty/issues/19346
   def asJava[T](f: Future[T]): CompletionStage[T] = javaapi.FutureConverters.asJava(f)
 
   implicit final class FutureOps[T](private val f: Future[T]) extends AnyVal {
-    inline def asJava: CompletionStage[T] = FutureConverters.asJava(f)
+    // Change to FutureConverters.asJava(f) once https://github.com/lampepfl/dotty/issues/19346
+    // is resolved and the asJava method is marked as inline
+    inline def asJava: CompletionStage[T] = javaapi.FutureConverters.asJava(f)
   }
 
+  // Ideally this should have the Scala 3 inline keyword but then Java sources are
+  // unable to call this method, see https://github.com/lampepfl/dotty/issues/19346
   def asScala[T](cs: CompletionStage[T]): Future[T] = javaapi.FutureConverters.asScala(cs)
 
   implicit final class CompletionStageOps[T](private val cs: CompletionStage[T]) extends AnyVal {
-    inline def asScala: Future[T] = FutureConverters.asScala(cs)
+    // Change to FutureConverters.asScala(cs) once https://github.com/lampepfl/dotty/issues/19346
+    // is resolved and the asScala method is marked as inline
+    inline def asScala: Future[T] = javaapi.FutureConverters.asScala(cs)
   }
 }

--- a/actor/src/main/scala-3/org/apache/pekko/util/JavaDurationConverters.scala
+++ b/actor/src/main/scala-3/org/apache/pekko/util/JavaDurationConverters.scala
@@ -23,13 +23,16 @@ import org.apache.pekko.annotation.InternalStableApi
  */
 @InternalStableApi
 private[pekko] object JavaDurationConverters {
+
+  // Ideally this should have the Scala 3 inline keyword but then Java sources are
+  // unable to call this method, see https://github.com/lampepfl/dotty/issues/19346
   def asFiniteDuration(duration: JDuration): FiniteDuration = duration.asScala
 
   final implicit class JavaDurationOps(val self: JDuration) extends AnyVal {
-    def asScala: FiniteDuration = Duration.fromNanos(self.toNanos)
+    inline def asScala: FiniteDuration = Duration.fromNanos(self.toNanos)
   }
 
   final implicit class ScalaDurationOps(val self: Duration) extends AnyVal {
-    def asJava: JDuration = JDuration.ofNanos(self.toNanos)
+    inline def asJava: JDuration = JDuration.ofNanos(self.toNanos)
   }
 }

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/package.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/package.scala
@@ -67,10 +67,10 @@ import scala.concurrent.Future
 package object scaladsl {
   implicit class SourceToCompletionStage[Out, T](val src: Source[Out, Future[T]]) extends AnyVal {
     def toCompletionStage(): Source[Out, CompletionStage[T]] =
-      src.mapMaterializedValue(FutureConverters.asJava)
+      src.mapMaterializedValue(f => FutureConverters.asJava(f))
   }
   implicit class SinkToCompletionStage[In, T](val sink: Sink[In, Future[T]]) extends AnyVal {
     def toCompletionStage(): Sink[In, CompletionStage[T]] =
-      sink.mapMaterializedValue(FutureConverters.asJava)
+      sink.mapMaterializedValue(f => FutureConverters.asJava(f))
   }
 }


### PR DESCRIPTION
The previous PR at https://github.com/apache/incubator-pekko/pull/857 managed to miss some inline annotations so this PR fills the rest.

Interestingly I managed to find a Scala 3 bug whereby if you mark a method with `inline` it cannot be called within Java sources because its missing a symbol, I have reported the issue upstream at https://github.com/lampepfl/dotty/issues/19346