### PR TITLE
Sort stream imports for pekko-stream modules

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -46,7 +46,10 @@ SortImports.blocks = [
   "scala.",
   "*",
   "com.sun."
-  "org.apache.pekko."
+  "re:^(org\\.apache\\.pekko|pekko\\.)\\w*"
   "org.reactivestreams."
   "io.netty."
+  "org.scalatest."
+  "org.slf4j."
+  "com.typesafe."
 ]

--- a/stream-testkit/src/test/scala/org/apache/pekko/stream/impl/fusing/GraphInterpreterSpecKit.scala
+++ b/stream-testkit/src/test/scala/org/apache/pekko/stream/impl/fusing/GraphInterpreterSpecKit.scala
@@ -13,11 +13,10 @@
 
 package org.apache.pekko.stream.impl.fusing
 
+import scala.annotation.nowarn
 import scala.collection.{ Map => SMap }
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration.FiniteDuration
-
-import scala.annotation.nowarn
 
 import org.apache.pekko
 import pekko.actor.ActorSystem

--- a/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/BaseTwoStreamsSetup.scala
+++ b/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/BaseTwoStreamsSetup.scala
@@ -16,12 +16,12 @@ package org.apache.pekko.stream.testkit
 import scala.collection.immutable
 import scala.util.control.NoStackTrace
 
-import org.reactivestreams.Publisher
-
 import org.apache.pekko
 import pekko.stream.scaladsl._
 import pekko.stream.testkit.scaladsl.StreamTestKit._
 import pekko.testkit.PekkoSpec
+
+import org.reactivestreams.Publisher
 
 abstract class BaseTwoStreamsSetup extends PekkoSpec("""
     pekko.stream.materializer.initial-input-buffer-size = 2

--- a/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/ChainSetup.scala
+++ b/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/ChainSetup.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.stream.testkit
 
 import scala.annotation.nowarn
-import org.reactivestreams.Publisher
 
 import org.apache.pekko
 import pekko.NotUsed
@@ -24,6 +23,8 @@ import pekko.stream.ActorMaterializer
 import pekko.stream.ActorMaterializerSettings
 import pekko.stream.Materializer
 import pekko.stream.scaladsl._
+
+import org.reactivestreams.Publisher
 
 class ChainSetup[In, Out, M](
     stream: Flow[In, In, NotUsed] => Flow[In, Out, M],

--- a/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/ScriptedTest.scala
+++ b/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/ScriptedTest.scala
@@ -15,12 +15,9 @@ package org.apache.pekko.stream.testkit
 
 import java.util.concurrent.ThreadLocalRandom
 
+import scala.annotation.nowarn
 import scala.annotation.tailrec
 import scala.concurrent.duration._
-
-import scala.annotation.nowarn
-import org.reactivestreams.Publisher
-import org.scalatest.matchers.should.Matchers
 
 import org.apache.pekko
 import pekko.NotUsed
@@ -33,6 +30,10 @@ import pekko.stream.scaladsl.Sink
 import pekko.stream.scaladsl.Source
 import pekko.stream.testkit.TestPublisher._
 import pekko.stream.testkit.TestSubscriber._
+
+import org.reactivestreams.Publisher
+
+import org.scalatest.matchers.should.Matchers
 
 trait ScriptedTest extends Matchers {
 

--- a/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/StreamSpec.scala
+++ b/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/StreamSpec.scala
@@ -16,18 +16,19 @@ package org.apache.pekko.stream.testkit
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-import com.typesafe.config.{ Config, ConfigFactory }
-import org.scalatest.Failed
-
 import org.apache.pekko
 import pekko.actor.{ ActorRef, ActorSystem }
+import pekko.stream.Materializer
+import pekko.stream.impl.PhasedFusingActorMaterializer
 import pekko.stream.impl.StreamSupervisor
 import pekko.stream.snapshot.{ MaterializerState, StreamSnapshotImpl }
+import pekko.stream.testkit.scaladsl.StreamTestKit.{ assertNoChildren, stopAllChildren }
 import pekko.testkit.{ PekkoSpec, TestProbe }
 import pekko.testkit.TestKitUtils
-import pekko.stream.impl.PhasedFusingActorMaterializer
-import pekko.stream.testkit.scaladsl.StreamTestKit.{ assertNoChildren, stopAllChildren }
-import pekko.stream.Materializer
+
+import org.scalatest.Failed
+
+import com.typesafe.config.{ Config, ConfigFactory }
 
 abstract class StreamSpec(_system: ActorSystem) extends PekkoSpec(_system) {
   def this(config: Config) =

--- a/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/StreamTestDefaultMailbox.scala
+++ b/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/StreamTestDefaultMailbox.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.stream.testkit
 
-import com.typesafe.config.Config
-
 import org.apache.pekko
 import pekko.actor.Actor
 import pekko.actor.ActorRef
@@ -25,6 +23,8 @@ import pekko.dispatch.MessageQueue
 import pekko.dispatch.ProducesMessageQueue
 import pekko.dispatch.UnboundedMailbox
 import pekko.stream.impl.MaterializerGuardian
+
+import com.typesafe.config.Config
 
 /**
  * INTERNAL API

--- a/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/StreamTestKitSpec.scala
+++ b/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/StreamTestKitSpec.scala
@@ -13,15 +13,16 @@
 
 package org.apache.pekko.stream.testkit
 
+import java.util
+
 import scala.concurrent.duration._
+
 import org.apache.pekko
 import pekko.stream.scaladsl.Source
 import pekko.stream.testkit.scaladsl.TestSink
 import pekko.testkit._
 import pekko.testkit.TestEvent.Mute
 import pekko.testkit.TestEvent.UnMute
-
-import java.util
 
 class StreamTestKitSpec extends PekkoSpec {
 

--- a/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/TestPublisherSubscriberSpec.scala
+++ b/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/TestPublisherSubscriberSpec.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.stream.testkit
 
-import org.reactivestreams.Subscription
-
 import org.apache.pekko
 import pekko.stream.scaladsl.Sink
 import pekko.stream.scaladsl.Source
@@ -22,6 +20,8 @@ import pekko.stream.testkit.TestPublisher._
 import pekko.stream.testkit.TestSubscriber._
 import pekko.stream.testkit.scaladsl.StreamTestKit._
 import pekko.testkit.PekkoSpec
+
+import org.reactivestreams.Subscription
 
 class TestPublisherSubscriberSpec extends PekkoSpec("""
     pekko.stream.materializer.initial-input-buffer-size = 2

--- a/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/TwoStreamsSetup.scala
+++ b/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/TwoStreamsSetup.scala
@@ -13,11 +13,11 @@
 
 package org.apache.pekko.stream.testkit
 
-import org.reactivestreams.Publisher
-
 import org.apache.pekko
 import pekko.stream._
 import pekko.stream.scaladsl._
+
+import org.reactivestreams.Publisher
 
 abstract class TwoStreamsSetup extends BaseTwoStreamsSetup {
 

--- a/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/Utils.scala
+++ b/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/Utils.scala
@@ -15,11 +15,11 @@ package org.apache.pekko.stream.testkit
 
 import scala.util.control.NoStackTrace
 
-import com.typesafe.config.ConfigFactory
-
 import org.apache.pekko
 import pekko.actor.ActorRef
 import pekko.actor.ActorRefWithCell
+
+import com.typesafe.config.ConfigFactory
 
 object Utils {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/ActorMaterializerSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/ActorMaterializerSpec.scala
@@ -19,8 +19,6 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{ Failure, Try }
 
-import com.typesafe.config.ConfigFactory
-
 import org.apache.pekko
 import pekko.Done
 import pekko.actor.{ Actor, ActorSystem, PoisonPill, Props }
@@ -34,6 +32,8 @@ import pekko.stream.scaladsl.{ Sink, Source }
 import pekko.stream.testkit.{ StreamSpec, TestPublisher }
 import pekko.testkit.{ ImplicitSender, TestProbe }
 import pekko.testkit.TestKit
+
+import com.typesafe.config.ConfigFactory
 
 object IndirectMaterializerCreation extends ExtensionId[IndirectMaterializerCreation] with ExtensionIdProvider {
   def createExtension(system: ExtendedActorSystem): IndirectMaterializerCreation =

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/DslConsistencySpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/DslConsistencySpec.scala
@@ -16,8 +16,9 @@ package org.apache.pekko.stream
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 
-import org.apache.pekko
 import scala.annotation.nowarn
+
+import org.apache.pekko
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/DslFactoriesConsistencySpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/DslFactoriesConsistencySpec.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.stream
 
 import org.apache.pekko
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/SystemMaterializerSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/SystemMaterializerSpec.scala
@@ -15,13 +15,13 @@ package org.apache.pekko.stream
 
 import scala.concurrent.Future
 
-import org.scalatest.concurrent.ScalaFutures
-
 import org.apache.pekko
 import pekko.stream.scaladsl.Keep
 import pekko.stream.scaladsl.Sink
 import pekko.stream.scaladsl.Source
 import pekko.stream.testkit.StreamSpec
+
+import org.scalatest.concurrent.ScalaFutures
 
 class SystemMaterializerSpec extends StreamSpec with ScalaFutures {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/impl/GraphStageLogicSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/impl/GraphStageLogicSpec.scala
@@ -15,8 +15,6 @@ package org.apache.pekko.stream.impl
 
 import scala.concurrent.duration.Duration
 
-import org.scalatest.concurrent.ScalaFutures
-
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream._
@@ -26,6 +24,8 @@ import pekko.stream.stage._
 import pekko.stream.stage.GraphStageLogic.{ EagerTerminateInput, EagerTerminateOutput }
 import pekko.stream.testkit.StreamSpec
 import pekko.stream.testkit.scaladsl.TestSink
+
+import org.scalatest.concurrent.ScalaFutures
 
 class GraphStageLogicSpec extends StreamSpec with GraphInterpreterSpecKit with ScalaFutures {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/impl/ResizableMultiReaderRingBufferSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/impl/ResizableMultiReaderRingBufferSpec.scala
@@ -15,10 +15,10 @@ package org.apache.pekko.stream.impl
 
 import scala.util.Random
 
+import org.apache.pekko.stream.impl.ResizableMultiReaderRingBuffer._
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-
-import org.apache.pekko.stream.impl.ResizableMultiReaderRingBuffer._
 
 class ResizableMultiReaderRingBufferSpec extends AnyWordSpec with Matchers {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/impl/TimeoutsSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/impl/TimeoutsSpec.scala
@@ -19,9 +19,6 @@ import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpecLike
-
 import org.apache.pekko
 import pekko.Done
 import pekko.stream._
@@ -30,6 +27,9 @@ import pekko.stream.testkit.StreamSpec
 import pekko.stream.testkit.TestPublisher
 import pekko.stream.testkit.TestSubscriber
 import pekko.stream.testkit.Utils._
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class TimeoutsSpec extends StreamSpec {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/impl/fusing/ActorGraphInterpreterSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/impl/fusing/ActorGraphInterpreterSpec.scala
@@ -19,10 +19,6 @@ import scala.concurrent.Await
 import scala.concurrent.Promise
 import scala.concurrent.duration._
 
-import org.reactivestreams.Publisher
-import org.reactivestreams.Subscriber
-import org.reactivestreams.Subscription
-
 import org.apache.pekko
 import pekko.Done
 import pekko.stream._
@@ -39,6 +35,10 @@ import pekko.stream.testkit.TestSubscriber
 import pekko.stream.testkit.Utils._
 import pekko.testkit.EventFilter
 import pekko.testkit.TestLatch
+
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
 
 class ActorGraphInterpreterSpec extends StreamSpec {
   "ActorGraphInterpreter" must {

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/impl/io/TLSUtilsSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/impl/io/TLSUtilsSpec.scala
@@ -15,12 +15,12 @@ package org.apache.pekko.stream.impl.io
 
 import javax.net.ssl.{ SSLContext, SSLEngine, SSLParameters }
 
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpecLike
-
 import org.apache.pekko
 import pekko.stream.TLSClientAuth
 import pekko.stream.TLSProtocol.NegotiateNewSession
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class TLSUtilsSpec extends AnyWordSpecLike with Matchers {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/DeprecatedTlsSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/DeprecatedTlsSpec.scala
@@ -26,8 +26,6 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Random
 
-import com.typesafe.sslconfig.pekko.PekkoSSLConfig
-
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.pattern.{ after => later }
@@ -41,6 +39,8 @@ import pekko.testkit.TestDuration
 import pekko.testkit.WithLogCapturing
 import pekko.util.ByteString
 import pekko.util.JavaVersion
+
+import com.typesafe.sslconfig.pekko.PekkoSSLConfig
 
 object DeprecatedTlsSpec {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/FileSinkSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/FileSinkSpec.scala
@@ -23,7 +23,6 @@ import scala.concurrent.duration._
 import scala.util.Success
 
 import com.google.common.jimfs.{ Configuration, Jimfs }
-import org.scalatest.concurrent.ScalaFutures
 
 import org.apache.pekko
 import pekko.dispatch.ExecutionContexts
@@ -34,6 +33,8 @@ import pekko.stream.scaladsl.{ FileIO, Keep, Sink, Source }
 import pekko.stream.testkit._
 import pekko.stream.testkit.Utils._
 import pekko.util.ByteString
+
+import org.scalatest.concurrent.ScalaFutures
 
 @nowarn
 class FileSinkSpec extends StreamSpec(UnboundedMailboxConfig) with ScalaFutures {

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/OutputStreamSinkSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/OutputStreamSinkSpec.scala
@@ -18,8 +18,6 @@ import java.io.OutputStream
 import scala.annotation.nowarn
 import scala.util.Success
 
-import org.scalatest.concurrent.ScalaFutures
-
 import org.apache.pekko
 import pekko.Done
 import pekko.stream.{ ActorMaterializer, ActorMaterializerSettings, IOOperationIncompleteException }
@@ -28,6 +26,8 @@ import pekko.stream.testkit._
 import pekko.stream.testkit.Utils._
 import pekko.testkit.TestProbe
 import pekko.util.ByteString
+
+import org.scalatest.concurrent.ScalaFutures
 
 @nowarn
 class OutputStreamSinkSpec extends StreamSpec(UnboundedMailboxConfig) with ScalaFutures {

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/TcpSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/TcpSpec.scala
@@ -25,11 +25,6 @@ import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration._
 
-import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
-import org.scalatest.concurrent.PatienceConfiguration
-import org.scalatest.concurrent.PatienceConfiguration.Timeout
-
 import org.apache.pekko
 import pekko.Done
 import pekko.NotUsed
@@ -58,6 +53,12 @@ import pekko.testkit.TestLatch
 import pekko.testkit.TestProbe
 import pekko.testkit.WithLogCapturing
 import pekko.util.ByteString
+
+import org.scalatest.concurrent.PatienceConfiguration
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
 
 @nowarn("msg=never used")
 class NonResolvingDnsActor(cache: SimpleDnsCache, config: Config) extends Actor {
@@ -1021,11 +1022,11 @@ class TcpSpec extends StreamSpec("""
       import java.security.KeyStore
       import javax.net.ssl._
 
-      import com.typesafe.sslconfig.pekko.PekkoSSLConfig
-
       import org.apache.pekko
       import pekko.stream.TLSClientAuth
       import pekko.stream.TLSProtocol
+
+      import com.typesafe.sslconfig.pekko.PekkoSSLConfig
 
       val sslConfig = PekkoSSLConfig(system)
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/compression/CodecSpecSupport.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/compression/CodecSpecSupport.scala
@@ -13,14 +13,14 @@
 
 package org.apache.pekko.stream.io.compression
 
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.Suite
-import org.scalatest.matchers.should.Matchers
-
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.testkit.TestKit
 import pekko.util.ByteString
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.Suite
+import org.scalatest.matchers.should.Matchers
 
 trait CodecSpecSupport extends Matchers with BeforeAndAfterAll { self: Suite =>
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/compression/CoderSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/compression/CoderSpec.scala
@@ -22,14 +22,14 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import org.scalatest.Inspectors
-import org.scalatest.wordspec.AnyWordSpec
-
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream.impl.io.compression.Compressor
 import pekko.stream.scaladsl.{ Compression, Flow, Sink, Source }
 import pekko.util.ByteString
+
+import org.scalatest.Inspectors
+import org.scalatest.wordspec.AnyWordSpec
 
 abstract class CoderSpec(codecName: String) extends AnyWordSpec with CodecSpecSupport with Inspectors {
   import CompressionTestingTools._

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/ActorRefSourceSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/ActorRefSourceSpec.scala
@@ -16,8 +16,6 @@ package org.apache.pekko.stream.scaladsl
 import scala.annotation.nowarn
 import scala.concurrent.duration._
 
-import org.reactivestreams.Publisher
-
 import org.apache.pekko
 import pekko.Done
 import pekko.actor.{ ActorRef, Status }
@@ -25,6 +23,8 @@ import pekko.stream.{ OverflowStrategy, _ }
 import pekko.stream.testkit._
 import pekko.stream.testkit.Utils._
 import pekko.stream.testkit.scaladsl._
+
+import org.reactivestreams.Publisher
 
 @nowarn("msg=deprecated")
 class ActorRefSourceSpec extends StreamSpec {

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/AggregateWithBoundarySpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/AggregateWithBoundarySpec.scala
@@ -17,15 +17,16 @@ import scala.collection.mutable.ListBuffer
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import com.typesafe.config.{ ConfigFactory, ConfigValueFactory }
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpecLike
-
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.stream.OverflowStrategy
 import pekko.stream.testkit.{ StreamSpec, TestPublisher, TestSubscriber }
 import pekko.testkit.{ ExplicitlyTriggeredScheduler, PekkoSpec }
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import com.typesafe.config.{ ConfigFactory, ConfigValueFactory }
 
 class AggregateWithBoundarySpec extends StreamSpec {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/AttributesSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/AttributesSpec.scala
@@ -14,21 +14,23 @@
 package org.apache.pekko.stream.scaladsl
 
 import java.util.concurrent.{ CompletionStage, TimeUnit }
+
 import scala.annotation.nowarn
 
-import com.typesafe.config.ConfigFactory
 import org.apache.pekko
 import pekko.{ Done, NotUsed }
 import pekko.actor.ActorSystem
 import pekko.dispatch.Dispatchers
-import pekko.stream.ActorAttributes.Dispatcher
 import pekko.stream._
+import pekko.stream.ActorAttributes.Dispatcher
 import pekko.stream.Attributes._
 import pekko.stream.javadsl
-import pekko.stream.stage._
 import pekko.stream.snapshot.MaterializerState
+import pekko.stream.stage._
 import pekko.stream.testkit._
 import pekko.testkit.TestKit
+
+import com.typesafe.config.ConfigFactory
 
 object AttributesSpec {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/CoupledTerminationFlowSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/CoupledTerminationFlowSpec.scala
@@ -19,11 +19,6 @@ import scala.util.Success
 import scala.util.Try
 import scala.xml.Node
 
-import org.reactivestreams.Publisher
-import org.reactivestreams.Subscriber
-import org.reactivestreams.Subscription
-import org.scalatest.Assertion
-
 import org.apache.pekko
 import pekko.Done
 import pekko.NotUsed
@@ -31,6 +26,12 @@ import pekko.stream._
 import pekko.stream.testkit._
 import pekko.stream.testkit.scaladsl.TestSource
 import pekko.testkit.TestProbe
+
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+
+import org.scalatest.Assertion
 
 class CoupledTerminationFlowSpec extends StreamSpec("""
     pekko.stream.materializer.initial-input-buffer-size = 2

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowAppendSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowAppendSpec.scala
@@ -13,13 +13,14 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import org.reactivestreams.Subscriber
-import org.scalatest.matchers.should.Matchers
-
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.stream.testkit.StreamSpec
 import pekko.stream.testkit.TestSubscriber
+
+import org.reactivestreams.Subscriber
+
+import org.scalatest.matchers.should.Matchers
 
 class FlowAppendSpec extends StreamSpec with River {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowCompileSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowCompileSpec.scala
@@ -17,11 +17,11 @@ import scala.annotation.nowarn
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
 
-import org.reactivestreams.Publisher
-
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream.testkit.StreamSpec
+
+import org.reactivestreams.Publisher
 
 @nowarn // unused vars are used in shouldNot compile tests
 class FlowCompileSpec extends StreamSpec {

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowConcatAllLazySpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowConcatAllLazySpec.scala
@@ -13,13 +13,14 @@
 
 package org.apache.pekko.stream.scaladsl
 
+import java.util.StringJoiner
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.util.control.NoStackTrace
+
 import org.apache.pekko
 import pekko.stream.testkit._
 import pekko.stream.testkit.scaladsl.TestSink
-
-import java.util.StringJoiner
-import java.util.concurrent.atomic.AtomicBoolean
-import scala.util.control.NoStackTrace
 
 class FlowConcatAllLazySpec extends StreamSpec("""
     pekko.stream.materializer.initial-input-buffer-size = 2

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowConcatSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowConcatSpec.scala
@@ -19,9 +19,6 @@ import scala.concurrent.Await
 import scala.concurrent.Promise
 import scala.concurrent.duration._
 
-import org.reactivestreams.Publisher
-import org.scalatest.concurrent.ScalaFutures
-
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream.testkit.BaseTwoStreamsSetup
@@ -29,6 +26,10 @@ import pekko.stream.testkit.TestPublisher
 import pekko.stream.testkit.TestSubscriber
 import pekko.stream.testkit.scaladsl.StreamTestKit._
 import pekko.stream.testkit.scaladsl.TestSink
+
+import org.reactivestreams.Publisher
+
+import org.scalatest.concurrent.ScalaFutures
 
 abstract class AbstractFlowConcatSpec extends BaseTwoStreamsSetup {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowDelaySpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowDelaySpec.scala
@@ -17,10 +17,6 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import org.scalatest.concurrent.PatienceConfiguration
-import org.scalatest.time.Milliseconds
-import org.scalatest.time.Span
-
 import org.apache.pekko
 import pekko.Done
 import pekko.stream._
@@ -32,6 +28,10 @@ import pekko.stream.testkit.TestSubscriber
 import pekko.stream.testkit.scaladsl.TestSink
 import pekko.testkit.TestDuration
 import pekko.testkit.TimingTest
+
+import org.scalatest.concurrent.PatienceConfiguration
+import org.scalatest.time.Milliseconds
+import org.scalatest.time.Span
 
 class FlowDelaySpec extends StreamSpec {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowFlattenMergeSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowFlattenMergeSpec.scala
@@ -16,8 +16,6 @@ package org.apache.pekko.stream.scaladsl
 import scala.concurrent._
 import scala.concurrent.duration._
 
-import org.scalatest.exceptions.TestFailedException
-
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream._
@@ -32,6 +30,8 @@ import pekko.stream.testkit.Utils.TE
 import pekko.stream.testkit.scaladsl.TestSink
 import pekko.testkit.TestLatch
 import pekko.util.OptionVal
+
+import org.scalatest.exceptions.TestFailedException
 
 class FlowFlattenMergeSpec extends StreamSpec {
   import system.dispatcher

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowFoldAsyncSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowFoldAsyncSpec.scala
@@ -19,8 +19,6 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import org.scalatest.concurrent.PatienceConfiguration.Timeout
-
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream.ActorAttributes.supervisionStrategy
@@ -30,6 +28,8 @@ import pekko.stream.impl.ReactiveStreamsCompliance
 import pekko.stream.testkit._
 import pekko.stream.testkit.Utils._
 import pekko.testkit.LongRunningTest
+
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
 
 class FlowFoldAsyncSpec extends StreamSpec {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowGroupBySpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowGroupBySpec.scala
@@ -22,9 +22,6 @@ import scala.concurrent.Await
 import scala.concurrent.Promise
 import scala.concurrent.duration._
 
-import org.reactivestreams.Publisher
-import org.scalatest.concurrent.PatienceConfiguration.Timeout
-
 import org.apache.pekko
 import pekko.Done
 import pekko.NotUsed
@@ -40,6 +37,10 @@ import pekko.stream.testkit.scaladsl.TestSink
 import pekko.stream.testkit.scaladsl.TestSource
 import pekko.testkit.TestLatch
 import pekko.util.ByteString
+
+import org.reactivestreams.Publisher
+
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
 
 object FlowGroupBySpec {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowInterleaveAllSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowInterleaveAllSpec.scala
@@ -13,12 +13,12 @@
 
 package org.apache.pekko.stream.scaladsl
 
+import java.util.StringJoiner
+
 import org.apache.pekko
 import pekko.stream.testkit._
 import pekko.stream.testkit.scaladsl.StreamTestKit._
 import pekko.stream.testkit.scaladsl.TestSink
-
-import java.util.StringJoiner
 
 class FlowInterleaveAllSpec extends StreamSpec("""
     pekko.stream.materializer.initial-input-buffer-size = 2

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowInterleaveSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowInterleaveSpec.scala
@@ -13,11 +13,11 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import org.reactivestreams.Publisher
-
 import org.apache.pekko
 import pekko.stream.testkit._
 import pekko.stream.testkit.scaladsl.StreamTestKit._
+
+import org.reactivestreams.Publisher
 
 class FlowInterleaveSpec extends BaseTwoStreamsSetup {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowJoinSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowJoinSpec.scala
@@ -15,13 +15,13 @@ package org.apache.pekko.stream.scaladsl
 
 import scala.collection.immutable
 
-import org.scalatest.time._
-
 import org.apache.pekko
 import pekko.stream.FlowShape
 import pekko.stream.OverflowStrategy
 import pekko.stream.testkit._
 import pekko.stream.testkit.scaladsl._
+
+import org.scalatest.time._
 
 class FlowJoinSpec extends StreamSpec("""
     pekko.stream.materializer.initial-input-buffer-size = 2

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapAsyncSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapAsyncSpec.scala
@@ -24,8 +24,6 @@ import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import org.scalatest.concurrent.PatienceConfiguration.Timeout
-
 import org.apache.pekko
 import pekko.stream.ActorAttributes
 import pekko.stream.ActorAttributes.supervisionStrategy
@@ -36,6 +34,8 @@ import pekko.stream.testkit.Utils._
 import pekko.stream.testkit.scaladsl.TestSink
 import pekko.testkit.TestLatch
 import pekko.testkit.TestProbe
+
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
 
 class FlowMapAsyncSpec extends StreamSpec {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapAsyncUnorderedSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapAsyncUnorderedSpec.scala
@@ -23,8 +23,6 @@ import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import org.scalatest.concurrent.PatienceConfiguration.Timeout
-
 import org.apache.pekko
 import pekko.stream.ActorAttributes.supervisionStrategy
 import pekko.stream.Supervision.resumingDecider
@@ -32,6 +30,8 @@ import pekko.stream.testkit._
 import pekko.stream.testkit.scaladsl._
 import pekko.testkit.TestLatch
 import pekko.testkit.TestProbe
+
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
 
 class FlowMapAsyncUnorderedSpec extends StreamSpec {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMergeSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMergeSpec.scala
@@ -13,11 +13,11 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import org.reactivestreams.Publisher
-
 import org.apache.pekko
 import pekko.stream.testkit._
 import pekko.stream.testkit.scaladsl.StreamTestKit._
+
+import org.reactivestreams.Publisher
 
 class FlowMergeSpec extends BaseTwoStreamsSetup {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowOnErrorCompleteSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowOnErrorCompleteSpec.scala
@@ -17,11 +17,12 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import org.apache.pekko.stream.testkit.StreamSpec
-import org.apache.pekko.stream.testkit.scaladsl.TestSink
-
 import scala.concurrent.TimeoutException
 import scala.util.control.NoStackTrace
+
+import org.apache.pekko
+import pekko.stream.testkit.StreamSpec
+import pekko.stream.testkit.scaladsl.TestSink
 
 class FlowOnErrorCompleteSpec extends StreamSpec {
   val ex = new RuntimeException("ex") with NoStackTrace

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowScanAsyncSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowScanAsyncSpec.scala
@@ -20,8 +20,6 @@ import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.util.Failure
 
-import org.scalatest.matchers.should.Matchers
-
 import org.apache.pekko
 import pekko.pattern
 import pekko.stream.ActorAttributes
@@ -31,6 +29,8 @@ import pekko.stream.testkit._
 import pekko.stream.testkit.TestSubscriber.Probe
 import pekko.stream.testkit.Utils.TE
 import pekko.stream.testkit.scaladsl._
+
+import org.scalatest.matchers.should.Matchers
 
 class FlowScanAsyncSpec extends StreamSpec with Matchers {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowSpec.scala
@@ -14,13 +14,14 @@
 package org.apache.pekko.stream.scaladsl
 
 import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.atomic.AtomicLong
+
+import scala.annotation.nowarn
 import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
-import scala.annotation.nowarn
-import com.typesafe.config.ConfigFactory
-import org.reactivestreams.{ Publisher, Subscriber }
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream._
@@ -30,7 +31,9 @@ import pekko.stream.testkit._
 import pekko.stream.testkit.scaladsl.{ TestSink, TestSource }
 import pekko.testkit.TestDuration
 
-import java.util.concurrent.atomic.AtomicLong
+import org.reactivestreams.{ Publisher, Subscriber }
+
+import com.typesafe.config.ConfigFactory
 
 object FlowSpec {
   class Fruit extends Serializable

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowSplitAfterSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowSplitAfterSpec.scala
@@ -16,8 +16,6 @@ package org.apache.pekko.stream.scaladsl
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import org.reactivestreams.Publisher
-
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream._
@@ -28,6 +26,8 @@ import pekko.stream.testkit.StreamSpec
 import pekko.stream.testkit.TestPublisher
 import pekko.stream.testkit.TestSubscriber
 import pekko.stream.testkit.Utils._
+
+import org.reactivestreams.Publisher
 
 object FlowSplitAfterSpec {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowSplitWhenSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowSplitWhenSpec.scala
@@ -17,8 +17,6 @@ import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-import org.reactivestreams.Publisher
-
 import org.apache.pekko
 import pekko.Done
 import pekko.NotUsed
@@ -29,6 +27,8 @@ import pekko.stream.impl.fusing.Split
 import pekko.stream.testkit._
 import pekko.stream.testkit.Utils._
 import pekko.stream.testkit.scaladsl.TestSink
+
+import org.reactivestreams.Publisher
 
 class FlowSplitWhenSpec extends StreamSpec("""
     pekko.stream.materializer.initial-input-buffer-size = 2

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowStatefulMapConcatSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowStatefulMapConcatSpec.scala
@@ -13,6 +13,7 @@
 
 package org.apache.pekko.stream.scaladsl
 
+import scala.annotation.nowarn
 import scala.util.control.NoStackTrace
 
 import org.apache.pekko
@@ -20,8 +21,6 @@ import pekko.stream.ActorAttributes
 import pekko.stream.Supervision
 import pekko.stream.testkit._
 import pekko.stream.testkit.scaladsl.TestSink
-
-import scala.annotation.nowarn
 
 @nowarn("msg=deprecated")
 class FlowStatefulMapConcatSpec extends StreamSpec("""

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowZipAllSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowZipAllSpec.scala
@@ -13,11 +13,11 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import org.reactivestreams.Publisher
-
 import org.apache.pekko
 import pekko.stream.testkit.{ BaseTwoStreamsSetup, TestSubscriber }
 import pekko.stream.testkit.scaladsl.StreamTestKit._
+
+import org.reactivestreams.Publisher
 
 class FlowZipAllSpec extends BaseTwoStreamsSetup {
   override type Outputs = (Int, Int)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/ForComprehensionsCompileSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/ForComprehensionsCompileSpec.scala
@@ -17,15 +17,16 @@
 
 package org.apache.pekko.stream.scaladsl
 
+import java.util.concurrent.CopyOnWriteArrayList
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
 import org.apache.pekko
 import pekko.Done
 import pekko.japi.Util
 import pekko.stream.testkit.StreamSpec
 import pekko.stream.testkit.scaladsl.TestSink
-
-import java.util.concurrent.CopyOnWriteArrayList
-import scala.concurrent.Await
-import scala.concurrent.duration.DurationInt
 
 class ForComprehensionsCompileSpec extends StreamSpec {
   "A Source" must {

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphBackedFlowSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphBackedFlowSpec.scala
@@ -15,13 +15,13 @@ package org.apache.pekko.stream.scaladsl
 
 import scala.annotation.nowarn
 
-import org.reactivestreams.Subscriber
-
 import org.apache.pekko
 import pekko.stream._
 import pekko.stream.ActorMaterializer
 import pekko.stream.ActorMaterializerSettings
 import pekko.stream.testkit._
+
+import org.reactivestreams.Subscriber
 
 object GraphFlowSpec {
   val source1 = Source(0 to 3)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphUnzipWithSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphUnzipWithSpec.scala
@@ -17,8 +17,6 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import org.reactivestreams.Publisher
-
 import org.apache.pekko
 import pekko.Done
 import pekko.NotUsed
@@ -29,6 +27,8 @@ import pekko.stream.testkit.Utils.TE
 import pekko.testkit.EventFilter
 import pekko.testkit.TestProbe
 import pekko.util.unused
+
+import org.reactivestreams.Publisher
 
 class GraphUnzipWithSpec extends StreamSpec("""
     pekko.stream.materializer.initial-input-buffer-size = 2

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphZipLatestSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphZipLatestSpec.scala
@@ -17,7 +17,6 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 
 import org.scalacheck.Gen
-import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import org.apache.pekko
@@ -28,6 +27,8 @@ import pekko.stream.testkit.TestPublisher.Probe
 import pekko.stream.testkit.TestSubscriber
 import pekko.stream.testkit.scaladsl.TestSink
 import pekko.stream.testkit.scaladsl.TestSource
+
+import org.scalatest.concurrent.ScalaFutures
 
 object GraphZipLatestSpec {
   val someString = "someString"

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphZipLatestWithSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphZipLatestWithSpec.scala
@@ -16,12 +16,12 @@ package org.apache.pekko.stream.scaladsl
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-import org.reactivestreams.Publisher
-
 import org.apache.pekko
 import pekko.stream._
 import pekko.stream.testkit._
 import pekko.testkit.EventFilter
+
+import org.reactivestreams.Publisher
 
 class GraphZipLatestWithSpec extends TwoStreamsSetup {
   import GraphDSL.Implicits._

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/LazilyAsyncSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/LazilyAsyncSpec.scala
@@ -18,13 +18,13 @@ import java.util.concurrent.atomic.AtomicBoolean
 import scala.annotation.nowarn
 import scala.concurrent.Future
 
-import org.scalatest.concurrent.ScalaFutures
-
 import org.apache.pekko
 import pekko.Done
 import pekko.stream.testkit.StreamSpec
 import pekko.stream.testkit.TestSubscriber
 import pekko.testkit.DefaultTimeout
+
+import org.scalatest.concurrent.ScalaFutures
 
 @nowarn("msg=deprecated") // tests deprecated methods
 class LazilyAsyncSpec extends StreamSpec with DefaultTimeout with ScalaFutures {

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/LazySourceSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/LazySourceSpec.scala
@@ -19,8 +19,6 @@ import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.concurrent.Promise
 
-import org.scalatest.concurrent.ScalaFutures
-
 import org.apache.pekko
 import pekko.Done
 import pekko.NotUsed
@@ -35,6 +33,8 @@ import pekko.stream.testkit.TestSubscriber
 import pekko.stream.testkit.Utils.TE
 import pekko.testkit.DefaultTimeout
 import pekko.testkit.TestProbe
+
+import org.scalatest.concurrent.ScalaFutures
 
 class LazySourceSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/QueueSourceSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/QueueSourceSpec.scala
@@ -17,8 +17,6 @@ import scala.annotation.nowarn
 import scala.concurrent._
 import scala.concurrent.duration._
 
-import org.scalatest.time.Span
-
 import org.apache.pekko
 import pekko.Done
 import pekko.actor.Status
@@ -31,6 +29,8 @@ import pekko.stream.testkit.TestSourceStage
 import pekko.stream.testkit.TestSubscriber
 import pekko.stream.testkit.scaladsl.TestSink
 import pekko.testkit.TestProbe
+
+import org.scalatest.time.Span
 
 class QueueSourceSpec extends StreamSpec {
   implicit val ec: ExecutionContextExecutor = system.dispatcher

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/RetryFlowSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/RetryFlowSpec.scala
@@ -16,13 +16,13 @@ package org.apache.pekko.stream.scaladsl
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success, Try }
 
-import org.scalatest.matchers.{ MatchResult, Matcher }
-
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream.OverflowStrategy
 import pekko.stream.testkit.{ StreamSpec, TestPublisher, TestSubscriber }
 import pekko.stream.testkit.scaladsl.{ TestSink, TestSource }
+
+import org.scalatest.matchers.{ MatchResult, Matcher }
 
 class RetryFlowSpec extends StreamSpec("""
     pekko.stream.materializer.initial-input-buffer-size = 1

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SinkSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SinkSpec.scala
@@ -18,7 +18,6 @@ import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 
 import org.apache.pekko
-import org.scalatest.concurrent.ScalaFutures
 import pekko.Done
 import pekko.stream._
 import pekko.stream.testkit._
@@ -26,6 +25,8 @@ import pekko.stream.testkit.scaladsl.{ TestSink, TestSource }
 import pekko.testkit.DefaultTimeout
 
 import org.reactivestreams.Publisher
+
+import org.scalatest.concurrent.ScalaFutures
 
 class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SourceFromPublisherSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SourceFromPublisherSpec.scala
@@ -13,14 +13,14 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AsyncWordSpecLike
-
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.stream.Attributes
 import pekko.stream.testkit.TestPublisher
 import pekko.testkit.TestKit
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpecLike
 
 class SourceFromPublisherSpec
     extends TestKit(ActorSystem("source-from-publisher-spec"))

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/StreamConvertersSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/StreamConvertersSpec.scala
@@ -26,15 +26,15 @@ import java.util.stream.Collectors
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import org.scalatest.time.Millis
-import org.scalatest.time.Span
-
 import org.apache.pekko
 import pekko.stream.ActorAttributes
 import pekko.stream.testkit.StreamSpec
 import pekko.stream.testkit.Utils.TE
 import pekko.testkit.DefaultTimeout
 import pekko.util.ByteString
+
+import org.scalatest.time.Millis
+import org.scalatest.time.Span
 
 class StreamConvertersSpec extends StreamSpec with DefaultTimeout {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/StreamRefsSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/StreamRefsSpec.scala
@@ -19,8 +19,6 @@ import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import com.typesafe.config._
-
 import org.apache.pekko
 import pekko.{ Done, NotUsed }
 import pekko.actor.{ Actor, ActorIdentity, ActorLogging, ActorRef, ActorSystem, ActorSystemImpl, Identify, Props }
@@ -33,6 +31,8 @@ import pekko.stream.testkit.Utils.TE
 import pekko.stream.testkit.scaladsl._
 import pekko.testkit.{ PekkoSpec, TestKit, TestProbe }
 import pekko.util.ByteString
+
+import com.typesafe.config._
 
 object StreamRefsSpec {
 

--- a/stream/src/main/scala/com/typesafe/sslconfig/pekko/PekkoSSLConfig.scala
+++ b/stream/src/main/scala/com/typesafe/sslconfig/pekko/PekkoSSLConfig.scala
@@ -15,14 +15,17 @@ package com.typesafe.sslconfig.pekko
 
 import java.util.Collections
 import javax.net.ssl._
-import com.typesafe.sslconfig.pekko.util.PekkoLoggerFactory
-import com.typesafe.sslconfig.ssl._
-import com.typesafe.sslconfig.util.LoggerFactory
+
+import scala.annotation.nowarn
+
 import org.apache.pekko
 import pekko.actor._
 import pekko.annotation.InternalApi
 import pekko.event.Logging
-import scala.annotation.nowarn
+
+import com.typesafe.sslconfig.pekko.util.PekkoLoggerFactory
+import com.typesafe.sslconfig.ssl._
+import com.typesafe.sslconfig.util.LoggerFactory
 
 @deprecated("Use Tcp and TLS with SSLEngine parameters instead. Setup the SSLEngine with needed parameters.",
   "Akka 2.6.0")

--- a/stream/src/main/scala/com/typesafe/sslconfig/pekko/util/PekkoLoggerBridge.scala
+++ b/stream/src/main/scala/com/typesafe/sslconfig/pekko/util/PekkoLoggerBridge.scala
@@ -13,12 +13,12 @@
 
 package com.typesafe.sslconfig.pekko.util
 
-import com.typesafe.sslconfig.util.{ LoggerFactory, NoDepsLogger }
-
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.event.{ DummyClassForStringSources, EventStream }
 import pekko.event.Logging._
+
+import com.typesafe.sslconfig.util.{ LoggerFactory, NoDepsLogger }
 
 final class PekkoLoggerFactory(system: ActorSystem) extends LoggerFactory {
   override def apply(clazz: Class[_]): NoDepsLogger = new PekkoLoggerBridge(system.eventStream, clazz)

--- a/stream/src/main/scala/org/apache/pekko/stream/ActorMaterializer.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/ActorMaterializer.scala
@@ -15,12 +15,9 @@ package org.apache.pekko.stream
 
 import java.util.concurrent.TimeUnit
 
+import scala.annotation.nowarn
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
-
-import scala.annotation.nowarn
-import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
 
 import org.apache.pekko
 import pekko.actor.ActorContext
@@ -35,6 +32,9 @@ import pekko.japi.function
 import pekko.stream.impl._
 import pekko.stream.stage.GraphStageLogic
 import pekko.util.Helpers.toRootLowerCase
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
 
 object ActorMaterializer {
 

--- a/stream/src/main/scala/org/apache/pekko/stream/IOResult.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/IOResult.scala
@@ -13,10 +13,9 @@
 
 package org.apache.pekko.stream
 
+import scala.annotation.nowarn
 import scala.util.{ Failure, Success, Try }
 import scala.util.control.NoStackTrace
-
-import scala.annotation.nowarn
 
 import org.apache.pekko
 import pekko.Done

--- a/stream/src/main/scala/org/apache/pekko/stream/MapAsyncPartitioned.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/MapAsyncPartitioned.scala
@@ -19,8 +19,8 @@ package org.apache.pekko.stream
 
 import scala.collection.mutable
 import scala.concurrent.Future
-import scala.util.control.{ NoStackTrace, NonFatal }
 import scala.util.{ Failure, Success, Try }
+import scala.util.control.{ NoStackTrace, NonFatal }
 
 import org.apache.pekko
 import pekko.annotation.InternalApi

--- a/stream/src/main/scala/org/apache/pekko/stream/Materializer.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/Materializer.scala
@@ -13,10 +13,9 @@
 
 package org.apache.pekko.stream
 
+import scala.annotation.{ implicitNotFound, nowarn }
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration.FiniteDuration
-
-import scala.annotation.{ implicitNotFound, nowarn }
 
 import org.apache.pekko
 import pekko.actor.ActorRef

--- a/stream/src/main/scala/org/apache/pekko/stream/RestartSettings.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/RestartSettings.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.stream
 
 import scala.concurrent.duration.FiniteDuration
+
 import org.apache.pekko
 import pekko.event.Logging
 import pekko.event.Logging.LogLevel

--- a/stream/src/main/scala/org/apache/pekko/stream/StreamRefSettings.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/StreamRefSettings.scala
@@ -15,15 +15,15 @@ package org.apache.pekko.stream
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.duration._
-
 import scala.annotation.nowarn
-import com.typesafe.config.Config
+import scala.concurrent.duration._
 
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.annotation.DoNotInherit
 import pekko.stream.impl.streamref.StreamRefSettingsImpl
+
+import com.typesafe.config.Config
 
 @nowarn("msg=deprecated")
 object StreamRefSettings {

--- a/stream/src/main/scala/org/apache/pekko/stream/StreamTimeoutException.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/StreamTimeoutException.scala
@@ -17,11 +17,11 @@
 
 package org.apache.pekko.stream
 
-import org.apache.pekko
-import pekko.annotation.DoNotInherit
-
 import scala.concurrent.TimeoutException
 import scala.util.control.NoStackTrace
+
+import org.apache.pekko
+import pekko.annotation.DoNotInherit
 
 /**
  * Base class for timeout exceptions specific to Pekko Streams

--- a/stream/src/main/scala/org/apache/pekko/stream/SubscriptionWithCancelException.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/SubscriptionWithCancelException.scala
@@ -15,9 +15,9 @@ package org.apache.pekko.stream
 
 import scala.util.control.NoStackTrace
 
-import org.reactivestreams.Subscription
-
 import org.apache.pekko.annotation.DoNotInherit
+
+import org.reactivestreams.Subscription
 
 /**
  * Extension of Subscription that allows to pass a cause when a subscription is cancelled.

--- a/stream/src/main/scala/org/apache/pekko/stream/SubstreamCancelStrategy.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/SubstreamCancelStrategy.scala
@@ -13,9 +13,9 @@
 
 package org.apache.pekko.stream
 
-import SubstreamCancelStrategies._
-
 import scala.annotation.nowarn
+
+import SubstreamCancelStrategies._
 
 /**
  * Represents a strategy that decides how to deal with substream events.

--- a/stream/src/main/scala/org/apache/pekko/stream/SystemMaterializer.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/SystemMaterializer.scala
@@ -13,10 +13,9 @@
 
 package org.apache.pekko.stream
 
+import scala.annotation.nowarn
 import scala.concurrent.Await
 import scala.concurrent.Promise
-
-import scala.annotation.nowarn
 
 import org.apache.pekko
 import pekko.actor.ActorSystem

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/ActorMaterializerImpl.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/ActorMaterializerImpl.scala
@@ -15,10 +15,11 @@ package org.apache.pekko.stream.impl
 
 import java.util.concurrent.atomic.AtomicBoolean
 
+import scala.annotation.nowarn
 import scala.collection.immutable
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration._
-import scala.annotation.nowarn
+
 import org.apache.pekko
 import pekko.actor._
 import pekko.annotation.DoNotInherit

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/ActorProcessor.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/ActorProcessor.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.stream.impl
 
-import org.reactivestreams.{ Processor, Subscriber, Subscription }
-
 import org.apache.pekko
 import pekko.actor._
 import pekko.annotation.InternalApi
@@ -23,6 +21,8 @@ import pekko.stream.{ AbruptTerminationException, Attributes }
 import pekko.stream.ActorAttributes
 import pekko.stream.impl.ActorSubscriberMessage.{ OnComplete, OnError, OnNext, OnSubscribe }
 import pekko.util.unused
+
+import org.reactivestreams.{ Processor, Subscriber, Subscription }
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/ActorPublisher.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/ActorPublisher.scala
@@ -19,12 +19,12 @@ import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.util.control.NoStackTrace
 
-import org.reactivestreams.{ Publisher, Subscriber }
-import org.reactivestreams.Subscription
-
 import org.apache.pekko
 import pekko.actor.{ Actor, ActorRef, Terminated }
 import pekko.annotation.InternalApi
+
+import org.reactivestreams.{ Publisher, Subscriber }
+import org.reactivestreams.Subscription
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/ActorRefBackpressureSinkStage.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/ActorRefBackpressureSinkStage.scala
@@ -13,15 +13,15 @@
 
 package org.apache.pekko.stream.impl
 
+import java.util
+
 import org.apache.pekko
 import pekko.actor._
 import pekko.annotation.InternalApi
-import pekko.stream.Attributes.InputBuffer
 import pekko.stream._
+import pekko.stream.Attributes.InputBuffer
 import pekko.stream.impl.Stages.DefaultAttributes
 import pekko.stream.stage._
-
-import java.util
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/ActorSubscriberMessage.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/ActorSubscriberMessage.scala
@@ -13,12 +13,12 @@
 
 package org.apache.pekko.stream.impl
 
-import org.reactivestreams.Subscription
-
 import org.apache.pekko
 import pekko.actor.DeadLetterSuppression
 import pekko.actor.NoSerializationVerificationNeeded
 import pekko.annotation.InternalApi
+
+import org.reactivestreams.Subscription
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/Buffers.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/Buffers.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.stream.impl
 
 import java.{ util => ju }
+
 import org.apache.pekko
 import pekko.annotation.{ InternalApi, InternalStableApi }
 import pekko.stream._

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/CompletedPublishers.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/CompletedPublishers.scala
@@ -13,9 +13,9 @@
 
 package org.apache.pekko.stream.impl
 
-import org.reactivestreams.{ Publisher, Subscriber, Subscription }
-
 import org.apache.pekko.annotation.InternalApi
+
+import org.reactivestreams.{ Publisher, Subscriber, Subscription }
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/FanIn.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/FanIn.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.stream.impl
 
-import org.reactivestreams.{ Subscriber, Subscription }
-
 import org.apache.pekko
 import pekko.actor._
 import pekko.annotation.{ DoNotInherit, InternalApi }
@@ -22,6 +20,8 @@ import pekko.stream.AbruptTerminationException
 import pekko.stream.ActorAttributes
 import pekko.stream.Attributes
 import pekko.util.unused
+
+import org.reactivestreams.{ Subscriber, Subscription }
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/FanOut.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/FanOut.scala
@@ -15,8 +15,6 @@ package org.apache.pekko.stream.impl
 
 import scala.collection.immutable
 
-import org.reactivestreams.Subscription
-
 import org.apache.pekko
 import pekko.actor._
 import pekko.annotation.{ DoNotInherit, InternalApi }
@@ -24,6 +22,8 @@ import pekko.stream.AbruptTerminationException
 import pekko.stream.ActorAttributes
 import pekko.stream.Attributes
 import pekko.util.unused
+
+import org.reactivestreams.Subscription
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/FanoutProcessor.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/FanoutProcessor.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.stream.impl
 
-import org.reactivestreams.Subscriber
-
 import org.apache.pekko
 import pekko.actor.Actor
 import pekko.actor.ActorRef
@@ -25,6 +23,8 @@ import pekko.stream.ActorAttributes.StreamSubscriptionTimeout
 import pekko.stream.Attributes
 import pekko.stream.StreamSubscriptionTimeoutTerminationMode
 import pekko.util.OptionVal
+
+import org.reactivestreams.Subscriber
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/JsonObjectParser.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/JsonObjectParser.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.stream.impl
 
 import scala.annotation.switch
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.stream.scaladsl.Framing.FramingException

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/LazySource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/LazySource.scala
@@ -15,10 +15,11 @@ package org.apache.pekko.stream.impl
 
 import scala.concurrent.{ Future, Promise }
 import scala.util.control.NonFatal
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
-import pekko.stream.Attributes.SourceLocation
 import pekko.stream._
+import pekko.stream.Attributes.SourceLocation
 import pekko.stream.impl.Stages.DefaultAttributes
 import pekko.stream.scaladsl.{ Keep, Source }
 import pekko.stream.stage._

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/MaterializerGuardian.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/MaterializerGuardian.scala
@@ -13,9 +13,8 @@
 
 package org.apache.pekko.stream.impl
 
-import scala.concurrent.Promise
-
 import scala.annotation.nowarn
+import scala.concurrent.Promise
 
 import org.apache.pekko
 import pekko.actor.Actor

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/Modules.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/Modules.scala
@@ -15,14 +15,14 @@ package org.apache.pekko.stream.impl
 
 import scala.annotation.unchecked.uncheckedVariance
 
-import org.reactivestreams._
-
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.{ DoNotInherit, InternalApi }
 import pekko.event.Logging
 import pekko.stream._
 import pekko.stream.impl.StreamLayout.AtomicModule
+
+import org.reactivestreams._
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/PhasedFusingActorMaterializer.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/PhasedFusingActorMaterializer.scala
@@ -16,14 +16,10 @@ package org.apache.pekko.stream.impl
 import java.util
 import java.util.concurrent.atomic.AtomicBoolean
 
+import scala.annotation.nowarn
 import scala.collection.immutable.Map
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration.FiniteDuration
-
-import scala.annotation.nowarn
-import org.reactivestreams.Processor
-import org.reactivestreams.Publisher
-import org.reactivestreams.Subscriber
 
 import org.apache.pekko
 import pekko.NotUsed
@@ -54,6 +50,10 @@ import pekko.stream.stage.GraphStageLogic
 import pekko.stream.stage.InHandler
 import pekko.stream.stage.OutHandler
 import pekko.util.OptionVal
+
+import org.reactivestreams.Processor
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/ReactiveStreamsCompliance.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/ReactiveStreamsCompliance.scala
@@ -15,11 +15,11 @@ package org.apache.pekko.stream.impl
 
 import scala.util.control.NonFatal
 
-import org.reactivestreams.{ Subscriber, Subscription }
-
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.stream.SubscriptionWithCancelException
+
+import org.reactivestreams.{ Subscriber, Subscription }
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/SetupStage.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/SetupStage.scala
@@ -16,10 +16,11 @@ package org.apache.pekko.stream.impl
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.util.control.NonFatal
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
-import pekko.stream.Attributes.SourceLocation
 import pekko.stream._
+import pekko.stream.Attributes.SourceLocation
 import pekko.stream.scaladsl.Flow
 import pekko.stream.scaladsl.Keep
 import pekko.stream.scaladsl.Sink

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/SinkholeSubscriber.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/SinkholeSubscriber.scala
@@ -15,11 +15,11 @@ package org.apache.pekko.stream.impl
 
 import scala.concurrent.Promise
 
-import org.reactivestreams.{ Subscriber, Subscription }
-
 import org.apache.pekko
 import pekko.Done
 import pekko.annotation.InternalApi
+
+import org.reactivestreams.{ Subscriber, Subscription }
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/Sinks.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/Sinks.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.stream.impl
 
 import java.util.function.BinaryOperator
+
 import scala.collection.immutable
 import scala.collection.mutable
 import scala.concurrent.Future
@@ -22,8 +23,7 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 import scala.util.control.NonFatal
-import org.reactivestreams.Publisher
-import org.reactivestreams.Subscriber
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.DoNotInherit
@@ -41,6 +41,9 @@ import pekko.stream.impl.StreamLayout.AtomicModule
 import pekko.stream.scaladsl.{ Keep, Sink, SinkQueueWithCancel, Source }
 import pekko.stream.stage._
 import pekko.util.ccompat._
+
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/StreamLayout.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/StreamLayout.scala
@@ -18,16 +18,16 @@ import java.util.concurrent.atomic.AtomicReference
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
-import org.reactivestreams.Processor
-import org.reactivestreams.Publisher
-import org.reactivestreams.Subscriber
-import org.reactivestreams.Subscription
-
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.stream._
 import pekko.stream.impl.Stages.DefaultAttributes
 import pekko.util.OptionVal
+
+import org.reactivestreams.Processor
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/StreamSubscriptionTimeout.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/StreamSubscriptionTimeout.scala
@@ -13,17 +13,17 @@
 
 package org.apache.pekko.stream.impl
 
+import scala.annotation.nowarn
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NoStackTrace
-
-import scala.annotation.nowarn
-import org.reactivestreams._
 
 import org.apache.pekko
 import pekko.actor._
 import pekko.annotation.InternalApi
 import pekko.stream.StreamSubscriptionTimeoutSettings
 import pekko.stream.StreamSubscriptionTimeoutTerminationMode.{ CancelTermination, NoopTermination, WarnTermination }
+
+import org.reactivestreams._
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/Throttle.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/Throttle.scala
@@ -13,15 +13,15 @@
 
 package org.apache.pekko.stream.impl
 
+import scala.concurrent.duration.{ FiniteDuration, _ }
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
-import pekko.stream.ThrottleMode.Enforcing
 import pekko.stream._
+import pekko.stream.ThrottleMode.Enforcing
 import pekko.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
 import pekko.stream.stage._
 import pekko.util.NanoTimeTokenBucket
-
-import scala.concurrent.duration.{ FiniteDuration, _ }
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/Unfold.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/Unfold.scala
@@ -13,17 +13,18 @@
 
 package org.apache.pekko.stream.impl
 
+import java.util.Optional
+import java.util.concurrent.CompletionStage
+
+import scala.concurrent.Future
+import scala.util.{ Failure, Success, Try }
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.japi.{ function, Pair }
 import pekko.stream._
 import pekko.stream.impl.Stages.DefaultAttributes
 import pekko.stream.stage.{ GraphStage, GraphStageLogic, OutHandler }
-
-import java.util.Optional
-import java.util.concurrent.CompletionStage
-import scala.concurrent.Future
-import scala.util.{ Failure, Success, Try }
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/UnfoldResourceSourceAsync.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/UnfoldResourceSourceAsync.scala
@@ -13,18 +13,18 @@
 
 package org.apache.pekko.stream.impl
 
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success, Try }
+import scala.util.control.NonFatal
+
 import org.apache.pekko
 import pekko.Done
 import pekko.annotation.InternalApi
 import pekko.dispatch.ExecutionContexts.parasitic
-import pekko.stream.ActorAttributes.SupervisionStrategy
 import pekko.stream._
+import pekko.stream.ActorAttributes.SupervisionStrategy
 import pekko.stream.impl.Stages.DefaultAttributes
 import pekko.stream.stage._
-
-import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.control.NonFatal
-import scala.util.{ Failure, Success, Try }
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -22,10 +22,6 @@ import scala.collection.immutable
 import scala.concurrent.Promise
 import scala.util.control.NonFatal
 
-import org.reactivestreams.Publisher
-import org.reactivestreams.Subscriber
-import org.reactivestreams.Subscription
-
 import org.apache.pekko
 import pekko.Done
 import pekko.actor._
@@ -44,6 +40,10 @@ import pekko.stream.stage.GraphStageLogic
 import pekko.stream.stage.InHandler
 import pekko.stream.stage.OutHandler
 import pekko.util.OptionVal
+
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/AggregateWithBoundary.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/AggregateWithBoundary.scala
@@ -13,12 +13,12 @@
 
 package org.apache.pekko.stream.impl.fusing
 
+import scala.concurrent.duration._
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.stream.{ Attributes, FlowShape, Inlet, Outlet }
 import pekko.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler, TimerGraphStageLogic }
-
-import scala.concurrent.duration._
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/FlatMapPrefix.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/FlatMapPrefix.scala
@@ -16,10 +16,11 @@ package org.apache.pekko.stream.impl.fusing
 import scala.collection.immutable
 import scala.concurrent.{ Future, Promise }
 import scala.util.control.NonFatal
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
-import pekko.stream.Attributes.SourceLocation
 import pekko.stream._
+import pekko.stream.Attributes.SourceLocation
 import pekko.stream.impl.Stages.DefaultAttributes
 import pekko.stream.scaladsl.{ Flow, Keep, Source }
 import pekko.stream.stage.{ GraphStageLogic, GraphStageWithMaterializedValue, InHandler, OutHandler }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/FutureFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/FutureFlow.scala
@@ -13,11 +13,13 @@
 
 package org.apache.pekko.stream.impl.fusing
 
+import scala.concurrent.{ Future, Promise }
+import scala.util.{ Failure, Success, Try }
+import scala.util.control.NonFatal
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.dispatch.ExecutionContexts
-import pekko.stream.Attributes.SourceLocation
-import pekko.stream.impl.Stages.DefaultAttributes
 import pekko.stream.{
   AbruptStageTerminationException,
   Attributes,
@@ -26,13 +28,11 @@ import pekko.stream.{
   NeverMaterializedException,
   Outlet
 }
+import pekko.stream.Attributes.SourceLocation
+import pekko.stream.impl.Stages.DefaultAttributes
 import pekko.stream.scaladsl.{ Flow, Keep, Source }
 import pekko.stream.stage.{ GraphStageLogic, GraphStageWithMaterializedValue, InHandler, OutHandler }
 import pekko.util.OptionVal
-
-import scala.concurrent.{ Future, Promise }
-import scala.util.control.NonFatal
-import scala.util.{ Failure, Success, Try }
 
 @InternalApi private[pekko] final class FutureFlow[In, Out, M](futureFlow: Future[Flow[In, Out, M]])
     extends GraphStageWithMaterializedValue[FlowShape[In, Out], Future[M]] {

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/StreamOfStreams.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/StreamOfStreams.scala
@@ -15,10 +15,12 @@ package org.apache.pekko.stream.impl.fusing
 
 import java.util.Collections
 import java.util.concurrent.atomic.AtomicReference
+
 import scala.annotation.{ nowarn, tailrec }
 import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.InternalApi
@@ -26,8 +28,8 @@ import pekko.stream._
 import pekko.stream.ActorAttributes.StreamSubscriptionTimeout
 import pekko.stream.ActorAttributes.SupervisionStrategy
 import pekko.stream.Attributes.SourceLocation
-import pekko.stream.impl.{ Buffer => BufferImpl }
 import pekko.stream.Supervision.Decider
+import pekko.stream.impl.{ Buffer => BufferImpl }
 import pekko.stream.impl.ActorSubscriberMessage
 import pekko.stream.impl.ActorSubscriberMessage.OnError
 import pekko.stream.impl.Stages.DefaultAttributes

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/io/TLSActor.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/io/TLSActor.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.stream.impl.io
 
 import java.nio.ByteBuffer
-
 import javax.net.ssl._
 import javax.net.ssl.SSLEngineResult.HandshakeStatus
 import javax.net.ssl.SSLEngineResult.HandshakeStatus._

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/io/TcpStages.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/io/TcpStages.scala
@@ -17,10 +17,10 @@ import java.net.InetSocketAddress
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong }
 
+import scala.annotation.nowarn
 import scala.collection.immutable
 import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration.{ Duration, FiniteDuration }
-import scala.annotation.nowarn
 
 import org.apache.pekko
 import pekko.{ Done, NotUsed }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/streamref/SinkRefImpl.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/streamref/SinkRefImpl.scala
@@ -13,9 +13,8 @@
 
 package org.apache.pekko.stream.impl.streamref
 
-import scala.util.{ Failure, Success, Try }
-
 import scala.annotation.nowarn
+import scala.util.{ Failure, Success, Try }
 
 import org.apache.pekko
 import pekko.Done

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/BidiFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/BidiFlow.scala
@@ -13,9 +13,8 @@
 
 package org.apache.pekko.stream.javadsl
 
-import scala.concurrent.duration.FiniteDuration
-
 import scala.annotation.nowarn
+import scala.concurrent.duration.FiniteDuration
 
 import org.apache.pekko
 import pekko.NotUsed

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/FileIO.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/FileIO.scala
@@ -20,10 +20,10 @@ import java.util.concurrent.CompletionStage
 
 import org.apache.pekko
 import pekko.stream.{ javadsl, scaladsl, IOResult }
-import pekko.util.ByteString
-import pekko.util.ccompat.JavaConverters._
 import pekko.stream.scaladsl.SinkToCompletionStage
 import pekko.stream.scaladsl.SourceToCompletionStage
+import pekko.util.ByteString
+import pekko.util.ccompat.JavaConverters._
 
 /**
  * Java API: Factories to create sinks and sources from files

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/FlowWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/FlowWithContext.scala
@@ -23,9 +23,9 @@ import pekko.event.{ LogMarker, LoggingAdapter, MarkerLoggingAdapter }
 import pekko.japi.{ function, Pair, Util }
 import pekko.stream._
 import pekko.util.ConstantFun
-import pekko.util.ccompat.JavaConverters._
 import pekko.util.FutureConverters._
 import pekko.util.JavaDurationConverters._
+import pekko.util.ccompat.JavaConverters._
 
 object FlowWithContext {
 

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Hub.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Hub.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.stream.javadsl
 
 import java.util.function.{ BiFunction, Supplier, ToLongBiFunction }
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.DoNotInherit

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SourceWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SourceWithContext.scala
@@ -26,9 +26,9 @@ import pekko.japi.Util
 import pekko.japi.function
 import pekko.stream._
 import pekko.util.ConstantFun
-import pekko.util.ccompat.JavaConverters._
 import pekko.util.FutureConverters._
 import pekko.util.JavaDurationConverters._
+import pekko.util.ccompat.JavaConverters._
 
 object SourceWithContext {
 

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/StreamConverters.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/StreamConverters.scala
@@ -17,18 +17,17 @@ import java.io.{ InputStream, OutputStream }
 import java.util.concurrent.CompletionStage
 import java.util.stream.Collector
 
-import scala.concurrent.duration.FiniteDuration
-
 import scala.annotation.nowarn
+import scala.concurrent.duration.FiniteDuration
 
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.japi.function
 import pekko.stream.{ javadsl, scaladsl }
 import pekko.stream.IOResult
-import pekko.util.ByteString
 import pekko.stream.scaladsl.SinkToCompletionStage
 import pekko.stream.scaladsl.SourceToCompletionStage
+import pekko.util.ByteString
 
 /**
  * Converters for interacting with the blocking `java.io` streams APIs and Java 8 Streams

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/TLS.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/TLS.scala
@@ -19,14 +19,14 @@ import javax.net.ssl.{ SSLContext, SSLEngine, SSLSession }
 
 import scala.util.Try
 
-import com.typesafe.sslconfig.pekko.PekkoSSLConfig
-
 import org.apache.pekko
 import pekko.{ japi, NotUsed }
 import pekko.stream._
 import pekko.stream.TLSProtocol._
 import pekko.util.ByteString
 import pekko.util.OptionConverters._
+
+import com.typesafe.sslconfig.pekko.PekkoSSLConfig
 
 /**
  * Stream cipher support based upon JSSE.

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Tcp.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Tcp.scala
@@ -23,11 +23,10 @@ import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLEngine
 import javax.net.ssl.SSLSession
 
+import scala.annotation.nowarn
 import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
-
-import scala.annotation.nowarn
 
 import org.apache.pekko
 import pekko.{ Done, NotUsed }

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/BidiFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/BidiFlow.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.stream.scaladsl
 
 import scala.concurrent.duration.FiniteDuration
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream.{ BidiShape, _ }

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -36,6 +36,7 @@ import pekko.stream.impl.LinearTraversalBuilder
 import pekko.stream.impl.ProcessorModule
 import pekko.stream.impl.SetupFlowStage
 import pekko.stream.impl.SingleConcat
+import pekko.stream.impl.Stages.DefaultAttributes
 import pekko.stream.impl.SubFlowImpl
 import pekko.stream.impl.Throttle
 import pekko.stream.impl.Timers
@@ -43,7 +44,6 @@ import pekko.stream.impl.TraversalBuilder
 import pekko.stream.impl.fusing
 import pekko.stream.impl.fusing._
 import pekko.stream.impl.fusing.FlattenMerge
-import pekko.stream.impl.Stages.DefaultAttributes
 import pekko.stream.stage._
 import pekko.util.ConstantFun
 import pekko.util.OptionVal

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContext.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.stream.scaladsl
 
 import scala.annotation.unchecked.uncheckedVariance
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.japi.Pair

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContextOps.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContextOps.scala
@@ -17,6 +17,7 @@ import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.ApiMayChange
@@ -24,8 +25,8 @@ import pekko.dispatch.ExecutionContexts
 import pekko.event.{ LogMarker, LoggingAdapter, MarkerLoggingAdapter }
 import pekko.stream._
 import pekko.stream.impl.Throttle
-import pekko.util.{ ccompat, ConstantFun }
-import ccompat._
+import pekko.util.ConstantFun
+import pekko.util.ccompat._
 
 /**
  * Shared stream operations for [[FlowWithContext]] and [[SourceWithContext]] that automatically propagate a context

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
@@ -18,12 +18,14 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.{ AtomicLong, AtomicReference }
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReferenceArray
+
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.collection.immutable.Queue
 import scala.collection.mutable.LongMap
 import scala.concurrent.{ Future, Promise }
 import scala.util.{ Failure, Success, Try }
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.DoNotInherit

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/JsonFraming.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/JsonFraming.scala
@@ -13,6 +13,8 @@
 
 package org.apache.pekko.stream.scaladsl
 
+import scala.util.control.NonFatal
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream.Attributes
@@ -21,8 +23,6 @@ import pekko.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
 import pekko.stream.scaladsl.Framing.FramingException
 import pekko.stream.stage.{ GraphStageLogic, InHandler, OutHandler }
 import pekko.util.ByteString
-
-import scala.util.control.NonFatal
 
 /** Provides JSON framing operators that can separate valid JSON objects from incoming [[pekko.util.ByteString]] objects. */
 object JsonFraming {

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/RestartSink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/RestartSink.scala
@@ -13,12 +13,12 @@
 
 package org.apache.pekko.stream.scaladsl
 
+import scala.concurrent.duration.FiniteDuration
+
 import org.apache.pekko
 import pekko.NotUsed
-import pekko.stream.stage.{ GraphStage, GraphStageLogic }
 import pekko.stream.{ Attributes, Inlet, RestartSettings, SinkShape }
-
-import scala.concurrent.duration.FiniteDuration
+import pekko.stream.stage.{ GraphStage, GraphStageLogic }
 
 /**
  * A RestartSink wraps a [[Sink]] that gets restarted when it completes or fails.

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/RestartSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/RestartSource.scala
@@ -13,12 +13,12 @@
 
 package org.apache.pekko.stream.scaladsl
 
+import scala.concurrent.duration.FiniteDuration
+
 import org.apache.pekko
 import pekko.NotUsed
-import pekko.stream.stage.{ GraphStage, GraphStageLogic }
 import pekko.stream.{ Attributes, Outlet, RestartSettings, SourceShape }
-
-import scala.concurrent.duration.FiniteDuration
+import pekko.stream.stage.{ GraphStage, GraphStageLogic }
 
 /**
  * A RestartSource wraps a [[Source]] that gets restarted when it completes or fails.

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/SourceWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/SourceWithContext.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.stream.scaladsl
 
 import scala.annotation.unchecked.uncheckedVariance
+
 import org.apache.pekko
 import pekko.stream._
 

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/TLS.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/TLS.scala
@@ -19,8 +19,6 @@ import javax.net.ssl.SSLParameters
 
 import scala.util.{ Failure, Success, Try }
 
-import com.typesafe.sslconfig.pekko.PekkoSSLConfig
-
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.actor.ActorSystem
@@ -28,6 +26,8 @@ import pekko.stream._
 import pekko.stream.TLSProtocol._
 import pekko.stream.impl.io.{ TlsModule, TlsUtils }
 import pekko.util.ByteString
+
+import com.typesafe.sslconfig.pekko.PekkoSSLConfig
 
 /**
  * Stream cipher support based upon JSSE.

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Tcp.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Tcp.scala
@@ -18,6 +18,8 @@ import java.util.concurrent.TimeoutException
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLEngine
 import javax.net.ssl.SSLSession
+
+import scala.annotation.nowarn
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
@@ -25,7 +27,7 @@ import scala.concurrent.duration.FiniteDuration
 import scala.util.Success
 import scala.util.Try
 import scala.util.control.NoStackTrace
-import scala.annotation.nowarn
+
 import org.apache.pekko
 import pekko.Done
 import pekko.NotUsed

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/package.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/package.scala
@@ -13,11 +13,11 @@
 
 package org.apache.pekko.stream
 
-import org.apache.pekko.util.FutureConverters._
-
 import java.util.concurrent.CompletionStage
 
 import scala.concurrent.Future
+
+import org.apache.pekko.util.FutureConverters._
 
 /**
  * Scala API: The flow DSL allows the formulation of stream transformations based on some

--- a/stream/src/main/scala/org/apache/pekko/stream/serialization/StreamRefSerializer.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/serialization/StreamRefSerializer.scala
@@ -13,6 +13,8 @@
 
 package org.apache.pekko.stream.serialization
 
+import java.nio.charset.StandardCharsets
+
 import org.apache.pekko
 import pekko.actor.ExtendedActorSystem
 import pekko.annotation.InternalApi
@@ -21,8 +23,6 @@ import pekko.protobufv3.internal.UnsafeByteOperations
 import pekko.serialization._
 import pekko.stream.StreamRefMessages
 import pekko.stream.impl.streamref._
-
-import java.nio.charset.StandardCharsets
 
 /** INTERNAL API */
 @InternalApi


### PR DESCRIPTION
Motivation:
When I do code modification in pekko-stream related module, after a `sortImports` I have to revert all unrelated changes, which is very annoying.

Result:
Sort the imports in `pekko-stream` and `pekko-stream-tests`.

The `sort-imports` will cause problem when encounter `#xxx` and does not obey the `#scala-fix:off/on` too.