### PR TITLE
chore: Ignore two pb files from java formatter.

### DIFF
--- a/.sbt-java-formatter.conf
+++ b/.sbt-java-formatter.conf
@@ -8,6 +8,9 @@ ignored-files = [
   "StreamRefMessages.java",
   //in tests
   "ProtobufProtocol.java"
+  //in docs
+  "TwoPhaseSetMessages.java"
+  "FlightAppModels.java"
 ]
 
 //ignore by packages:


### PR DESCRIPTION
Motivation:
Ignore these two files, which is very annoying.

Result:
will not be formatted when run `javafmtAll`