### PR TITLE
feat: Add Sink#forall operator.

### DIFF
--- a/docs/src/main/paradox/stream/operators/Sink/forall.md
+++ b/docs/src/main/paradox/stream/operators/Sink/forall.md
@@ -1,0 +1,47 @@
+# Sink.forall
+
+A `Sink` that will test the given predicate `p` for every received element and completes with the result.
+
+@ref[Sink operators](../index.md#sink-operators)
+
+## Signature
+
+@apidoc[Sink.forall](Sink$) { scala="#forall[T](p:T=%3EBoolean):org.apache.pekko.stream.scaladsl.Sink[T,scala.concurrent.Future[Boolean]]" java="#forall(org.apache.pekko.japi.function.Predicate)" }
+
+## Description
+forall applies a predicate function to assert each element received, it returns true if all elements satisfy the assertion, otherwise it returns false.
+
+It materializes into a `Future` (in Scala) or a `CompletionStage` (in Java) that completes with the last state when the stream has finished.
+
+Notes that if source is empty, it will return true
+
+A `Sink` that will test the given predicate `p` for every received element and
+
+ - completes and returns  @scala[`Future`] @java[`CompletionStage`] of `true` if the predicate is true for all elements; 
+ - completes and returns  @scala[`Future`] @java[`CompletionStage`] of `true` if the stream is empty (i.e. completes before signalling any elements); 
+ - completes and returns  @scala[`Future`] @java[`CompletionStage`] of `false` if the predicate is false for any element.
+
+The materialized value @scala[`Future`] @java[`CompletionStage`] will be completed with the value `true` or `false`
+when the input stream ends, or completed with `Failure` if there is a failure signaled in the stream.
+
+## Example
+
+This example tests all elements in the stream is `<=` 100.
+
+Scala
+:   @@snip [ForAll.scala](/docs/src/test/scala/docs/stream/operators/sink/ForAll.scala) { #forall }
+
+Java
+:   @@snip [ForAll.java](/docs/src/test/java/jdocs/stream/operators/sink/ForAll.java) { #forall }
+
+## Reactive Streams Semantics
+
+@@@div { .callout }
+
+***Completes*** when upstream completes or the predicate `p` returns `false`
+
+**cancels** when predicate `p` returns `false`
+
+**backpressures** when the invocation of predicate `p` has not yet completed
+
+@@@

--- a/docs/src/main/paradox/stream/operators/index.md
+++ b/docs/src/main/paradox/stream/operators/index.md
@@ -62,6 +62,7 @@ These built-in sinks are available from @scala[`org.apache.pekko.stream.scaladsl
 |Sink|<a name="completionstagesink"></a>@ref[completionStageSink](Sink/completionStageSink.md)|Streams the elements to the given future sink once it successfully completes. |
 |Sink|<a name="fold"></a>@ref[fold](Sink/fold.md)|Fold over emitted elements with a function, where each invocation will get the new element and the result from the previous fold invocation.|
 |Sink|<a name="foldwhile"></a>@ref[foldWhile](Sink/foldWhile.md)|Fold over emitted elements with a function, where each invocation will get the new element and the result from the previous fold invocation.|
+|Sink|<a name="forall"></a>@ref[forall](Sink/forall.md)|A `Sink` that will test the given predicate `p` for every received element and completes with the result.|
 |Sink|<a name="foreach"></a>@ref[foreach](Sink/foreach.md)|Invoke a given procedure for each element received.|
 |Sink|<a name="foreachasync"></a>@ref[foreachAsync](Sink/foreachAsync.md)|Invoke a given procedure asynchronously for each element received.|
 |Sink|<a name="foreachparallel"></a>@ref[foreachParallel](Sink/foreachParallel.md)|Like `foreach` but allows up to `parallellism` procedure calls to happen in parallel.|
@@ -459,6 +460,7 @@ For more background see the @ref[Error Handling in Streams](../stream-error.md) 
 * [foldAsync](Source-or-Flow/foldAsync.md)
 * [foldWhile](Source-or-Flow/foldWhile.md)
 * [foldWhile](Sink/foldWhile.md)
+* [forall](Sink/forall.md)
 * [foreach](Sink/foreach.md)
 * [foreachAsync](Sink/foreachAsync.md)
 * [foreachParallel](Sink/foreachParallel.md)

--- a/docs/src/test/java/jdocs/stream/operators/sink/ForAll.java
+++ b/docs/src/test/java/jdocs/stream/operators/sink/ForAll.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jdocs.stream.operators.sink;
+
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+
+import java.util.concurrent.TimeUnit;
+
+public class ForAll {
+  private ActorSystem system = null;
+
+  public void forAllUsage() throws Exception {
+    // #forall
+    final boolean allMatch =
+        Source.range(1, 100)
+            .runWith(Sink.forall(elem -> elem <= 100), system)
+            .toCompletableFuture()
+            .get(3, TimeUnit.SECONDS);
+    System.out.println(allMatch);
+    // Expect prints:
+    // true
+    // #forall
+  }
+}

--- a/docs/src/test/scala/docs/stream/operators/sink/ForAll.scala
+++ b/docs/src/test/scala/docs/stream/operators/sink/ForAll.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package docs.stream.operators.sink
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.{ Sink, Source }
+
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ Await, ExecutionContextExecutor, Future }
+
+object ForAll {
+  implicit val system: ActorSystem = ???
+  implicit val ec: ExecutionContextExecutor = system.dispatcher
+  def foldExample: Unit = {
+    // #forall
+    val result: Future[Boolean] =
+      Source(1 to 100)
+        .runWith(Sink.forall(_ <= 100))
+    val allMatch = Await.result(result, 3.seconds)
+    println(allMatch)
+    // Expect prints:
+    // true
+    // #forall
+  }
+}

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SinkTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SinkTest.java
@@ -236,4 +236,13 @@ public class SinkTest extends StreamTest {
     // #foreach
     assertEquals(Done.done(), done);
   }
+
+  @Test
+  public void sinkMustBeAbleToUseForall()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    CompletionStage<Boolean> cs =
+        Source.from(Arrays.asList(1, 2, 3, 4)).runWith(Sink.forall(param -> param > 0), system);
+    boolean allMatch = cs.toCompletableFuture().get(100, TimeUnit.MILLISECONDS);
+    assertTrue(allMatch);
+  }
 }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SinkSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SinkSpec.scala
@@ -20,6 +20,7 @@ import scala.concurrent.duration._
 import org.apache.pekko
 import pekko.Done
 import pekko.stream._
+import pekko.stream.ActorAttributes.supervisionStrategy
 import pekko.stream.testkit._
 import pekko.stream.testkit.scaladsl.{ TestSink, TestSource }
 import pekko.testkit.DefaultTimeout
@@ -337,6 +338,47 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
       // #foreach
       done shouldBe Done
     }
+  }
+
+  "The forall sink" must {
+
+    "completes with `ture` when all elements match" in {
+      Source(1 to 4)
+        .runWith(Sink.forall(_ > 0))
+        .futureValue shouldBe true
+    }
+
+    "completes with `false` when any element match" in {
+      Source(1 to 4)
+        .runWith(Sink.forall(_ > 2))
+        .futureValue shouldBe false
+    }
+
+    "completes with `true` if the stream is empty" in {
+      Source.empty[Int]
+        .runWith(Sink.forall(_ > 2))
+        .futureValue shouldBe true
+    }
+
+    "completes with `Failure` if the stream failed" in {
+      Source.failed[Int](new RuntimeException("Oops"))
+        .runWith(Sink.forall(_ > 2))
+        .failed.futureValue shouldBe a[RuntimeException]
+    }
+
+    "completes with `true` with restart strategy" in {
+      val sink = Sink.forall[Int](elem => {
+        if (elem == 2) {
+          throw new RuntimeException("Oops")
+        }
+        elem > 0
+      }).withAttributes(supervisionStrategy(Supervision.restartingDecider))
+
+      Source(1 to 2)
+        .runWith(sink)
+        .futureValue shouldBe true
+    }
+
   }
 
   "Sink pre-materialization" must {

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.stream.impl.fusing
 
 import java.util.concurrent.TimeUnit.NANOSECONDS
 
-import scala.annotation.{ nowarn, tailrec }
+import scala.annotation.nowarn
+import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.collection.immutable.VectorBuilder
 import scala.concurrent.Future


### PR DESCRIPTION
Motivation:
Add `Sink#forall` operator for to test whether all the elements match a predicate.
refs: https://github.com/apache/incubator-pekko/issues/972

Note:
The origin author is @laglangyue and I updated and continued with it, so the review will leave to others.

![image](https://github.com/apache/incubator-pekko/assets/501740/411d60fb-72f0-4af8-9f53-c10938b872b8)

