### PR TITLE
chore: Add @since 1.1.0 to contramap operator.

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -539,6 +539,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * '''Backpressures when''' original [[Flow]] backpressures
    *
    * '''Cancels when''' original [[Flow]] cancels
+   * @since 1.1.0
    */
   def contramap[In2](f: function.Function[In2, In]): javadsl.Flow[In2, Out, Mat] =
     new Flow(delegate.contramap(elem => f(elem)))

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Sink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Sink.scala
@@ -568,6 +568,7 @@ final class Sink[In, Mat](delegate: scaladsl.Sink[In, Mat]) extends Graph[SinkSh
    * '''Backpressures when''' original [[Sink]] backpressures
    *
    * '''Cancels when''' original [[Sink]] backpressures
+   * @since 1.1.0
    */
   def contramap[In2](f: function.Function[In2, In]): Sink[In2, Mat] =
     javadsl.Flow.fromFunction(f).toMat(this, Keep.right[NotUsed, Mat])

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -179,6 +179,7 @@ final class Flow[-In, +Out, +Mat](
    * '''Backpressures when''' original [[Flow]] backpressures
    *
    * '''Cancels when''' original [[Flow]] cancels
+   * @since 1.1.0
    */
   def contramap[In2](f: In2 => In): Flow[In2, Out, Mat] =
     Flow.fromFunction(f).viaMat(this)(Keep.right)

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Sink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Sink.scala
@@ -56,6 +56,7 @@ final class Sink[-In, +Mat](override val traversalBuilder: LinearTraversalBuilde
    * '''Backpressures when''' original [[Sink]] backpressures
    *
    * '''Cancels when''' original [[Sink]] cancels
+   * @since 1.1.0
    */
   def contramap[In2](f: In2 => In): Sink[In2, Mat] = Flow.fromFunction(f).toMat(this)(Keep.right)
 


### PR DESCRIPTION
Motivation:
Add the `@since 1.1.0` to `contramap` operator
