### PR TITLE
feat: Add onTermination hook to PekkoForkJoinWorkerThread.

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/dispatch/ThreadPoolBuilder.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/ThreadPoolBuilder.scala
@@ -176,6 +176,9 @@ object MonitorableThreadFactory {
   private[pekko] class PekkoForkJoinWorkerThread(_pool: ForkJoinPool)
       extends ForkJoinWorkerThread(_pool)
       with BlockContext {
+
+    override def onTermination(exception: Throwable): Unit = super.onTermination(exception)
+
     override def blockOn[T](thunk: => T)(implicit permission: CanAwait): T = {
       val result = new AtomicReference[Option[T]](None)
       ForkJoinPool.managedBlock(new ForkJoinPool.ManagedBlocker {


### PR DESCRIPTION
Motivation:
Internal usage, we are using ThreadLocal for RPC tracing, and some time the ThreadLocal can leak. So I would like to add this hook for later aop usage, where I can do a clean up with `EagleEye.cleanUpRpcContext()`.

I would like to implement it with byte-buddy

Result:
A hook for clean up.