### PR TITLE
chore: clarify the JMH Readme

### DIFF
--- a/bench-jmh/README.md
+++ b/bench-jmh/README.md
@@ -9,17 +9,17 @@ Pekko uses [sbt-jmh](https://github.com/sbt/sbt-jmh) to integrate [Java Microben
 ```shell
 sbt shell
 pekko > project bench-jmh
-sbt:bench-jmh> Jmh:run -i 3 -wi 3 -f 1 .*ActorCreationBenchmark
+sbt:bench-jmh> Jmh/run -i 3 -wi 3 -f 1 .*ActorCreationBenchmark
 ```
 
 or execute in one-line command
 
 ```shell
-sbt bench-jmh/Jmh:run -i 3 -wi 3 -f 1 .*ActorCreationBenchmark
+sbt bench-jmh/Jmh/run -i 3 -wi 3 -f 1 .*ActorCreationBenchmark
 ```
    
 
-Use 'Jmh:run -h' to get an overview of the available options.
+Use 'Jmh/run -h' to get an overview of the available options.
 
 Some potentially out of date resources for writing JMH benchmarks:
 

--- a/bench-jmh/README.md
+++ b/bench-jmh/README.md
@@ -6,8 +6,18 @@ own jmh module)
 
 You can run them like:
 
-   project bench-jmh
-   jmh:run -i 3 -wi 3 -f 1 .*ActorCreationBenchmark
+```shell
+sbt shell
+sbt:pekko> project bench-jmh
+sbt:pekko-bench-jmh> jmh:run -i 3 -wi 3 -f 1 .*ActorCreationBenchmark
+```
+
+or execute in one line command
+
+```shell
+sbt bench-jmh/jmh:run -i 3 -wi 3 -f 1 .*ActorCreationBenchmark
+```
+   
 
 Use 'jmh:run -h' to get an overview of the available options.
 

--- a/bench-jmh/README.md
+++ b/bench-jmh/README.md
@@ -4,18 +4,18 @@ This subproject contains some microbenchmarks excercising key parts of Apache Pe
 own jmh module)
 
 
-You can run them like:
+Pekko uses [sbt-jmh](https://github.com/sbt/sbt-jmh) to integrate [Java Microbenchmark Harness](https://github.com/openjdk/jmh). You can run them like:
 
 ```shell
 sbt shell
 pekko > project bench-jmh
-sbt:pekko-bench-jmh> jmh:run -i 3 -wi 3 -f 1 .*ActorCreationBenchmark
+sbt:bench-jmh> Jmh:run -i 3 -wi 3 -f 1 .*ActorCreationBenchmark
 ```
 
 or execute in one-line command
 
 ```shell
-sbt bench-jmh/jmh:run -i 3 -wi 3 -f 1 .*ActorCreationBenchmark
+sbt bench-jmh/Jmh:run -i 3 -wi 3 -f 1 .*ActorCreationBenchmark
 ```
    
 

--- a/bench-jmh/README.md
+++ b/bench-jmh/README.md
@@ -8,7 +8,7 @@ You can run them like:
 
 ```shell
 sbt shell
-sbt:pekko> project bench-jmh
+pekko > project bench-jmh
 sbt:pekko-bench-jmh> jmh:run -i 3 -wi 3 -f 1 .*ActorCreationBenchmark
 ```
 

--- a/bench-jmh/README.md
+++ b/bench-jmh/README.md
@@ -19,7 +19,7 @@ sbt bench-jmh/Jmh:run -i 3 -wi 3 -f 1 .*ActorCreationBenchmark
 ```
    
 
-Use 'jmh:run -h' to get an overview of the available options.
+Use 'Jmh:run -h' to get an overview of the available options.
 
 Some potentially out of date resources for writing JMH benchmarks:
 

--- a/bench-jmh/README.md
+++ b/bench-jmh/README.md
@@ -12,7 +12,7 @@ sbt:pekko> project bench-jmh
 sbt:pekko-bench-jmh> jmh:run -i 3 -wi 3 -f 1 .*ActorCreationBenchmark
 ```
 
-or execute in one line command
+or execute in one-line command
 
 ```shell
 sbt bench-jmh/jmh:run -i 3 -wi 3 -f 1 .*ActorCreationBenchmark


### PR DESCRIPTION
The original Readme line break seemed like was broken, it was not friendly for newcomers, I have clarified it both with shell and one-line command execution.