### PR TITLE
feat: Add `create` method to PFBuilder.

### DIFF
--- a/actor-tests/src/test/java/org/apache/pekko/japi/pf/PFBuilderTest.java
+++ b/actor-tests/src/test/java/org/apache/pekko/japi/pf/PFBuilderTest.java
@@ -25,7 +25,7 @@ public class PFBuilderTest extends JUnitSuite {
   @Test
   public void pfbuilder_matchAny_should_infer_declared_input_type_for_lambda() {
     PartialFunction<String, Integer> pf =
-        new PFBuilder<String, Integer>()
+        PFBuilder.<String, Integer>create()
             .matchEquals("hello", s -> 1)
             .matchAny(s -> Integer.valueOf(s))
             .build();

--- a/actor-typed-tests/src/test/java/org/apache/pekko/actor/typed/javadsl/ActorLoggingTest.java
+++ b/actor-typed-tests/src/test/java/org/apache/pekko/actor/typed/javadsl/ActorLoggingTest.java
@@ -62,7 +62,7 @@ public class ActorLoggingTest extends JUnitSuite {
   public void loggingProvidesClassWhereLogWasCalled() {
     CustomEventFilter eventFilter =
         new CustomEventFilter(
-            new PFBuilder<Logging.LogEvent, Object>()
+            PFBuilder.<Logging.LogEvent, Object>create()
                 .match(
                     Logging.LogEvent.class, (event) -> event.logClass() == ActorLoggingTest.class)
                 .build(),
@@ -103,7 +103,7 @@ public class ActorLoggingTest extends JUnitSuite {
 
     CustomEventFilter eventFilter =
         new CustomEventFilter(
-            new PFBuilder<Logging.LogEvent, Object>()
+            PFBuilder.<Logging.LogEvent, Object>create()
                 .match(Logging.LogEvent.class, (event) -> event.getMDC().containsKey("txId"))
                 .build(),
             1);
@@ -118,7 +118,7 @@ public class ActorLoggingTest extends JUnitSuite {
 
     CustomEventFilter eventFilter =
         new CustomEventFilter(
-            new PFBuilder<Logging.LogEvent, Object>()
+            PFBuilder.<Logging.LogEvent, Object>create()
                 .match(
                     Logging.LogEvent.class,
                     (event) -> event.message().equals("received message Hello"))

--- a/actor/src/main/java/org/apache/pekko/japi/pf/FSMStateFunctionBuilder.java
+++ b/actor/src/main/java/org/apache/pekko/japi/pf/FSMStateFunctionBuilder.java
@@ -26,8 +26,7 @@ import java.util.List;
 @SuppressWarnings("rawtypes")
 public class FSMStateFunctionBuilder<S, D> {
 
-  private PFBuilder<FSM.Event<D>, FSM.State<S, D>> builder =
-      new PFBuilder<FSM.Event<D>, FSM.State<S, D>>();
+  private final PFBuilder<FSM.Event<D>, FSM.State<S, D>> builder = PFBuilder.create();
 
   /**
    * An erased processing of the event matcher. The compile time checks are enforced by the public

--- a/actor/src/main/java/org/apache/pekko/japi/pf/PFBuilder.java
+++ b/actor/src/main/java/org/apache/pekko/japi/pf/PFBuilder.java
@@ -21,6 +21,15 @@ package org.apache.pekko.japi.pf;
  */
 public final class PFBuilder<I, R> extends AbstractPFBuilder<I, R> {
 
+  /**
+   * Create a new {@link PFBuilder}.
+   *
+   * @since 1.1.0
+   */
+  public static <I, R> PFBuilder<I, R> create() {
+    return new PFBuilder<>();
+  }
+
   /** Create a PFBuilder. */
   public PFBuilder() {}
 

--- a/docs/src/test/java/jdocs/stream/BidiFlowDocTest.java
+++ b/docs/src/test/java/jdocs/stream/BidiFlowDocTest.java
@@ -260,7 +260,9 @@ public class BidiFlowDocTest extends AbstractJavaTest {
     final Flow<Message, Message, NotUsed> pingpong =
         Flow.of(Message.class)
             .collect(
-                new PFBuilder<Message, Message>().match(Ping.class, p -> new Pong(p.id)).build());
+                PFBuilder.<Message, Message>create()
+                    .match(Ping.class, p -> new Pong(p.id))
+                    .build());
     final Flow<Message, Message, NotUsed> flow = stack.atop(stack.reversed()).join(pingpong);
     final CompletionStage<List<Message>> result =
         Source.from(Arrays.asList(0, 1, 2))

--- a/docs/src/test/java/jdocs/stream/FlowErrorDocTest.java
+++ b/docs/src/test/java/jdocs/stream/FlowErrorDocTest.java
@@ -156,7 +156,7 @@ public class FlowErrorDocTest extends AbstractJavaTest {
               else return n.toString();
             })
         .recover(
-            new PFBuilder<Throwable, String>()
+            PFBuilder.<Throwable, String>create()
                 .match(RuntimeException.class, Throwable::getMessage)
                 .build())
         .runForeach(System.out::println, system);
@@ -187,7 +187,7 @@ public class FlowErrorDocTest extends AbstractJavaTest {
             })
         .recoverWithRetries(
             1, // max attempts
-            new PFBuilder<Throwable, Source<String, NotUsed>>()
+            PFBuilder.<Throwable, Source<String, NotUsed>>create()
                 .match(RuntimeException.class, ex -> planB)
                 .build())
         .runForeach(System.out::println, system);

--- a/docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeAdhocSourceTest.java
+++ b/docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeAdhocSourceTest.java
@@ -62,7 +62,7 @@ public class RecipeAdhocSourceTest extends RecipeTest {
                 .backpressureTimeout(timeout)
                 .recoverWithRetries(
                     maxRetries,
-                    new PFBuilder<Throwable, Source<T, NotUsed>>()
+                    PFBuilder.<Throwable, Source<T, NotUsed>>create()
                         .match(
                             TimeoutException.class,
                             ex ->

--- a/docs/src/test/java/jdocs/stream/operators/SourceOrFlow.java
+++ b/docs/src/test/java/jdocs/stream/operators/SourceOrFlow.java
@@ -395,7 +395,7 @@ class SourceOrFlow {
     Flow<Message, Pong, NotUsed> flow =
         Flow.of(Message.class)
             .collect(
-                new PFBuilder<Message, Pong>()
+                PFBuilder.<Message, Pong>create()
                     .match(Ping.class, p -> p.id != 0, p -> new Pong(p.id))
                     .build());
     // #collect

--- a/persistence/src/main/java/org/apache/pekko/persistence/fsm/japi/pf/FSMStateFunctionBuilder.java
+++ b/persistence/src/main/java/org/apache/pekko/persistence/fsm/japi/pf/FSMStateFunctionBuilder.java
@@ -31,13 +31,10 @@ import java.util.List;
 @Deprecated
 public class FSMStateFunctionBuilder<S, D, E> {
 
-  private PFBuilder<
+  private final PFBuilder<
           org.apache.pekko.persistence.fsm.PersistentFSM.Event<D>,
           org.apache.pekko.persistence.fsm.PersistentFSM.State<S, D, E>>
-      builder =
-          new PFBuilder<
-              org.apache.pekko.persistence.fsm.PersistentFSM.Event<D>,
-              org.apache.pekko.persistence.fsm.PersistentFSM.State<S, D, E>>();
+      builder = PFBuilder.create();
 
   /**
    * An erased processing of the event matcher. The compile time checks are enforced by the public

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/FlowTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/FlowTest.java
@@ -1124,7 +1124,7 @@ public class FlowTest extends StreamTest {
                 })
             .recoverWithRetries(
                 3,
-                new PFBuilder<Throwable, Graph<SourceShape<Integer>, NotUsed>>()
+                PFBuilder.<Throwable, Graph<SourceShape<Integer>, NotUsed>>create()
                     .match(RuntimeException.class, ex -> Source.from(recover))
                     .build());
 

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
@@ -913,7 +913,7 @@ public class SourceTest extends StreamTest {
                 })
             .recoverWithRetries(
                 1,
-                new PFBuilder<Throwable, Source<Integer, NotUsed>>()
+                PFBuilder.<Throwable, Source<Integer, NotUsed>>create()
                     .matchAny(ex -> Source.single(0))
                     .build());
 


### PR DESCRIPTION
Motivation:

`new PFBuilder<>()` is not that fluent.

Result:
Add a `create` method on `PFBuilder`, alias with others.