### PR TITLE
chore: mention the faster code fmt approach

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,10 +171,16 @@ sbt
 applyCodeStyle
 ```
 
-or you could format code via [Scala-Cli](https://scala-cli.virtuslab.org/), which can be improve the code format speed.
+To format Scala code more faster, you could format code with [Scala-CLI](https://scala-cli.virtuslab.org/) or [Coursier CLI](https://scalameta.org/scalafmt/docs/installation.html#cli):
 
+**With Scala-Cli**
 ```shell
-Scala-cli fmt
+scala-cli fmt
+```
+**With Coursier CLI**
+```Shell
+cs install scalafmt
+scalafmt --version # should be 3.7.17
 ```
 
 #### Do not use `-optimize` Scala compiler flag

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,6 +171,12 @@ sbt
 applyCodeStyle
 ```
 
+or you could format code via [Scala-Cli](https://scala-cli.virtuslab.org/), which can be improve the code format speed.
+
+```shell
+Scala-cli fmt
+```
+
 #### Do not use `-optimize` Scala compiler flag
 
 Pekko has not been compiled or tested with `-optimize` Scala compiler flag. (In sbt, you can specify compiler options in the `scalacOptions` key.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,7 +179,7 @@ scala-cli fmt
 ```
 **With Coursier CLI**
 ```Shell
-cs install scalafmt
+cs install scalafmt // skip it if scalafmt is already installed.
 scalafmt
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,7 +179,7 @@ scala-cli fmt
 ```
 **With Coursier CLI**
 ```Shell
-cs install scalafmt // skip it if scalafmt is already installed.
+cs install scalafmt // skip it if scalafmt is already installed. If you are a macOS or Linux user, you can simply download the native binaries from the Coursier CLI installation page.
 scalafmt
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,7 @@ scala-cli fmt
 **With Coursier CLI**
 ```Shell
 cs install scalafmt
-scalafmt --version # should be 3.7.17
+scalafmt
 ```
 
 #### Do not use `-optimize` Scala compiler flag


### PR DESCRIPTION
## Motivation

Mention an easy way to format pekko code, which allows you to skip the sbt loading, in specific cases may be vert useful.

## Using Scala-Cli

<img width="982" alt="截屏2024-01-23 01 52 46" src="https://github.com/apache/incubator-pekko/assets/26020358/f3872eaf-b492-4c4c-baa1-b8ffc7b41187">

![image](https://github.com/apache/incubator-pekko/assets/26020358/3e9d514e-9a9b-4b85-9f15-fecdbe374e06)

## Using sbt

<img width="984" alt="截屏2024-01-23 01 53 02" src="https://github.com/apache/incubator-pekko/assets/26020358/8c99b6c5-588a-409c-9577-162d34f2383e">
