### PR TITLE
chore: Fix typo in fold.md.

### DIFF
--- a/docs/src/main/paradox/stream/operators/Sink/fold.md
+++ b/docs/src/main/paradox/stream/operators/Sink/fold.md
@@ -1,6 +1,6 @@
 # Sink.fold
 
-Fold over emitted element with a function, where each invocation will get the new element and the result from the previous fold invocation.
+Fold over emitted elements with a function, where each invocation will get the new element and the result from the previous fold invocation.
 
 @ref[Sink operators](../index.md#sink-operators)
 
@@ -10,7 +10,7 @@ Fold over emitted element with a function, where each invocation will get the ne
 
 ## Description
 
-Fold over emitted element with a function, where each invocation will get the new element and the result from the
+Fold over emitted elements with a function, where each invocation will get the new element and the result from the
 previous fold invocation. The first invocation will be provided the `zero` value.
 
 Materializes into a @scala[`Future`] @java[`CompletionStage`] that will complete with the last state when the stream has completed.

--- a/docs/src/main/paradox/stream/operators/index.md
+++ b/docs/src/main/paradox/stream/operators/index.md
@@ -60,7 +60,7 @@ These built-in sinks are available from @scala[`org.apache.pekko.stream.scaladsl
 |Sink|<a name="collection"></a>@ref[collection](Sink/collection.md)|@scala[Collect all values emitted from the stream into a collection.]@java[Operator only available in the Scala API. The closest operator in the Java API is @ref[`Sink.seq`](Sink/seq.md)].|
 |Sink|<a name="combine"></a>@ref[combine](Sink/combine.md)|Combine several sinks into one using a user specified strategy|
 |Sink|<a name="completionstagesink"></a>@ref[completionStageSink](Sink/completionStageSink.md)|Streams the elements to the given future sink once it successfully completes. |
-|Sink|<a name="fold"></a>@ref[fold](Sink/fold.md)|Fold over emitted element with a function, where each invocation will get the new element and the result from the previous fold invocation.|
+|Sink|<a name="fold"></a>@ref[fold](Sink/fold.md)|Fold over emitted elements with a function, where each invocation will get the new element and the result from the previous fold invocation.|
 |Sink|<a name="foreach"></a>@ref[foreach](Sink/foreach.md)|Invoke a given procedure for each element received.|
 |Sink|<a name="foreachasync"></a>@ref[foreachAsync](Sink/foreachAsync.md)|Invoke a given procedure asynchronously for each element received.|
 |Sink|<a name="foreachparallel"></a>@ref[foreachParallel](Sink/foreachParallel.md)|Like `foreach` but allows up to `parallellism` procedure calls to happen in parallel.|


### PR DESCRIPTION
Motivation:
In https://github.com/apache/incubator-pekko/pull/1012 @mdedetrich find some typos, and fix the typo in fold.md too.