### PR TITLE
improve performance in PEM reader

### DIFF
--- a/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ssl/PemManagersProvider.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ssl/PemManagersProvider.scala
@@ -13,24 +13,16 @@
 
 package org.apache.pekko.remote.artery.tcp.ssl
 
-import java.io.ByteArrayInputStream
 import java.io.File
-import java.nio.charset.StandardCharsets
 import java.nio.file.Files
-import java.security.KeyStore
-import java.security.PrivateKey
-import java.security.cert.Certificate
-import java.security.cert.CertificateFactory
-import java.security.cert.X509Certificate
+import java.security.{ KeyStore, PrivateKey }
+import java.security.cert.{ Certificate, CertificateFactory, X509Certificate }
 
 import org.apache.pekko
 import pekko.annotation.InternalApi
-import pekko.pki.pem.DERPrivateKeyLoader
-import pekko.pki.pem.PEMDecoder
-import javax.net.ssl.KeyManager
-import javax.net.ssl.KeyManagerFactory
-import javax.net.ssl.TrustManager
-import javax.net.ssl.TrustManagerFactory
+import pekko.pki.pem.{ DERPrivateKeyLoader, PEMDecoder }
+
+import javax.net.ssl.{ KeyManager, KeyManagerFactory, TrustManager, TrustManagerFactory }
 
 import scala.concurrent.blocking
 
@@ -82,8 +74,7 @@ private[ssl] object PemManagersProvider {
    */
   @InternalApi
   private[ssl] def loadPrivateKey(filename: String): PrivateKey = blocking {
-    val bytes = Files.readAllBytes(new File(filename).toPath)
-    val pemData = new String(bytes, StandardCharsets.UTF_8)
+    val pemData = Files.readString(new File(filename).toPath)
     DERPrivateKeyLoader.load(PEMDecoder.decode(pemData))
   }
 
@@ -94,8 +85,7 @@ private[ssl] object PemManagersProvider {
    */
   @InternalApi
   private[ssl] def loadCertificate(filename: String): Certificate = blocking {
-    val bytes = Files.readAllBytes(new File(filename).toPath)
-    certFactory.generateCertificate(new ByteArrayInputStream(bytes))
+    certFactory.generateCertificate(Files.newInputStream(new File(filename).toPath))
   }
 
 }

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ssl/PemManagersProvider.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ssl/PemManagersProvider.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.remote.artery.tcp.ssl
 
 import java.io.File
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.security.{ KeyStore, PrivateKey }
 import java.security.cert.{ Certificate, CertificateFactory, X509Certificate }
@@ -74,7 +75,8 @@ private[ssl] object PemManagersProvider {
    */
   @InternalApi
   private[ssl] def loadPrivateKey(filename: String): PrivateKey = blocking {
-    val pemData = Files.readString(new File(filename).toPath)
+    val bytes = Files.readAllBytes(new File(filename).toPath)
+    val pemData = new String(bytes, StandardCharsets.UTF_8)
     DERPrivateKeyLoader.load(PEMDecoder.decode(pemData))
   }
 


### PR DESCRIPTION
* We don't need the ByteArrayInputStream, we can read from the file directly 