### PR TITLE
Add second sbt-osgi in dependency update ignore list

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -20,6 +20,7 @@ updates.ignore = [
   { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-jdk8" }
   { groupId = "com.typesafe", artifactId = "ssl-config-core" }
   { groupId = "com.typesafe.sbt", artifactId = "sbt-osgi" }
+  { groupId = "com.github.sbt", artifactId = "sbt-osgi" }
   { groupId = "org.agrona", artifactId = "agrona" }
   { groupId = "org.mockito", artifactId = "mockito-core" }
   { groupId = "com.typesafe.sbt", artifactId = "sbt-osgi" }


### PR DESCRIPTION
(cherry picked from commit 688eac7bf5bcd7ca99d4c926b7a16d57598c79e4)

While it can be argued that this is pointless since we aren't going to enable scala-steward on the `1.0.x` branch, I still think its a good idea to do this as a defensive strategy in case in the future we change our minds for w/e reason.