### PR TITLE
chore: Micro optimization for `collect*` operator.

### DIFF
--- a/bench-jmh/src/main/scala/org/apache/pekko/stream/CollectBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/stream/CollectBenchmark.scala
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package org.apache.pekko.stream
+
+import com.typesafe.config.ConfigFactory
+import org.apache.pekko
+import org.apache.pekko.stream.ActorAttributes.SupervisionStrategy
+import org.apache.pekko.stream.Attributes.SourceLocation
+import org.apache.pekko.stream.impl.Stages.DefaultAttributes
+import org.apache.pekko.stream.impl.fusing.Collect
+import org.apache.pekko.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
+import org.openjdk.jmh.annotations._
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl._
+
+import java.util.concurrent.TimeUnit
+import scala.annotation.nowarn
+import scala.concurrent._
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+
+object CollectBenchmark {
+  final val OperationsPerInvocation = 10000000
+}
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@BenchmarkMode(Array(Mode.Throughput))
+@nowarn("msg=deprecated")
+class CollectBenchmark {
+  import CollectBenchmark._
+
+  private val config = ConfigFactory.parseString("""
+    pekko.actor.default-dispatcher {
+      executor = "fork-join-executor"
+      fork-join-executor {
+        parallelism-factor = 1
+      }
+    }
+    """)
+
+  private implicit val system: ActorSystem = ActorSystem("CollectBenchmark", config)
+
+  @TearDown
+  def shutdown(): Unit = {
+    Await.result(system.terminate(), 5.seconds)
+  }
+
+  private val newCollect = Source
+    .repeat(1)
+    .via(new Collect({ case elem => elem }))
+    .take(OperationsPerInvocation)
+    .toMat(Sink.ignore)(Keep.right)
+
+  private val oldCollect = Source
+    .repeat(1)
+    .via(new SimpleCollect({ case elem => elem }))
+    .take(OperationsPerInvocation)
+    .toMat(Sink.ignore)(Keep.right)
+
+  private class SimpleCollect[In, Out](pf: PartialFunction[In, Out])
+      extends GraphStage[FlowShape[In, Out]] {
+    val in = Inlet[In]("SimpleCollect.in")
+    val out = Outlet[Out]("SimpleCollect.out")
+    override val shape = FlowShape(in, out)
+
+    override def initialAttributes: Attributes = DefaultAttributes.collect and SourceLocation.forLambda(pf)
+
+    def createLogic(inheritedAttributes: Attributes) =
+      new GraphStageLogic(shape) with InHandler with OutHandler {
+        private lazy val decider = inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider
+        import Collect.NotApplied
+
+        override def onPush(): Unit =
+          try {
+            pf.applyOrElse(grab(in), NotApplied) match {
+              case NotApplied             => pull(in)
+              case result: Out @unchecked => push(out, result)
+              case _                      => throw new RuntimeException()
+            }
+          } catch {
+            case NonFatal(ex) =>
+              decider(ex) match {
+                case Supervision.Stop    => failStage(ex)
+                case Supervision.Resume  => if (!hasBeenPulled(in)) pull(in)
+                case Supervision.Restart => if (!hasBeenPulled(in)) pull(in)
+              }
+          }
+
+        override def onPull(): Unit = pull(in)
+
+        setHandlers(in, out, this)
+      }
+
+    override def toString = "SimpleCollect"
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(OperationsPerInvocation)
+  def benchOldCollect(): Unit =
+    Await.result(oldCollect.run(), Duration.Inf)
+
+  @Benchmark
+  @OperationsPerInvocation(OperationsPerInvocation)
+  def benchNewCollect(): Unit =
+    Await.result(newCollect.run(), Duration.Inf)
+
+}


### PR DESCRIPTION
Motivation:
As `collect` and `collectWhile` are hot, I think it's worth to do this kind of micro optimization, and these code  unlikely to be changed too.
Same trick can be find https://github.com/scala/scala/blob/2.13.x/src/library/scala/collection/IterableOnce.scala#L1178
Result:
`IF_ACMPEQ` will be a little faster, and reduce an `INVOKEVIRTUAL java/lang/Object.equals`

> Jmh/run -i 10 -wi 10 -f1 -t1 .*CollectBenchmark.*

first run:
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                          Mode  Cnt         Score        Error  Units
[info] CollectBenchmark.benchNewCollect  thrpt   10  14550829.734 ± 110526.538  ops/s
[info] CollectBenchmark.benchOldCollect  thrpt   10  14268840.296 ± 332840.984  ops/s
[success] Total time: 783 s (13:03), completed 2024年1月20日 上午2:04:44
sbt:pekko-bench-jmh> Jmh/run -i 10 -wi 10 -f1 -t1 .*CollectBenchmark.*

info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                          Mode  Cnt         Score        Error  Units
[info] CollectBenchmark.benchNewCollect  thrpt   10  15099034.601 ± 331220.483  ops/s
[info] CollectBenchmark.benchOldCollect  thrpt   10  14517524.914 ± 281804.895  ops/s
[success] Total time: 469 s (07:49), completed 2024年1月20日 上午3:25:36

[info] Iteration  10: 2024-01-20 03:54:31,099 INFO  org.apache.pekko.actor.CoordinatedShutdown  - Running CoordinatedShutdown with reason [ActorSystemTerminateReason] MDC: {pekkoUid=5508704921438154807, sourceThread=org.apache.pekko.stream.CollectBenchmark.benchOldCollect-jmh-worker-1, sourceActorSystem=CollectBenchmark, pekkoAddress=pekko://CollectBenchmark, pekkoSource=CoordinatedShutdown(pekko://CollectBenchmark), pekkoTimestamp=19:54:31.099UTC}
[info] 14499689.518 ops/s
[info] Result "org.apache.pekko.stream.CollectBenchmark.benchOldCollect":
[info]   14603414.744 ±(99.9%) 115289.942 ops/s [Average]
[info]   (min, avg, max) = (14499689.518, 14603414.744, 14709273.129), stdev = 76257.158
[info]   CI (99.9%): [14488124.802, 14718704.686] (assumes normal distribution)
[info] # Run complete. Total time: 00:07:00
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                          Mode  Cnt         Score        Error  Units
[info] CollectBenchmark.benchNewCollect  thrpt   10  15046779.903 ± 565166.752  ops/s
[info] CollectBenchmark.benchOldCollect  thrpt   10  14603414.744 ± 115289.942  ops/s
[success] Total time: 465 s (07:45), completed 2024年1月20日 上午3:54:32

```

![image](https://github.com/apache/incubator-pekko/assets/501740/a1f44b40-963d-40e2-9096-7cb2183fb631)
