### PR TITLE
chore: Fix typos in onErrorComplete.md

### DIFF
--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/onErrorComplete.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/onErrorComplete.md
@@ -1,6 +1,6 @@
 # onErrorComplete
 
-Allows completing the stream when an upstream error occur.
+Allows completing the stream when an upstream error occurs.
 
 @ref[Error handling](../index.md#error-handling)
 
@@ -13,7 +13,7 @@ Allows completing the stream when an upstream error occur.
 
 ## Description
 
-Allows to complete the stream when an upstream error occur.
+Allows to complete the stream when an upstream error occurs.
 
 ## Reactive Streams semantics
 

--- a/docs/src/main/paradox/stream/operators/index.md
+++ b/docs/src/main/paradox/stream/operators/index.md
@@ -363,7 +363,7 @@ For more background see the @ref[Error Handling in Streams](../stream-error.md) 
 | |Operator|Description|
 |--|--|--|
 |Source/Flow|<a name="maperror"></a>@ref[mapError](Source-or-Flow/mapError.md)|While similar to `recover` this operators can be used to transform an error signal to a different one *without* logging it as an error in the process.|
-|Source/Flow|<a name="onerrorcomplete"></a>@ref[onErrorComplete](Source-or-Flow/onErrorComplete.md)|Allows completing the stream when an upstream error occur.|
+|Source/Flow|<a name="onerrorcomplete"></a>@ref[onErrorComplete](Source-or-Flow/onErrorComplete.md)|Allows completing the stream when an upstream error occurs.|
 |RestartSource|<a name="onfailureswithbackoff"></a>@ref[onFailuresWithBackoff](RestartSource/onFailuresWithBackoff.md)|Wrap the given @apidoc[Source] with a @apidoc[Source] that will restart it when it fails using an exponential backoff. Notice that this @apidoc[Source] will not restart on completion of the wrapped flow.|
 |RestartFlow|<a name="onfailureswithbackoff"></a>@ref[onFailuresWithBackoff](RestartFlow/onFailuresWithBackoff.md)|Wrap the given @apidoc[Flow] with a @apidoc[Flow] that will restart it when it fails using an exponential backoff. Notice that this @apidoc[Flow] will not restart on completion of the wrapped flow.|
 |Source/Flow|<a name="recover"></a>@ref[recover](Source-or-Flow/recover.md)|Allow sending of one last element downstream when a failure has happened upstream.|


### PR DESCRIPTION
Motivation:
Fix up typos.

Sorry for missed that.