### PR TITLE
Use lazy val's in sbt build

### DIFF
--- a/project/AddLogTimestamps.scala
+++ b/project/AddLogTimestamps.scala
@@ -23,12 +23,12 @@ import sbt.internal.util.ConsoleOut
 object AddLogTimestamps extends AutoPlugin {
   val enableTimestamps: Boolean = CliOption("pekko.log.timestamps", false).get
 
-  override def requires: Plugins = plugins.JvmPlugin
-  override def trigger: PluginTrigger = allRequirements
+  override lazy val requires: Plugins = plugins.JvmPlugin
+  override lazy val trigger: PluginTrigger = allRequirements
 
   private val UTC = ZoneId.of("UTC")
 
-  override def projectSettings: Seq[Def.Setting[_]] = {
+  override lazy val projectSettings: Seq[Def.Setting[_]] = {
     logManager := {
       val original = logManager.value
 

--- a/project/AddMetaInfLicenseFiles.scala
+++ b/project/AddMetaInfLicenseFiles.scala
@@ -78,7 +78,7 @@ object AddMetaInfLicenseFiles extends AutoPlugin {
         }
       }))
 
-  override def trigger = allRequirements
+  override lazy val trigger = allRequirements
 
-  override def requires = ApacheSonatypePlugin
+  override lazy val requires = ApacheSonatypePlugin
 }

--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -18,10 +18,10 @@ import sbt._
 object CopyrightHeader extends AutoPlugin {
   import HeaderPlugin.autoImport._
 
-  override def requires = HeaderPlugin
-  override def trigger = allRequirements
+  override lazy val requires = HeaderPlugin
+  override lazy val trigger = allRequirements
 
-  override def projectSettings = Def.settings(
+  override lazy val projectSettings = Def.settings(
     Seq(Compile, Test).flatMap { config =>
       inConfig(config)(
         Seq(

--- a/project/CopyrightHeaderForBoilerplate.scala
+++ b/project/CopyrightHeaderForBoilerplate.scala
@@ -18,10 +18,10 @@ import sbt.{ inConfig, Compile, Def, Plugins, Test, _ }
 import spray.boilerplate.BoilerplatePlugin
 
 object CopyrightHeaderForBoilerplate extends AutoPlugin {
-  override def requires: Plugins = BoilerplatePlugin && CopyrightHeader
-  override def trigger: PluginTrigger = allRequirements
+  override lazy val requires: Plugins = BoilerplatePlugin && CopyrightHeader
+  override lazy val trigger: PluginTrigger = allRequirements
 
-  override def projectSettings: Seq[Def.Setting[_]] = {
+  override lazy val projectSettings: Seq[Def.Setting[_]] = {
     Seq(Compile, Test).flatMap { config =>
       inConfig(config) {
         Seq(

--- a/project/CopyrightHeaderForBuild.scala
+++ b/project/CopyrightHeaderForBuild.scala
@@ -17,10 +17,10 @@ import sbt.Keys.baseDirectory
 import sbt.{ inConfig, Compile, Def, PluginTrigger, Test, _ }
 
 object CopyrightHeaderForBuild extends AutoPlugin {
-  override def requires: Plugins = CopyrightHeader
-  override def trigger: PluginTrigger = noTrigger
+  override lazy val requires: Plugins = CopyrightHeader
+  override lazy val trigger: PluginTrigger = noTrigger
 
-  override def projectSettings: Seq[Def.Setting[_]] = {
+  override lazy val projectSettings: Seq[Def.Setting[_]] = {
     Seq(Compile, Test).flatMap { config =>
       inConfig(config) {
         Seq(

--- a/project/CopyrightHeaderForJdk9.scala
+++ b/project/CopyrightHeaderForJdk9.scala
@@ -17,10 +17,10 @@ import sbt.{ Compile, Def, Test, _ }
 
 object CopyrightHeaderForJdk9 extends AutoPlugin {
 
-  override def requires = CopyrightHeader && Jdk9
-  override def trigger = allRequirements
+  override lazy val requires = CopyrightHeader && Jdk9
+  override lazy val trigger = allRequirements
 
-  override def projectSettings: Seq[Def.Setting[_]] = {
+  override lazy val projectSettings: Seq[Def.Setting[_]] = {
     import Jdk9._
     Seq(
       Compile / headerSources ++=

--- a/project/CopyrightHeaderForProtobuf.scala
+++ b/project/CopyrightHeaderForProtobuf.scala
@@ -18,10 +18,10 @@ import sbt.{ inConfig, Compile, Def, Test, _ }
 
 object CopyrightHeaderForProtobuf extends AutoPlugin {
 
-  override def requires = CopyrightHeader
-  override def trigger = allRequirements
+  override lazy val requires = CopyrightHeader
+  override lazy val trigger = allRequirements
 
-  override def projectSettings: Seq[Def.Setting[_]] = {
+  override lazy val projectSettings: Seq[Def.Setting[_]] = {
     Seq(Compile, Test).flatMap { config =>
       inConfig(config) {
         Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,9 +77,7 @@ object Dependencies {
     val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion
 
     // ssl-config
-    val sslConfigCore = Def.setting {
-      "com.typesafe" %% "ssl-config-core" % sslConfigVersion
-    }
+    val sslConfigCore = "com.typesafe" %% "ssl-config-core" % sslConfigVersion
 
     val lmdb = "org.lmdbjava" % "lmdbjava" % "0.9.0"
 
@@ -87,7 +85,7 @@ object Dependencies {
     val junit5 = "org.junit.jupiter" % "junit-jupiter-engine" % junit5Version
 
     // For Java 8 Conversions
-    val java8Compat = Def.setting {
+    lazy val java8Compat = Def.setting {
       "org.scala-lang.modules" %% "scala-java8-compat" % java8CompatVersion.value
     }
 
@@ -98,30 +96,14 @@ object Dependencies {
 
     val asnOne = ("com.hierynomus" % "asn-one" % "0.6.0").exclude("org.slf4j", "slf4j-api")
 
-    val jacksonCore = Def.setting {
-      "com.fasterxml.jackson.core" % "jackson-core" % jacksonCoreVersion
-    } // ApacheV2
-    val jacksonAnnotations = Def.setting {
-      "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonCoreVersion
-    } // ApacheV2
-    val jacksonDatabind = Def.setting {
-      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
-    } // ApacheV2
-    val jacksonJdk8 = Def.setting {
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonCoreVersion
-    } // ApacheV2
-    val jacksonJsr310 = Def.setting {
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonCoreVersion
-    } // ApacheV2
-    val jacksonScala = Def.setting {
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonCoreVersion
-    } // ApacheV2
-    val jacksonParameterNames = Def.setting {
-      "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % jacksonCoreVersion
-    } // ApacheV2
-    val jacksonCbor = Def.setting {
-      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonCoreVersion
-    } // ApacheV2
+    val jacksonCore = "com.fasterxml.jackson.core" % "jackson-core" % jacksonCoreVersion
+    val jacksonAnnotations = "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonCoreVersion
+    val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
+    val jacksonJdk8 = "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonCoreVersion
+    val jacksonJsr310 = "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonCoreVersion
+    val jacksonScala = "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonCoreVersion
+    val jacksonParameterNames = "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % jacksonCoreVersion
+    val jacksonCbor = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonCoreVersion
     val lz4Java = "org.lz4" % "lz4-java" % "1.8.0"
 
     val logback = "ch.qos.logback" % "logback-classic" % logbackVersion
@@ -140,23 +122,16 @@ object Dependencies {
 
       val logback = Compile.logback % Test
 
-      val scalatest = Def.setting { "org.scalatest" %% "scalatest" % scalaTestVersion % Test } // ApacheV2
+      val scalatest = "org.scalatest" %% "scalatest" % scalaTestVersion % Test
 
       // The 'scalaTestPlus' projects are independently versioned,
       // but the version of each module starts with the scalatest
       // version it was intended to work with
-      val scalatestJUnit = Def.setting {
-        "org.scalatestplus" %% "junit-4-13" % (scalaTestVersion + ".0") % Test
-      }
-      val scalatestTestNG = Def.setting {
-        "org.scalatestplus" %% "testng-7-5" % (scalaTestVersion + ".0") % Test
-      }
-      val scalatestScalaCheck = Def.setting {
+      val scalatestJUnit = "org.scalatestplus" %% "junit-4-13" % (scalaTestVersion + ".0") % Test
+      val scalatestTestNG = "org.scalatestplus" %% "testng-7-5" % (scalaTestVersion + ".0") % Test
+      val scalatestScalaCheck =
         "org.scalatestplus" %% s"scalacheck-$scalaTestScalaCheckVersion" % (scalaTestVersion + ".0") % Test
-      }
-      val scalatestMockito = Def.setting {
-        "org.scalatestplus" %% "mockito-4-11" % (scalaTestVersion + ".0") % Test
-      }
+      val scalatestMockito = "org.scalatestplus" %% "mockito-4-11" % (scalaTestVersion + ".0") % Test
 
       val pojosr = "com.googlecode.pojosr" % "de.kalpatec.pojosr.framework" % "0.2.1" % Test
       val tinybundles = "org.ops4j.pax.tinybundles" % "tinybundles" % "3.0.0" % Test
@@ -164,21 +139,17 @@ object Dependencies {
       // in-memory filesystem for file related tests
       val jimfs = "com.google.jimfs" % "jimfs" % "1.3.0" % Test
 
-      val dockerClient = Def.setting {
-        Seq(
-          "com.github.docker-java" % "docker-java-core" % "3.3.4" % Test,
-          "com.github.docker-java" % "docker-java-transport-httpclient5" % "3.3.4" % Test)
-      }
+      val dockerClient = Seq(
+        "com.github.docker-java" % "docker-java-core" % "3.3.4" % Test,
+        "com.github.docker-java" % "docker-java-transport-httpclient5" % "3.3.4" % Test)
 
-      val jackson = Def.setting {
-        Seq(
-          (jacksonCore.value % Test).force(),
-          (jacksonAnnotations.value % Test).force(),
-          (jacksonDatabind.value % Test).force(),
-          ("com.fasterxml.jackson.jaxrs" % "jackson-jaxrs-base" % jacksonCoreVersion % Test).force(),
-          ("com.fasterxml.jackson.jaxrs" % "jackson-jaxrs-json-provider" % jacksonCoreVersion % Test).force(),
-          ("com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % jacksonCoreVersion % Test).force())
-      }
+      val jackson = Seq(
+        (jacksonCore % Test).force(),
+        (jacksonAnnotations % Test).force(),
+        (jacksonDatabind % Test).force(),
+        ("com.fasterxml.jackson.jaxrs" % "jackson-jaxrs-base" % jacksonCoreVersion % Test).force(),
+        ("com.fasterxml.jackson.jaxrs" % "jackson-jaxrs-json-provider" % jacksonCoreVersion % Test).force(),
+        ("com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % jacksonCoreVersion % Test).force())
 
       // metrics, measurements, perf testing
       val metrics = "io.dropwizard.metrics" % "metrics-core" % "4.2.24" % Test
@@ -214,7 +185,7 @@ object Dependencies {
       val junit = Compile.junit % "optional;provided;test"
       val junit5 = Compile.junit5 % "optional;provided;test"
 
-      val scalatest = Def.setting { "org.scalatest" %% "scalatest" % scalaTestVersion % "optional;provided;test" }
+      val scalatest = "org.scalatest" %% "scalatest" % scalaTestVersion % "optional;provided;test"
 
       val logback = Compile.logback % "optional;provided;test"
 
@@ -226,164 +197,165 @@ object Dependencies {
 
   import Compile._
   // TODO check if `l ++=` everywhere expensive?
-  val l = libraryDependencies
+  lazy val l = libraryDependencies
 
-  val actor = l ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+  lazy val actor = l ++= (CrossVersion.partialVersion(scalaVersion.value) match {
     // java8-compat is only used in a couple of places for 2.13,
     // it is probably possible to remove the dependency if needed.
     case Some((2, n)) if n == 12 =>
-      List("org.scala-lang.modules" %% "scala-java8-compat" % java8CompatVersion.value) // Scala License
+      List("org.scala-lang.modules" %% "scala-java8-compat" % java8CompatVersion.value)
     case _ => List.empty
   }) ++ Seq(config)
 
   val actorTyped = l ++= Seq(slf4jApi)
 
-  val discovery = l ++= Seq(TestDependencies.junit, TestDependencies.scalatest.value)
+  val discovery = l ++= Seq(TestDependencies.junit, TestDependencies.scalatest)
 
-  val coordination = l ++= Seq(TestDependencies.junit, TestDependencies.scalatest.value)
+  val coordination = l ++= Seq(TestDependencies.junit, TestDependencies.scalatest)
 
-  val testkit = l ++= Seq(TestDependencies.junit, TestDependencies.scalatest.value) ++ TestDependencies.metricsAll
+  val testkit = l ++= Seq(TestDependencies.junit, TestDependencies.scalatest) ++ TestDependencies.metricsAll
 
   // TestDependencies.dockerClient brings in older versions of jackson libs that have CVEs
   val actorTests = l ++= Seq(
     TestDependencies.junit,
-    TestDependencies.scalatest.value,
-    TestDependencies.scalatestJUnit.value,
-    TestDependencies.scalatestScalaCheck.value,
+    TestDependencies.scalatest,
+    TestDependencies.scalatestJUnit,
+    TestDependencies.scalatestScalaCheck,
     TestDependencies.commonsCodec,
     TestDependencies.jimfs) ++
-  TestDependencies.jackson.value ++ TestDependencies.dockerClient.value
+  TestDependencies.jackson ++ TestDependencies.dockerClient
 
-  val actorTestkitTyped = l ++= Seq(
+  lazy val actorTestkitTyped = l ++= Seq(
     Provided.logback,
     Provided.junit,
     Provided.junit5,
-    Provided.scalatest.value,
-    TestDependencies.scalatestJUnit.value)
+    Provided.scalatest,
+    TestDependencies.scalatestJUnit)
 
-  val pki = l ++=
+  lazy val pki = l ++=
     Seq(
       asnOne,
       // pull up slf4j version from the one provided transitively in asnOne to fix unidoc
       Compile.slf4jApi,
-      TestDependencies.scalatest.value)
+      TestDependencies.scalatest)
 
   val remoteDependencies = Seq(`netty-transport`, `netty-handler`, aeronDriver, aeronClient)
   val remoteOptionalDependencies = remoteDependencies.map(_ % "optional")
 
-  val remote = l ++= Seq(
+  lazy val remote = l ++= Seq(
     agrona,
     TestDependencies.junit,
-    TestDependencies.scalatest.value,
+    TestDependencies.scalatest,
     TestDependencies.jimfs,
     TestDependencies.protobufRuntime) ++ remoteOptionalDependencies
 
-  val remoteTests = l ++= Seq(TestDependencies.junit, TestDependencies.scalatest.value) ++ remoteDependencies
+  lazy val remoteTests = l ++= Seq(TestDependencies.junit, TestDependencies.scalatest) ++ remoteDependencies
 
-  val multiNodeTestkit = l ++= Seq(`netty-transport`, `netty-handler`)
+  lazy val multiNodeTestkit = l ++= Seq(`netty-transport`, `netty-handler`)
 
-  val cluster = l ++= Seq(TestDependencies.junit, TestDependencies.scalatest.value, TestDependencies.logback)
+  lazy val cluster = l ++= Seq(TestDependencies.junit, TestDependencies.scalatest, TestDependencies.logback)
 
-  val clusterTools = l ++= Seq(TestDependencies.junit, TestDependencies.scalatest.value)
+  lazy val clusterTools = l ++= Seq(TestDependencies.junit, TestDependencies.scalatest)
 
-  val clusterSharding = l ++= Seq(
+  lazy val clusterSharding = l ++= Seq(
     Provided.levelDBmultiJVM,
     Provided.levelDBNative,
     TestDependencies.junit,
-    TestDependencies.scalatest.value,
+    TestDependencies.scalatest,
     TestDependencies.commonsIo,
     TestDependencies.ycsb)
 
-  val clusterMetrics = l ++= Seq(
+  lazy val clusterMetrics = l ++= Seq(
     Provided.sigarLoader,
     TestDependencies.slf4jJul,
     TestDependencies.slf4jLog4j,
     TestDependencies.logback,
-    TestDependencies.scalatestMockito.value)
+    TestDependencies.scalatestMockito)
 
-  val distributedData = l ++= Seq(lmdb, TestDependencies.junit, TestDependencies.scalatest.value)
+  lazy val distributedData = l ++= Seq(lmdb, TestDependencies.junit, TestDependencies.scalatest)
 
-  val slf4j = l ++= Seq(slf4jApi, TestDependencies.logback)
+  lazy val slf4j = l ++= Seq(slf4jApi, TestDependencies.logback)
 
-  val persistence = l ++= Seq(
+  lazy val persistence = l ++= Seq(
     Provided.levelDB,
     Provided.levelDBNative,
-    TestDependencies.scalatest.value,
-    TestDependencies.scalatestJUnit.value,
+    TestDependencies.scalatest,
+    TestDependencies.scalatestJUnit,
     TestDependencies.junit,
     TestDependencies.commonsIo,
     TestDependencies.commonsCodec)
 
-  val persistenceQuery = l ++= Seq(
-    TestDependencies.scalatest.value,
+  lazy val persistenceQuery = l ++= Seq(
+    TestDependencies.scalatest,
     TestDependencies.junit,
     TestDependencies.commonsIo,
     Provided.levelDB,
     Provided.levelDBNative)
 
-  val persistenceTck = l ++= Seq(
-    TestDependencies.scalatest.value.withConfigurations(Some("compile")),
+  lazy val persistenceTck = l ++= Seq(
+    TestDependencies.scalatest.withConfigurations(Some("compile")),
     TestDependencies.junit.withConfigurations(Some("compile")),
     Provided.levelDB,
     Provided.levelDBNative)
 
-  val persistenceTestKit = l ++= Seq(TestDependencies.scalatest.value, TestDependencies.logback)
+  lazy val persistenceTestKit = l ++= Seq(TestDependencies.scalatest, TestDependencies.logback)
 
-  val persistenceTypedTests = l ++= Seq(TestDependencies.scalatest.value, TestDependencies.logback)
+  lazy val persistenceTypedTests = l ++= Seq(TestDependencies.scalatest, TestDependencies.logback)
 
-  val persistenceShared = l ++= Seq(Provided.levelDB, Provided.levelDBNative, TestDependencies.logback)
+  lazy val persistenceShared = l ++= Seq(Provided.levelDB, Provided.levelDBNative, TestDependencies.logback)
 
-  val jackson = l ++= Seq(
-    jacksonCore.value,
-    jacksonAnnotations.value,
-    jacksonDatabind.value,
-    jacksonJdk8.value,
-    jacksonJsr310.value,
-    jacksonParameterNames.value,
-    jacksonCbor.value,
-    jacksonScala.value,
+  lazy val jackson = l ++= Seq(
+    jacksonCore,
+    jacksonAnnotations,
+    jacksonDatabind,
+    jacksonJdk8,
+    jacksonJsr310,
+    jacksonParameterNames,
+    jacksonCbor,
+    jacksonScala,
     lz4Java,
     TestDependencies.junit,
-    TestDependencies.scalatest.value)
-  val osgi = l ++= Seq(
+    TestDependencies.scalatest)
+
+  lazy val osgi = l ++= Seq(
     osgiCore,
     osgiCompendium,
     TestDependencies.logback,
     TestDependencies.commonsIo,
     TestDependencies.pojosr,
     TestDependencies.tinybundles,
-    TestDependencies.scalatest.value,
+    TestDependencies.scalatest,
     TestDependencies.junit)
 
-  val docs = l ++= Seq(
-    TestDependencies.scalatest.value,
+  lazy val docs = l ++= Seq(
+    TestDependencies.scalatest,
     TestDependencies.junit,
     Docs.sprayJson,
     Docs.gson,
     Provided.levelDB)
 
-  val benchJmh = l ++= Seq(logback, Provided.levelDB, Provided.levelDBNative, Compile.jctools)
+  lazy val benchJmh = l ++= Seq(logback, Provided.levelDB, Provided.levelDBNative, Compile.jctools)
 
   // pekko stream
 
-  lazy val stream = l ++= Seq[sbt.ModuleID](reactiveStreams, sslConfigCore.value, TestDependencies.scalatest.value)
+  lazy val stream = l ++= Seq[sbt.ModuleID](reactiveStreams, sslConfigCore, TestDependencies.scalatest)
 
   lazy val streamTestkit = l ++= Seq(
-    TestDependencies.scalatest.value,
-    TestDependencies.scalatestScalaCheck.value,
+    TestDependencies.scalatest,
+    TestDependencies.scalatestScalaCheck,
     TestDependencies.junit)
 
   lazy val streamTests = l ++= Seq(
-    TestDependencies.scalatest.value,
-    TestDependencies.scalatestScalaCheck.value,
+    TestDependencies.scalatest,
+    TestDependencies.scalatestScalaCheck,
     TestDependencies.junit,
     TestDependencies.commonsIo,
     TestDependencies.jimfs)
 
   lazy val streamTestsTck = l ++= Seq(
-    TestDependencies.scalatest.value,
-    TestDependencies.scalatestTestNG.value,
-    TestDependencies.scalatestScalaCheck.value,
+    TestDependencies.scalatest,
+    TestDependencies.scalatestTestNG,
+    TestDependencies.scalatestScalaCheck,
     TestDependencies.junit,
     TestDependencies.reactiveStreamsTck)
 

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -25,12 +25,12 @@ import sbt.ScopeFilter.ProjectFilter
 object Scaladoc extends AutoPlugin {
 
   object CliOptions {
-    val scaladocDiagramsEnabled = CliOption("pekko.scaladoc.diagrams", true)
-    val scaladocAutoAPI = CliOption("pekko.scaladoc.autoapi", true)
+    lazy val scaladocDiagramsEnabled = CliOption("pekko.scaladoc.diagrams", true)
+    lazy val scaladocAutoAPI = CliOption("pekko.scaladoc.autoapi", true)
   }
 
-  override def trigger = allRequirements
-  override def requires = plugins.JvmPlugin
+  override lazy val trigger = allRequirements
+  override lazy val requires = plugins.JvmPlugin
 
   val validateDiagrams = settingKey[Boolean]("Validate generated scaladoc diagrams")
 
@@ -112,8 +112,8 @@ object Scaladoc extends AutoPlugin {
  */
 object ScaladocNoVerificationOfDiagrams extends AutoPlugin {
 
-  override def trigger = noTrigger
-  override def requires = Scaladoc
+  override lazy val trigger = noTrigger
+  override lazy val requires = Scaladoc
 
   override lazy val projectSettings = Seq(Compile / Scaladoc.validateDiagrams := false)
 }
@@ -124,21 +124,21 @@ object ScaladocNoVerificationOfDiagrams extends AutoPlugin {
 object UnidocRoot extends AutoPlugin {
 
   object CliOptions {
-    val genjavadocEnabled = CliOption("pekko.genjavadoc.enabled", false)
+    lazy val genjavadocEnabled = CliOption("pekko.genjavadoc.enabled", false)
   }
 
   object autoImport {
-    val unidocRootIgnoreProjects = settingKey[Seq[ProjectReference]]("Projects to ignore when generating unidoc")
+    lazy val unidocRootIgnoreProjects = settingKey[Seq[ProjectReference]]("Projects to ignore when generating unidoc")
   }
   import autoImport._
 
-  override def trigger = noTrigger
-  override def requires =
+  override lazy val trigger = noTrigger
+  override lazy val requires =
     UnidocRoot.CliOptions.genjavadocEnabled
       .ifTrue(sbtunidoc.ScalaUnidocPlugin && sbtunidoc.JavaUnidocPlugin && sbtunidoc.GenJavadocPlugin)
       .getOrElse(sbtunidoc.ScalaUnidocPlugin)
 
-  val pekkoSettings = UnidocRoot.CliOptions.genjavadocEnabled
+  lazy val pekkoSettings = UnidocRoot.CliOptions.genjavadocEnabled
     .ifTrue(Seq(
       JavaUnidoc / unidoc / javacOptions := {
         if (JdkOptions.isJdk8) Seq("-Xdoclint:none")
@@ -209,9 +209,9 @@ object UnidocRoot extends AutoPlugin {
  */
 object BootstrapGenjavadoc extends AutoPlugin {
 
-  override def trigger = allRequirements
+  override lazy val trigger = allRequirements
 
-  override def requires =
+  override lazy val requires =
     UnidocRoot.CliOptions.genjavadocEnabled
       .ifTrue {
         // require 11, fail fast for 8, 9, 10

--- a/project/JavaFormatter.scala
+++ b/project/JavaFormatter.scala
@@ -16,9 +16,9 @@ import sbt.{ AutoPlugin, PluginTrigger, Plugins }
 
 object JavaFormatter extends AutoPlugin {
 
-  override def trigger = PluginTrigger.AllRequirements
+  override lazy val trigger = PluginTrigger.AllRequirements
 
-  override def requires: Plugins = JavaFormatterPlugin
+  override lazy val requires: Plugins = JavaFormatterPlugin
 
   private val ignoreConfigFileName: String = ".sbt-java-formatter.conf"
   private val descriptor: String = "sbt-java-formatter"
@@ -28,7 +28,7 @@ object JavaFormatter extends AutoPlugin {
   import sbt._
   import sbt.io._
 
-  override def projectSettings: Seq[Def.Setting[_]] =
+  override lazy val projectSettings: Seq[Def.Setting[_]] =
     Seq(
       // below is for sbt java formatter
       javafmt / excludeFilter := {

--- a/project/Jdk9.scala
+++ b/project/Jdk9.scala
@@ -17,16 +17,16 @@ import sbt.Keys._
 object Jdk9 extends AutoPlugin {
   import JdkOptions.notOnJdk8
 
-  val CompileJdk9 = config("CompileJdk9").extend(Compile)
+  lazy val CompileJdk9 = config("CompileJdk9").extend(Compile)
 
-  val TestJdk9 = config("TestJdk9").extend(Test).extend(CompileJdk9)
+  lazy val TestJdk9 = config("TestJdk9").extend(Test).extend(CompileJdk9)
 
   val SCALA_SOURCE_DIRECTORY = "scala-jdk-9"
   val SCALA_TEST_SOURCE_DIRECTORY = "scala-jdk9-only"
   val JAVA_SOURCE_DIRECTORY = "java-jdk-9"
   val JAVA_TEST_SOURCE_DIRECTORY = "java-jdk9-only"
 
-  val compileJdk9Settings = Seq(
+  lazy val compileJdk9Settings = Seq(
     // following the scala-2.12, scala-sbt-1.0, ... convention
     unmanagedSourceDirectories := notOnJdk8(
       Seq(
@@ -35,7 +35,7 @@ object Jdk9 extends AutoPlugin {
     scalacOptions := PekkoBuild.DefaultScalacOptions.value ++ notOnJdk8(Seq("-release", "11")),
     javacOptions := PekkoBuild.DefaultJavacOptions ++ notOnJdk8(Seq("--release", "11")))
 
-  val testJdk9Settings = Seq(
+  lazy val testJdk9Settings = Seq(
     // following the scala-2.12, scala-sbt-1.0, ... convention
     unmanagedSourceDirectories := notOnJdk8(
       Seq(
@@ -47,20 +47,20 @@ object Jdk9 extends AutoPlugin {
     classpathConfiguration := TestJdk9,
     externalDependencyClasspath := (Test / externalDependencyClasspath).value)
 
-  val compileSettings = Seq(
+  lazy val compileSettings = Seq(
     // It might have been more 'neat' to add the jdk9 products to the jar via packageBin/mappings, but that doesn't work with the OSGi plugin,
     // so we add them to the fullClasspath instead.
     //    Compile / packageBin / mappings
     //      ++= (CompileJdk9 / products).value.flatMap(Path.allSubpaths),
     Compile / fullClasspath ++= (CompileJdk9 / exportedProducts).value)
 
-  val testSettings = Seq((Test / test) := {
+  lazy val testSettings = Seq((Test / test) := {
     (Test / test).value
     (TestJdk9 / test).value
   })
 
-  override def trigger = noTrigger
-  override def projectConfigurations = Seq(CompileJdk9)
+  override lazy val trigger = noTrigger
+  override lazy val projectConfigurations = Seq(CompileJdk9)
   override lazy val projectSettings =
     inConfig(CompileJdk9)(Defaults.compileSettings) ++
     inConfig(CompileJdk9)(compileJdk9Settings) ++

--- a/project/JdkOptions.scala
+++ b/project/JdkOptions.scala
@@ -19,22 +19,22 @@ import sbt.librarymanagement.VersionNumber
 
 object JdkOptions extends AutoPlugin {
   object autoImport {
-    val jdk8home = settingKey[String]("JDK 8 home. Only needs to be set when it cannot be auto-detected by sbt")
-    val targetSystemJdk = settingKey[Boolean](
+    lazy val jdk8home = settingKey[String]("JDK 8 home. Only needs to be set when it cannot be auto-detected by sbt")
+    lazy val targetSystemJdk = settingKey[Boolean](
       "Target the system JDK instead of building against JDK 8. When this is enabled resulting artifacts may not work on JDK 8!")
   }
   import autoImport._
 
-  val specificationVersion: String = sys.props("java.specification.version")
+  lazy val specificationVersion: String = sys.props("java.specification.version")
 
-  val isJdk8: Boolean =
+  lazy val isJdk8: Boolean =
     VersionNumber(specificationVersion).matchesSemVer(SemanticSelector(s"=1.8"))
-  val isJdk11orHigher: Boolean =
+  lazy val isJdk11orHigher: Boolean =
     VersionNumber(specificationVersion).matchesSemVer(SemanticSelector(">=11"))
-  val isJdk17orHigher: Boolean =
+  lazy val isJdk17orHigher: Boolean =
     VersionNumber(specificationVersion).matchesSemVer(SemanticSelector(">=17"))
 
-  val versionSpecificJavaOptions =
+  lazy val versionSpecificJavaOptions =
     if (isJdk17orHigher) {
       // for aeron
       "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED" ::
@@ -87,5 +87,5 @@ object JdkOptions extends AutoPlugin {
             "A JDK 8 installation was not found, but is required to build Apache Pekko. To manually specify a JDK 8 installation, set the JAVA_8_HOME environment variable to its path or use the \"set every jdk8home := \\\"/path/to/jdk\\\" sbt command. If you have no JDK 8 installation, target your system JDK with the \"set every targetSystemJdk := true\" sbt command, but beware resulting artifacts will not work on JDK 8")
       }
 
-  val targetJdkSettings = Seq(targetSystemJdk := false, jdk8home := sys.env.get("JAVA_8_HOME").getOrElse(""))
+  lazy val targetJdkSettings = Seq(targetSystemJdk := false, jdk8home := sys.env.get("JAVA_8_HOME").getOrElse(""))
 }

--- a/project/LicenseReport.scala
+++ b/project/LicenseReport.scala
@@ -37,8 +37,8 @@ object LicenseReport extends AutoPlugin {
       Column.OriginatingArtifactName,
       Column.Configuration))
 
-  override def requires = plugins.JvmPlugin && SbtLicenseReport
+  override lazy val requires = plugins.JvmPlugin && SbtLicenseReport
 
-  override def trigger = allRequirements
+  override lazy val trigger = allRequirements
 
 }

--- a/project/MultiNode.scala
+++ b/project/MultiNode.scala
@@ -25,33 +25,33 @@ import sbtassembly.AssemblyKeys._
 object MultiNode extends AutoPlugin {
 
   object autoImport {
-    val validateCompile = taskKey[Unit]("Validates compile for any project it is enabled")
+    lazy val validateCompile = taskKey[Unit]("Validates compile for any project it is enabled")
   }
   import autoImport._
 
   // MultiJvm tests can be excluded from normal test target an validatePullRequest
   // with -Dpekko.test.multi-in-test=false
-  val multiNodeTestInTest: Boolean = sys.props.getOrElse("pekko.test.multi-in-test", "true").toBoolean
+  lazy val multiNodeTestInTest: Boolean = sys.props.getOrElse("pekko.test.multi-in-test", "true").toBoolean
 
   object CliOptions {
-    val multiNode = CliOption("pekko.test.multi-node", false)
-    val sbtLogNoFormat = CliOption("sbt.log.noformat", false)
+    lazy val multiNode = CliOption("pekko.test.multi-node", false)
+    lazy val sbtLogNoFormat = CliOption("sbt.log.noformat", false)
 
-    val hostsFileName = sys.props.get("pekko.test.multi-node.hostsFileName").toSeq
-    val javaName = sys.props.get("pekko.test.multi-node.java").toSeq
-    val targetDirName = sys.props.get("pekko.test.multi-node.targetDirName").toSeq
+    lazy val hostsFileName = sys.props.get("pekko.test.multi-node.hostsFileName").toSeq
+    lazy val javaName = sys.props.get("pekko.test.multi-node.java").toSeq
+    lazy val targetDirName = sys.props.get("pekko.test.multi-node.targetDirName").toSeq
   }
 
-  val multiExecuteTests =
+  lazy val multiExecuteTests =
     CliOptions.multiNode.ifTrue(MultiJvm / multiNodeExecuteTests).getOrElse(MultiJvm / executeTests)
-  val multiTest = CliOptions.multiNode.ifTrue(MultiJvm / multiNodeTest).getOrElse(MultiJvm / test)
+  lazy val multiTest = CliOptions.multiNode.ifTrue(MultiJvm / multiNodeTest).getOrElse(MultiJvm / test)
 
-  override def trigger = noTrigger
-  override def requires = plugins.JvmPlugin && MultiJvmPlugin
+  override lazy val trigger = noTrigger
+  override lazy val requires = plugins.JvmPlugin && MultiJvmPlugin
 
   override lazy val projectSettings: Seq[Def.Setting[_]] = multiJvmSettings
 
-  private val defaultMultiJvmOptions: Seq[String] = {
+  private lazy val defaultMultiJvmOptions: Seq[String] = {
     import scala.collection.JavaConverters._
     // multinode.D= and multinode.X= makes it possible to pass arbitrary
     // -D or -X arguments to the forked jvm, e.g.
@@ -69,9 +69,9 @@ object MultiNode extends AutoPlugin {
     "-Xmx256m" :: pekkoProperties ::: CliOptions.sbtLogNoFormat.ifTrue("-Dpekko.test.nocolor=true").toList
   } ++ JdkOptions.versionSpecificJavaOptions
 
-  private val anyConfigsInThisProject = ScopeFilter(configurations = inAnyConfiguration)
+  private lazy val anyConfigsInThisProject = ScopeFilter(configurations = inAnyConfiguration)
 
-  private val multiJvmSettings =
+  private lazy val multiJvmSettings =
     MultiJvmPlugin.multiJvmSettings ++
     inConfig(MultiJvm)(scalafmtConfigSettings) ++
     Seq(
@@ -137,7 +137,7 @@ object MultiNode extends AutoPlugin {
  */
 object MultiNodeScalaTest extends AutoPlugin {
 
-  override def requires = MultiNode
+  override lazy val requires = MultiNode
 
   override lazy val projectSettings =
     Seq(

--- a/project/OSGi.scala
+++ b/project/OSGi.scala
@@ -23,7 +23,7 @@ object OSGi {
   // The included osgiSettings that creates bundles also publish the jar files
   // in the .../bundles directory which makes testing locally published artifacts
   // a pain. Create bundles but publish them to the normal .../jars directory.
-  def osgiSettings =
+  lazy val osgiSettings =
     defaultOsgiSettings ++ Seq(
       Compile / packageBin := {
         val bundle = OsgiKeys.bundle.value
@@ -45,7 +45,7 @@ object OSGi {
       // Recent versions of BND create corrupted jars so use JDK jar instead, see https://github.com/sbt/sbt-osgi/pull/81
       OsgiKeys.packageWithJVMJar := true)
 
-  val actor = osgiSettings ++ Seq(
+  lazy val actor = osgiSettings ++ Seq(
     OsgiKeys.exportPackage := Seq("org.apache.pekko*"),
     OsgiKeys.privatePackage := Seq("org.apache.pekko.osgi.impl"),
     // pekko-actor packages are not imported, as contained in the CP
@@ -58,22 +58,23 @@ object OSGi {
     // dynamicImportPackage needed for loading classes defined in configuration
     OsgiKeys.dynamicImportPackage := Seq("*"))
 
-  val actorTyped = exports(Seq("org.apache.pekko.actor.typed.*"))
+  lazy val actorTyped = exports(Seq("org.apache.pekko.actor.typed.*"))
 
-  val cluster = exports(Seq("org.apache.pekko.cluster.*"))
+  lazy val cluster = exports(Seq("org.apache.pekko.cluster.*"))
 
-  val clusterTools = exports(Seq("org.apache.pekko.cluster.singleton.*", "org.apache.pekko.cluster.client.*",
+  lazy val clusterTools = exports(Seq("org.apache.pekko.cluster.singleton.*", "org.apache.pekko.cluster.client.*",
     "org.apache.pekko.cluster.pubsub.*"))
 
-  val clusterSharding = exports(Seq("org.apache.pekko.cluster.sharding.*"))
+  lazy val clusterSharding = exports(Seq("org.apache.pekko.cluster.sharding.*"))
 
-  val clusterMetrics = exports(Seq("org.apache.pekko.cluster.metrics.*"), imports = Seq(kamonImport(), sigarImport()))
+  lazy val clusterMetrics =
+    exports(Seq("org.apache.pekko.cluster.metrics.*"), imports = Seq(kamonImport(), sigarImport()))
 
-  val distributedData = exports(Seq("org.apache.pekko.cluster.ddata.*"))
+  lazy val distributedData = exports(Seq("org.apache.pekko.cluster.ddata.*"))
 
-  val osgi = exports(Seq("org.apache.pekko.osgi.*"))
+  lazy val osgi = exports(Seq("org.apache.pekko.osgi.*"))
 
-  val protobufV3 = osgiSettings ++ Seq(
+  lazy val protobufV3 = osgiSettings ++ Seq(
     OsgiKeys.importPackage := Seq(
       "!sun.misc",
       scalaJava8CompatImport(),
@@ -89,11 +90,11 @@ object OSGi {
     // (including typical ones such as scala runtime)
     OsgiKeys.explodedJars := Seq(assembly.value))
 
-  val jackson = exports(Seq("org.apache.pekko.serialization.jackson.*"))
+  lazy val jackson = exports(Seq("org.apache.pekko.serialization.jackson.*"))
 
-  val remote = exports(Seq("org.apache.pekko.remote.*"))
+  lazy val remote = exports(Seq("org.apache.pekko.remote.*"))
 
-  val stream =
+  lazy val stream =
     exports(
       packages = Seq("org.apache.pekko.stream.*", "com.typesafe.sslconfig.pekko.*"),
       imports = Seq(
@@ -103,25 +104,25 @@ object OSGi {
         sslConfigCoreImport("com.typesafe.sslconfig.util.*"),
         "!com.typesafe.sslconfig.pekko.*"))
 
-  val streamTestkit = exports(Seq("org.apache.pekko.stream.testkit.*"))
+  lazy val streamTestkit = exports(Seq("org.apache.pekko.stream.testkit.*"))
 
-  val slf4j = exports(Seq("org.apache.pekko.event.slf4j.*"))
+  lazy val slf4j = exports(Seq("org.apache.pekko.event.slf4j.*"))
 
-  val persistence = exports(
+  lazy val persistence = exports(
     Seq("org.apache.pekko.persistence.*"),
     imports = Seq(optionalResolution("org.fusesource.leveldbjni.*"), optionalResolution("org.iq80.leveldb.*")))
 
-  val persistenceTyped = exports(Seq("org.apache.pekko.persistence.typed.*"))
+  lazy val persistenceTyped = exports(Seq("org.apache.pekko.persistence.typed.*"))
 
-  val persistenceQuery = exports(Seq("org.apache.pekko.persistence.query.*"))
+  lazy val persistenceQuery = exports(Seq("org.apache.pekko.persistence.query.*"))
 
-  val testkit = exports(Seq("org.apache.pekko.testkit.*"))
+  lazy val testkit = exports(Seq("org.apache.pekko.testkit.*"))
 
-  val discovery = exports(Seq("org.apache.pekko.discovery.*"))
+  lazy val discovery = exports(Seq("org.apache.pekko.discovery.*"))
 
-  val coordination = exports(Seq("org.apache.pekko.coordination.*"))
+  lazy val coordination = exports(Seq("org.apache.pekko.coordination.*"))
 
-  val osgiOptionalImports = Seq(
+  lazy val osgiOptionalImports = Seq(
     // needed because testkit is normally not used in the application bundle,
     // but it should still be included as transitive dependency and used by BundleDelegatingClassLoader
     // to be able to find reference.conf

--- a/project/Paradox.scala
+++ b/project/Paradox.scala
@@ -24,7 +24,7 @@ import scala.concurrent.duration._
 
 object Paradox {
   val pekkoBaseURL = "https://pekko.apache.org"
-  val propertiesSettings = Seq(
+  lazy val propertiesSettings = Seq(
     Compile / paradoxProperties ++= Map(
       "canonical.base_url" -> s"$pekkoBaseURL/docs/pekko/current",
       "github.base_url" -> GitHub
@@ -69,18 +69,18 @@ object Paradox {
       "netty_version" -> Dependencies.nettyVersion,
       "logback_version" -> Dependencies.logbackVersion))
 
-  val rootsSettings = Seq(
+  lazy val rootsSettings = Seq(
     paradoxRoots := List(
       "index.html",
       // TODO page not linked to
       "fault-tolerance-sample.html"))
 
-  val themeSettings = Seq(
+  lazy val themeSettings = Seq(
     pekkoParadoxGithub := Some("https://github.com/apache/incubator-pekko"))
 
   // FIXME https://github.com/lightbend/paradox/issues/350
   // Exclusions from direct compilation for includes dirs/files not belonging in a TOC
-  val includesSettings = Seq(
+  lazy val includesSettings = Seq(
     (Compile / paradoxMarkdownToHtml / excludeFilter) := (Compile / paradoxMarkdownToHtml / excludeFilter).value ||
     ParadoxPlugin.InDirectoryFilter((Compile / paradox / sourceDirectory).value / "includes"),
     // Links are interpreted relative to the page the snippet is included in,
@@ -88,11 +88,11 @@ object Paradox {
     (Compile / paradoxMarkdownToHtml / excludeFilter) := (Compile / paradoxMarkdownToHtml / excludeFilter).value ||
     ParadoxPlugin.InDirectoryFilter((Compile / paradox / sourceDirectory).value / "includes.html"))
 
-  val groupsSettings = Seq(Compile / paradoxGroups := Map("Language" -> Seq("Scala", "Java")))
+  lazy val groupsSettings = Seq(Compile / paradoxGroups := Map("Language" -> Seq("Scala", "Java")))
 
-  val parsingSettings = Seq(Compile / paradoxParsingTimeout := 5.seconds)
+  lazy val parsingSettings = Seq(Compile / paradoxParsingTimeout := 5.seconds)
 
-  val sourceGeneratorSettings = Seq(
+  lazy val sourceGeneratorSettings = Seq(
     Compile / paradoxMarkdownToHtml / sourceGenerators += Def.taskDyn {
       val targetFile = (Compile / paradox / sourceManaged).value / "project" / "license-report.md"
 
@@ -101,7 +101,7 @@ object Paradox {
       }
     }.taskValue)
 
-  val settings =
+  lazy val settings =
     propertiesSettings ++
     rootsSettings ++
     includesSettings ++

--- a/project/ParadoxBrowse.scala
+++ b/project/ParadoxBrowse.scala
@@ -19,12 +19,12 @@ import sbt._
 object ParadoxBrowse extends AutoPlugin {
 
   object autoImport {
-    val paradoxBrowse = taskKey[Unit]("Open the docs in the default browser")
+    lazy val paradoxBrowse = taskKey[Unit]("Open the docs in the default browser")
   }
   import autoImport._
 
-  override def trigger = allRequirements
-  override def requires = ParadoxPlugin
+  override lazy val trigger = allRequirements
+  override lazy val requires = ParadoxPlugin
 
   override lazy val projectSettings = Seq(paradoxBrowse := {
     import java.awt.Desktop

--- a/project/PekkoDisciplinePlugin.scala
+++ b/project/PekkoDisciplinePlugin.scala
@@ -17,12 +17,12 @@ import sbt.plugins.JvmPlugin
 
 object PekkoDisciplinePlugin extends AutoPlugin {
 
-  override def trigger: PluginTrigger = allRequirements
-  override def requires: Plugins = JvmPlugin
+  override lazy val trigger: PluginTrigger = allRequirements
+  override lazy val requires: Plugins = JvmPlugin
   override lazy val projectSettings = disciplineSettings
 
   // allow toggling for pocs/exploration of ideas without discipline
-  val enabled = !sys.props.contains("pekko.no.discipline")
+  lazy val enabled = !sys.props.contains("pekko.no.discipline")
 
   // We allow warnings in docs to get the 'snippets' right
   val nonFatalJavaWarningsFor = Set(
@@ -95,7 +95,7 @@ object PekkoDisciplinePlugin extends AutoPlugin {
   /**
    * We are a little less strict in docs
    */
-  val docs =
+  lazy val docs =
     Seq(
       Compile / scalacOptions -= defaultScalaOptions,
       Compile / scalacOptions ++= (

--- a/project/ProjectFileIgnoreSupport.scala
+++ b/project/ProjectFileIgnoreSupport.scala
@@ -17,7 +17,7 @@ import com.typesafe.config.ConfigFactory
 import sbt.ConsoleLogger
 
 class ProjectFileIgnoreSupport(ignoreConfigFile: File, descriptor: String) {
-  private val stdoutLogger = ConsoleLogger(System.out)
+  private lazy val stdoutLogger = ConsoleLogger(System.out)
 
   private val javaSourceDirectories = Set("java", Jdk9.JAVA_SOURCE_DIRECTORY, Jdk9.JAVA_TEST_SOURCE_DIRECTORY)
 

--- a/project/Protobuf.scala
+++ b/project/Protobuf.scala
@@ -23,15 +23,15 @@ import Keys._
 import sbtassembly.AssemblyKeys._
 
 object Protobuf {
-  val paths = SettingKey[Seq[File]]("protobuf-paths", "The paths that contain *.proto files.")
-  val outputPaths =
+  lazy val paths = SettingKey[Seq[File]]("protobuf-paths", "The paths that contain *.proto files.")
+  lazy val outputPaths =
     SettingKey[Seq[File]]("protobuf-output-paths", "The paths where to save the generated *.java files.")
-  val importPath = SettingKey[Option[File]](
+  lazy val importPath = SettingKey[Option[File]](
     "protobuf-import-path",
     "The path that contain additional *.proto files that can be imported.")
-  val protoc = SettingKey[String]("protobuf-protoc", "The path and name of the protoc executable.")
-  val protocVersion = SettingKey[String]("protobuf-protoc-version", "The version of the protoc executable.")
-  val generate = TaskKey[Unit]("protobuf-generate", "Compile the protobuf sources and do all processing.")
+  lazy val protoc = SettingKey[String]("protobuf-protoc", "The path and name of the protoc executable.")
+  lazy val protocVersion = SettingKey[String]("protobuf-protoc-version", "The version of the protoc executable.")
+  lazy val generate = TaskKey[Unit]("protobuf-generate", "Compile the protobuf sources and do all processing.")
 
   lazy val settings: Seq[Setting[_]] = Seq(
     paths := Seq((Compile / sourceDirectory).value, (Test / sourceDirectory).value).map(_ / "protobuf"),

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -19,7 +19,7 @@ import sbtdynver.DynVerPlugin.autoImport.dynverSonatypeSnapshots
 
 object Publish extends AutoPlugin {
 
-  override def trigger = allRequirements
+  override lazy val trigger = allRequirements
 
   override lazy val projectSettings = Seq(
     startYear := Some(2022),
@@ -33,15 +33,15 @@ object Publish extends AutoPlugin {
   override lazy val buildSettings = Seq(
     dynverSonatypeSnapshots := true)
 
-  override def requires = ApacheSonatypePlugin && DynVerPlugin
+  override lazy val requires = ApacheSonatypePlugin && DynVerPlugin
 }
 
 /**
  * For projects that are not to be published.
  */
 object NoPublish extends AutoPlugin {
-  override def requires = plugins.JvmPlugin
+  override lazy val requires = plugins.JvmPlugin
 
-  override def projectSettings =
+  override lazy val projectSettings =
     Seq(publish / skip := true, Compile / doc / sources := Seq.empty)
 }

--- a/project/SbtMultiJvmPlugin.scala
+++ b/project/SbtMultiJvmPlugin.scala
@@ -78,11 +78,11 @@ object MultiJvmPlugin extends AutoPlugin {
 
   import MultiJvmKeys._
 
-  override def requires = plugins.JvmPlugin
+  override lazy val requires = plugins.JvmPlugin
 
   override def projectConfigurations = Seq(MultiJvm)
 
-  override def projectSettings = multiJvmSettings
+  override lazy val projectSettings = multiJvmSettings
 
   private[this] def noTestsMessage(scoped: ScopedKey[_])(implicit display: Show[ScopedKey[_]]): String =
     "No tests to run for " + display.show(scoped)

--- a/project/ScalaFixExtraRulesPlugin.scala
+++ b/project/ScalaFixExtraRulesPlugin.scala
@@ -15,13 +15,13 @@ import sbt.{ AutoPlugin, PluginTrigger, Plugins }
 import scalafix.sbt.ScalafixPlugin
 
 object ScalaFixExtraRulesPlugin extends AutoPlugin with ScalafixSupport {
-  override def trigger: PluginTrigger = allRequirements
+  override lazy val trigger: PluginTrigger = allRequirements
 
-  override def requires: Plugins = ScalafixPlugin
+  override lazy val requires: Plugins = ScalafixPlugin
 
   import sbt._
   import scalafix.sbt.ScalafixPlugin.autoImport.scalafixDependencies
-  override def projectSettings: Seq[Def.Setting[_]] = super.projectSettings ++ {
+  override lazy val projectSettings: Seq[Def.Setting[_]] = super.projectSettings ++ {
     ThisBuild / scalafixDependencies ++= Seq(
       "com.nequissimus" %% "sort-imports" % "0.6.1",
       // https://github.com/ohze/scala-rewrites

--- a/project/ScalaFixForJdk9Plugin.scala
+++ b/project/ScalaFixForJdk9Plugin.scala
@@ -15,16 +15,16 @@ import sbt.{ AutoPlugin, PluginTrigger, Plugins }
 import scalafix.sbt.ScalafixPlugin
 
 object ScalaFixForJdk9Plugin extends AutoPlugin with ScalafixSupport {
-  override def trigger: PluginTrigger = allRequirements
+  override lazy val trigger: PluginTrigger = allRequirements
   import Jdk9._
-  override def requires: Plugins = Jdk9 && ScalafixPlugin
+  override lazy val requires: Plugins = Jdk9 && ScalafixPlugin
 
   import ScalafixPlugin.autoImport.scalafixConfigSettings
   import sbt._
 
   lazy val scalafixIgnoredSetting: Seq[Setting[_]] = Seq(ignore(TestJdk9))
 
-  override def projectSettings: Seq[Def.Setting[_]] =
+  override lazy val projectSettings: Seq[Def.Setting[_]] =
     Seq(CompileJdk9, TestJdk9).flatMap(c => inConfig(c)(scalafixConfigSettings(c))) ++
     scalafixIgnoredSetting ++ Seq(
       updateProjectCommands(

--- a/project/ScalafixForMultiNodePlugin.scala
+++ b/project/ScalafixForMultiNodePlugin.scala
@@ -16,15 +16,15 @@ import scalafix.sbt.ScalafixPlugin
 import scalafix.sbt.ScalafixPlugin.autoImport.scalafixConfigSettings
 
 object ScalafixForMultiNodePlugin extends AutoPlugin with ScalafixSupport {
-  override def trigger: PluginTrigger = allRequirements
+  override lazy val trigger: PluginTrigger = allRequirements
 
-  override def requires: Plugins = MultiNode && ScalafixPlugin
+  override lazy val requires: Plugins = MultiNode && ScalafixPlugin
 
   import MultiJvmPlugin.autoImport._
 
   lazy val scalafixIgnoredSetting: Seq[Setting[_]] = Seq(ignore(MultiJvm))
 
-  override def projectSettings: Seq[Def.Setting[_]] =
+  override lazy val projectSettings: Seq[Def.Setting[_]] =
     Seq(MultiJvm).flatMap(c => inConfig(c)(scalafixConfigSettings(c))) ++
     scalafixIgnoredSetting ++ Seq(
       updateProjectCommands(alias = "fixall", value = ";scalafixEnable;scalafixAll;scalafmtAll"),

--- a/project/ScalafixIgnoreFilePlugin.scala
+++ b/project/ScalafixIgnoreFilePlugin.scala
@@ -16,13 +16,13 @@ import sbt.{ AutoPlugin, PluginTrigger, Plugins }
 import scalafix.sbt.ScalafixPlugin
 
 object ScalafixIgnoreFilePlugin extends AutoPlugin with ScalafixSupport {
-  override def trigger: PluginTrigger = allRequirements
+  override lazy val trigger: PluginTrigger = allRequirements
 
-  override def requires: Plugins = JvmPlugin && ScalafixPlugin
+  override lazy val requires: Plugins = JvmPlugin && ScalafixPlugin
   import sbt._
   lazy val scalafixIgnoredSetting: Seq[Setting[_]] = if (ScalafixSupport.fixTestScope) Nil else Seq(ignore(Test))
 
-  override def projectSettings: Seq[Def.Setting[_]] =
+  override lazy val projectSettings: Seq[Def.Setting[_]] =
     scalafixIgnoredSetting ++ Seq(
       addProjectCommandsIfAbsent(alias = "fixall", value = ";scalafixEnable;scalafixAll;test:compile;reload"))
 }

--- a/project/ScalafixSupport.scala
+++ b/project/ScalafixSupport.scala
@@ -49,5 +49,5 @@ trait ScalafixSupport {
 }
 
 object ScalafixSupport {
-  def fixTestScope: Boolean = System.getProperty("pekko.scalafix.fixTestScope", "false").toBoolean
+  lazy val fixTestScope: Boolean = System.getProperty("pekko.scalafix.fixTestScope", "false").toBoolean
 }

--- a/project/TestExtras.scala
+++ b/project/TestExtras.scala
@@ -18,25 +18,25 @@ object TestExtras {
   import JdkOptions.isJdk8
   object Filter {
     object Keys {
-      val excludeTestNames = settingKey[Set[String]](
+      lazy val excludeTestNames = settingKey[Set[String]](
         "Names of tests to be excluded. Not supported by MultiJVM tests. Example usage: -Dpekko.test.names.exclude=TimingSpec")
-      val excludeTestTags = settingKey[Set[String]](
+      lazy val excludeTestTags = settingKey[Set[String]](
         "Tags of tests to be excluded. It will not be used if you specify -Dpekko.test.tags.only. Example usage: -Dpekko.test.tags.exclude=long-running")
-      val onlyTestTags =
+      lazy val onlyTestTags =
         settingKey[Set[String]]("Tags of tests to be ran. Example usage: -Dpekko.test.tags.only=long-running")
 
-      val checkTestsHaveRun = taskKey[Unit]("Verify a number of notable tests have actually run")
+      lazy val checkTestsHaveRun = taskKey[Unit]("Verify a number of notable tests have actually run")
     }
 
     import Keys._
 
     private[Filter] object Params {
-      val testNamesExclude = systemPropertyAsSeq("pekko.test.names.exclude").toSet
-      val testTagsExlcude = systemPropertyAsSeq("pekko.test.tags.exclude").toSet
-      val testTagsOnly = systemPropertyAsSeq("pekko.test.tags.only").toSet
+      lazy val testNamesExclude = systemPropertyAsSeq("pekko.test.names.exclude").toSet
+      lazy val testTagsExlcude = systemPropertyAsSeq("pekko.test.tags.exclude").toSet
+      lazy val testTagsOnly = systemPropertyAsSeq("pekko.test.tags.only").toSet
     }
 
-    def settings = {
+    lazy val settings = {
       Seq(
         excludeTestNames := Params.testNamesExclude,
         excludeTestTags := {

--- a/project/TestQuickUntilPassed.scala
+++ b/project/TestQuickUntilPassed.scala
@@ -20,12 +20,12 @@ import sbt.Keys._
 import sbt.plugins.JvmPlugin
 
 object TestQuickUntilPassed extends AutoPlugin {
-  override def requires = JvmPlugin
+  override lazy val requires = JvmPlugin
 
-  override def trigger = allRequirements
+  override lazy val trigger = allRequirements
 
   object autoImport {
-    val testQuickUntilPassed = inputKey[Unit]("runs testQuick continuously until it passes")
+    lazy val testQuickUntilPassed = inputKey[Unit]("runs testQuick continuously until it passes")
   }
 
   import autoImport._

--- a/project/ValidatePullRequest.scala
+++ b/project/ValidatePullRequest.scala
@@ -24,19 +24,19 @@ import sbt._
 object PekkoValidatePullRequest extends AutoPlugin {
 
   object CliOptions {
-    val mimaEnabled = CliOption("pekko.mima.enabled", true)
+    lazy val mimaEnabled = CliOption("pekko.mima.enabled", true)
   }
 
   import ValidatePullRequest.autoImport._
 
-  override def trigger = allRequirements
-  override def requires = ValidatePullRequest
+  override lazy val trigger = allRequirements
+  override lazy val requires = ValidatePullRequest
 
-  val ValidatePR = config("pr-validation").extend(Test)
+  lazy val ValidatePR = config("pr-validation").extend(Test)
 
   override lazy val projectConfigurations = Seq(ValidatePR)
 
-  val additionalTasks = settingKey[Seq[TaskKey[_]]]("Additional tasks for pull request validation")
+  lazy val additionalTasks = settingKey[Seq[TaskKey[_]]]("Additional tasks for pull request validation")
 
   override lazy val globalSettings = Seq(credentials ++= {
       // todo this should probably be supplied properly
@@ -86,8 +86,8 @@ object PekkoValidatePullRequest extends AutoPlugin {
 object MultiNodeWithPrValidation extends AutoPlugin {
   import PekkoValidatePullRequest._
 
-  override def trigger = allRequirements
-  override def requires = PekkoValidatePullRequest && MultiNode
+  override lazy val trigger = allRequirements
+  override lazy val requires = PekkoValidatePullRequest && MultiNode
   override lazy val projectSettings =
     if (MultiNode.multiNodeTestInTest) Seq(additionalTasks += MultiNode.multiTest)
     else Seq.empty
@@ -100,8 +100,8 @@ object MultiNodeWithPrValidation extends AutoPlugin {
 object MimaWithPrValidation extends AutoPlugin {
   import PekkoValidatePullRequest._
 
-  override def trigger = allRequirements
-  override def requires = PekkoValidatePullRequest && MimaPlugin
+  override lazy val trigger = allRequirements
+  override lazy val requires = PekkoValidatePullRequest && MimaPlugin
   override lazy val projectSettings =
     CliOptions.mimaEnabled.ifTrue(additionalTasks += mimaReportBinaryIssues).toList
 }
@@ -113,14 +113,14 @@ object MimaWithPrValidation extends AutoPlugin {
 object ParadoxWithPrValidation extends AutoPlugin {
   import PekkoValidatePullRequest._
 
-  override def trigger = allRequirements
-  override def requires = PekkoValidatePullRequest && ParadoxPlugin
+  override lazy val trigger = allRequirements
+  override lazy val requires = PekkoValidatePullRequest && ParadoxPlugin
   override lazy val projectSettings = Seq(additionalTasks += Compile / paradox)
 }
 
 object UnidocWithPrValidation extends AutoPlugin {
   import PekkoValidatePullRequest._
 
-  override def trigger = noTrigger
+  override lazy val trigger = noTrigger
   override lazy val projectSettings = Seq(additionalTasks += Compile / unidoc)
 }

--- a/project/VersionGenerator.scala
+++ b/project/VersionGenerator.scala
@@ -19,7 +19,7 @@ import sbt.Keys._
  */
 object VersionGenerator {
 
-  val settings: Seq[Setting[_]] = inConfig(Compile)(
+  lazy val settings: Seq[Setting[_]] = inConfig(Compile)(
     Seq(
       resourceGenerators += generateVersion(
         resourceManaged, _ / "version.conf",


### PR DESCRIPTION
This PR updates the sbt build so it uses `lazy val`'s in the areas where its idiomatic/expected to do so with the intention that the code is both easier to understand and in some cases faster (i.e. avoiding unnecessary re-evaluation or not evaluating values if they aren't needed) specifically

* zero arg `def`'s. There is no reason to use a `def`'s here because computed values will not change in consecutive evaluations so the behaviour of `lazy val` caching the value after initial evaluation is what we want here.
* `val`'s: Any `val`'s which use the sbt dsl/syntax have been changed to `lazy val` because sbt dsl/syntax is expensive to compute for the first time so this means that we only actually compute the values if they are needed. `val`'s that only initiate constants (i.e. string constants) that don't use the sbt dsl/syntax have been untouched because evaluating those is likely as fast (if not faster) than the overhead that `lazy val` has
* For `project/Depedencies.scala` there was a lot of cases where `Def.setting` was used where it didn't need to be (as a quick refresher `Def.setting` should only be used when you need to reference an sbt `SettingKey`/`TaskKey` i.e. `scalaVersion.value`). `Def.setting` was needed in these cases previously because we had different dependency versions based on things like scala versions and the like (such as Scala 2 vs Scala 3) however this is no longer the case since in Pekko 1.1.x we have updated to the latest version's of dependencies which have the same version releases between the Scala versions that we support. In summary the `Def.settings` were accidentally left over when we update the dependencies.
  * I have also removed the redundant `// <LICENSE>` comments as this is no longer needed ([sbt-license-report](https://github.com/sbt/sbt-license-report) solves this need automatically which Pekko already uses)