### PR TITLE
remove unnecessary sbt setting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,10 +129,6 @@ lazy val actor = pekkoModule("actor")
   .settings(OSGi.actor)
   .settings(AutomaticModuleName.settings("pekko.actor"))
   .settings(AddMetaInfLicenseFiles.actorSettings)
-  .settings(Compile / unmanagedSourceDirectories += {
-    val ver = scalaVersion.value.take(4)
-    (Compile / scalaSource).value.getParentFile / s"scala-$ver"
-  })
   .settings(VersionGenerator.settings)
   .settings(serialversionRemoverPluginSettings)
   .enablePlugins(BoilerplatePlugin)


### PR DESCRIPTION
Pekko's sbt settings already pick up the necessary scala source dirs.

With this change, sbt still finds all the necessary source dirs.
```
sbt ++2.12 "show actor/unmanagedSourceDirectories"
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala-2.12
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala-2
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/java

sbt ++2.13 "show actor/unmanagedSourceDirectories"
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala-2.13
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala-2
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/java
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala-2.13+

sbt ++3.3.1 "show actor/unmanagedSourceDirectories"
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala-3
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/java
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala-2.13+
```

Before this change, we had this result - including one extra non-existent dir for scala 3.3
```
sbt ++2.12 "show actor/unmanagedSourceDirectories"
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala-2.12
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala-2
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/java
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala-2.12

sbt ++2.13 "show actor/unmanagedSourceDirectories"
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala-2.13
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala-2
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/java
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala-2.13+
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala-2.13

sbt ++3.3.1 "show actor/unmanagedSourceDirectories"
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala-3
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/java
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala-2.13+
[info] * /Users/pj.fanning/code/incubator-pekko/actor/src/main/scala-3.3.
```