### PR TITLE
Fix header for Scala212CompatTest

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/util/Scala212CompatTest.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/Scala212CompatTest.scala
@@ -1,10 +1,18 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * license agreements; and to You under the Apache License, version 2.0:
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- *   https://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- * This file is part of the Apache Pekko project, which was derived from Akka.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.pekko.util


### PR DESCRIPTION
(cherry picked from commit 7ed85713e2a9c4b9d0aa607aa9649fb05e88ee6b)