### PR TITLE
feat: Add expectNextN to StreamTestKit for javadsl.

### DIFF
--- a/stream-testkit/src/main/scala/org/apache/pekko/stream/testkit/StreamTestKit.scala
+++ b/stream-testkit/src/main/scala/org/apache/pekko/stream/testkit/StreamTestKit.scala
@@ -23,15 +23,16 @@ import scala.concurrent.duration._
 import scala.reflect.ClassTag
 
 import org.apache.pekko
-import pekko.actor.ClassicActorSystemProvider
-import org.reactivestreams.{ Publisher, Subscriber, Subscription }
 import pekko.actor.{ ActorRef, ActorSystem, DeadLetterSuppression, NoSerializationVerificationNeeded }
+import pekko.actor.ClassicActorSystemProvider
 import pekko.stream._
 import pekko.stream.impl._
 import pekko.testkit.{ TestActor, TestProbe }
 import pekko.testkit.TestActor.AutoPilot
 import pekko.util.JavaDurationConverters
 import pekko.util.ccompat._
+
+import org.reactivestreams.{ Publisher, Subscriber, Subscription }
 
 /**
  * Provides factory methods for various Publishers.
@@ -459,6 +460,16 @@ object TestSubscriber {
      */
     def expectNextN(all: immutable.Seq[I]): Self = {
       all.foreach(e => probe.expectMsg(OnNext(e)))
+      self
+    }
+
+    /**
+     * Fluent DSL
+     * Expect the given elements to be signalled in order.
+     * @since 1.1.0
+     */
+    def expectNextN(elems: java.util.List[I]): Self = {
+      elems.forEach(e => probe.expectMsg(OnNext(e)))
       self
     }
 

--- a/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/StreamTestKitSpec.scala
+++ b/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/StreamTestKitSpec.scala
@@ -14,15 +14,14 @@
 package org.apache.pekko.stream.testkit
 
 import scala.concurrent.duration._
-
 import org.apache.pekko
 import pekko.stream.scaladsl.Source
 import pekko.stream.testkit.scaladsl.TestSink
-
 import pekko.testkit._
-
 import pekko.testkit.TestEvent.Mute
 import pekko.testkit.TestEvent.UnMute
+
+import java.util
 
 class StreamTestKitSpec extends PekkoSpec {
 
@@ -198,6 +197,13 @@ class StreamTestKitSpec extends PekkoSpec {
 
     "#expectNextN given specific elements" in {
       Source(1 to 4).runWith(TestSink.probe).request(4).expectNextN(4) should ===(List(1, 2, 3, 4))
+    }
+
+    "#expectNextN given specific elements for java list" in {
+      Source(1 to 4).runWith(TestSink[Int]())
+        .request(4)
+        .expectNextN(util.Arrays.asList(1, 2, 3, 4))
+        .expectComplete()
     }
   }
 }


### PR DESCRIPTION
Motivation:
Add an `expectN` method to StreamTestKit which supports java List