### PR TITLE
Only use dependabot for alerts

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,7 +18,7 @@ github:
     - "v*.*.*"
 
   dependabot_alerts:  true
-  dependabot_updates: true
+  dependabot_updates: false
 
   features:
     # Enable wiki for documentation


### PR DESCRIPTION
We are using scala steward instead of dependabot to make PR's for dependency updates