### PR TITLE
chore: Fix incorrectly prefixed config names

### DIFF
--- a/bench-jmh/src/main/scala/org/apache/pekko/stream/ZipWithIndexBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/stream/ZipWithIndexBenchmark.scala
@@ -44,7 +44,7 @@ class ZipWithIndexBenchmark {
   import ZipWithIndexBenchmark._
 
   private val config = ConfigFactory.parseString("""
-    akka.actor.default-dispatcher {
+    pekko.actor.default-dispatcher {
       executor = "fork-join-executor"
       fork-join-executor {
         parallelism-factor = 1


### PR DESCRIPTION
Motivation:
This should be pekko prefix.

Result:
correct prefix.

No need to backport to 1.0.x