### PR TITLE
chore: Update java-formatter ignore lists

### DIFF
--- a/.sbt-java-formatter.conf
+++ b/.sbt-java-formatter.conf
@@ -10,7 +10,37 @@ ignored-files = [
   "ProtobufProtocol.java"
   //in docs
   "TwoPhaseSetMessages.java"
-  "FlightAppModels.java"
+  "FlightAppModels.java",
+
+  //pekko-actor
+  "OnSpinWait.java",
+  "AbstractBoundedNodeQueue.java",
+  "AbstractMailbox.java",
+  "AbstractMessageDispatcher.java",
+  "AbstractNodeQueue.java",
+  //pekko-cluster
+  "ClusterMessages.java",
+  //pekko-cluster-metrics
+  "ClusterMetricsMessages.java",
+  //pekko-cluster-sharding-typed
+  "ShardingMessages.java",
+  //pekko-cluster-sharding
+  "ClusterShardingMessages.java",
+  //pekko-cluster-tools
+  "ClusterClientMessages.java",
+  "DistributedPubSubMessages.java",
+  //pekko-cluster-typed
+  "ClusterMessages.java",
+  "ReliableDelivery.java",
+  //pekko-distributed-data
+  "ReplicatedDataMessages.java",
+  "ReplicatorMessages.java",
+  //pekko-multi-node-testkit
+  "TestConductorProtocol.java",
+  //pekko-persistence
+  "MessageFormats.java",
+  //pekko-remote-tests
+  "TestMessages.java",
 ]
 
 //ignore by packages:

--- a/actor-tests/src/test/java/org/apache/pekko/dispatch/JavaFutureTests.java
+++ b/actor-tests/src/test/java/org/apache/pekko/dispatch/JavaFutureTests.java
@@ -40,7 +40,7 @@ public class JavaFutureTests extends JUnitSuite {
 
   @ClassRule
   public static PekkoJUnitActorSystemResource actorSystemResource =
-    new PekkoJUnitActorSystemResource("JavaFutureTests", PekkoSpec.testConf());
+      new PekkoJUnitActorSystemResource("JavaFutureTests", PekkoSpec.testConf());
 
   private final ActorSystem system = actorSystemResource.getSystem();
   private final Duration timeout = Duration.create(5, TimeUnit.SECONDS);
@@ -48,17 +48,23 @@ public class JavaFutureTests extends JUnitSuite {
   @Test
   public void mustBeAbleToMapAFuture() throws Exception {
 
-    Future<String> f1 = Futures.future(new Callable<String>() {
-      public String call() {
-        return "Hello";
-      }
-    }, system.dispatcher());
+    Future<String> f1 =
+        Futures.future(
+            new Callable<String>() {
+              public String call() {
+                return "Hello";
+              }
+            },
+            system.dispatcher());
 
-    Future<String> f2 = f1.map(new Mapper<String, String>() {
-      public String apply(String s) {
-        return s + " World";
-      }
-    }, system.dispatcher());
+    Future<String> f2 =
+        f1.map(
+            new Mapper<String, String>() {
+              public String apply(String s) {
+                return s + " World";
+              }
+            },
+            system.dispatcher());
 
     assertEquals("Hello World", Await.result(f2, timeout));
   }
@@ -68,12 +74,13 @@ public class JavaFutureTests extends JUnitSuite {
     final CountDownLatch latch = new CountDownLatch(1);
     Promise<String> cf = Futures.promise();
     Future<String> f = cf.future();
-    f.onComplete(new OnComplete<String>() {
-      public void onComplete(Throwable t, String r) {
-        if ("foo".equals(r))
-          latch.countDown();
-      }
-    }, system.dispatcher());
+    f.onComplete(
+        new OnComplete<String>() {
+          public void onComplete(Throwable t, String r) {
+            if ("foo".equals(r)) latch.countDown();
+          }
+        },
+        system.dispatcher());
 
     cf.success("foo");
     assertTrue(latch.await(5, TimeUnit.SECONDS));
@@ -85,13 +92,14 @@ public class JavaFutureTests extends JUnitSuite {
     final CountDownLatch latch = new CountDownLatch(1);
     Promise<String> cf = Futures.promise();
     Future<String> f = cf.future();
-    f.onComplete(new OnComplete<String>() {
-      public void onComplete(Throwable t, String r) {
-        // 'null instanceof ...' is always false
-        if (t instanceof NullPointerException)
-          latch.countDown();
-      }
-    }, system.dispatcher());
+    f.onComplete(
+        new OnComplete<String>() {
+          public void onComplete(Throwable t, String r) {
+            // 'null instanceof ...' is always false
+            if (t instanceof NullPointerException) latch.countDown();
+          }
+        },
+        system.dispatcher());
 
     Throwable exception = new NullPointerException();
     cf.failure(exception);
@@ -104,11 +112,13 @@ public class JavaFutureTests extends JUnitSuite {
     final CountDownLatch latch = new CountDownLatch(1);
     Promise<String> cf = Futures.promise();
     Future<String> f = cf.future();
-    f.onComplete(new OnComplete<String>() {
-      public void onComplete(Throwable t, String r) {
-        latch.countDown();
-      }
-    }, system.dispatcher());
+    f.onComplete(
+        new OnComplete<String>() {
+          public void onComplete(Throwable t, String r) {
+            latch.countDown();
+          }
+        },
+        system.dispatcher());
 
     cf.success("foo");
     assertTrue(latch.await(5, TimeUnit.SECONDS));
@@ -120,11 +130,13 @@ public class JavaFutureTests extends JUnitSuite {
     final CountDownLatch latch = new CountDownLatch(1);
     Promise<String> cf = Futures.promise();
     Future<String> f = cf.future();
-    f.foreach(new Foreach<String>() {
-      public void each(String future) {
-        latch.countDown();
-      }
-    },system.dispatcher());
+    f.foreach(
+        new Foreach<String>() {
+          public void each(String future) {
+            latch.countDown();
+          }
+        },
+        system.dispatcher());
 
     cf.success("foo");
     assertTrue(latch.await(5, TimeUnit.SECONDS));
@@ -137,15 +149,18 @@ public class JavaFutureTests extends JUnitSuite {
     Promise<String> cf = Futures.promise();
     cf.success("1000");
     Future<String> f = cf.future();
-    Future<Integer> r = f.flatMap(new Mapper<String, Future<Integer>>() {
-      public Future<Integer> checkedApply(String r) throws Throwable {
-        if (false) throw new IOException("Just here to make sure this compiles.");
-        latch.countDown();
-        Promise<Integer> cf = Futures.promise();
-        cf.success(Integer.parseInt(r));
-        return cf.future();
-      }
-    }, system.dispatcher());
+    Future<Integer> r =
+        f.flatMap(
+            new Mapper<String, Future<Integer>>() {
+              public Future<Integer> checkedApply(String r) throws Throwable {
+                if (false) throw new IOException("Just here to make sure this compiles.");
+                latch.countDown();
+                Promise<Integer> cf = Futures.promise();
+                cf.success(Integer.parseInt(r));
+                return cf.future();
+              }
+            },
+            system.dispatcher());
 
     assertEquals("1000", Await.result(f, timeout));
     assertEquals(1000, Await.result(r, timeout).intValue());
@@ -157,12 +172,16 @@ public class JavaFutureTests extends JUnitSuite {
     final CountDownLatch latch = new CountDownLatch(1);
     Promise<String> cf = Futures.promise();
     Future<String> f = cf.future();
-    Future<String> r = f.filter(Filter.filterOf(new Function<String, Boolean>() {
-      public Boolean apply(String r) {
-        latch.countDown();
-        return r.equals("foo");
-      }
-    }), system.dispatcher());
+    Future<String> r =
+        f.filter(
+            Filter.filterOf(
+                new Function<String, Boolean>() {
+                  public Boolean apply(String r) {
+                    latch.countDown();
+                    return r.equals("foo");
+                  }
+                }),
+            system.dispatcher());
 
     cf.success("foo");
     assertTrue(latch.await(5, TimeUnit.SECONDS));
@@ -172,17 +191,20 @@ public class JavaFutureTests extends JUnitSuite {
 
   // TODO: Improve this test, perhaps with an Actor
   @Test
-  public void mustSequenceAFutureList() throws Exception{
+  public void mustSequenceAFutureList() throws Exception {
     LinkedList<Future<String>> listFutures = new LinkedList<>();
     LinkedList<String> listExpected = new LinkedList<>();
 
     for (int i = 0; i < 10; i++) {
       listExpected.add("test");
-      listFutures.add(Futures.future(new Callable<String>() {
-        public String call() {
-          return "test";
-        }
-      }, system.dispatcher()));
+      listFutures.add(
+          Futures.future(
+              new Callable<String>() {
+                public String call() {
+                  return "test";
+                }
+              },
+              system.dispatcher()));
     }
 
     Future<Iterable<String>> futureList = Futures.sequence(listFutures, system.dispatcher());
@@ -192,53 +214,68 @@ public class JavaFutureTests extends JUnitSuite {
 
   // TODO: Improve this test, perhaps with an Actor
   @Test
-  public void foldForJavaApiMustWork() throws Exception{
+  public void foldForJavaApiMustWork() throws Exception {
     LinkedList<Future<String>> listFutures = new LinkedList<>();
     StringBuilder expected = new StringBuilder();
 
     for (int i = 0; i < 10; i++) {
       expected.append("test");
-      listFutures.add(Futures.future(new Callable<String>() {
-        public String call() {
-          return "test";
-        }
-      }, system.dispatcher()));
+      listFutures.add(
+          Futures.future(
+              new Callable<String>() {
+                public String call() {
+                  return "test";
+                }
+              },
+              system.dispatcher()));
     }
 
-    Future<String> result = Futures.fold("", listFutures, new Function2<String, String, String>() {
-      public String apply(String r, String t) {
-        return r + t;
-      }
-    }, system.dispatcher());
+    Future<String> result =
+        Futures.fold(
+            "",
+            listFutures,
+            new Function2<String, String, String>() {
+              public String apply(String r, String t) {
+                return r + t;
+              }
+            },
+            system.dispatcher());
 
     assertEquals(expected.toString(), Await.result(result, timeout));
   }
 
   @Test
-  public void reduceForJavaApiMustWork() throws Exception{
+  public void reduceForJavaApiMustWork() throws Exception {
     LinkedList<Future<String>> listFutures = new LinkedList<>();
     StringBuilder expected = new StringBuilder();
 
     for (int i = 0; i < 10; i++) {
       expected.append("test");
-      listFutures.add(Futures.future(new Callable<String>() {
-        public String call() {
-          return "test";
-        }
-      }, system.dispatcher()));
+      listFutures.add(
+          Futures.future(
+              new Callable<String>() {
+                public String call() {
+                  return "test";
+                }
+              },
+              system.dispatcher()));
     }
 
-    Future<String> result = Futures.reduce(listFutures, new Function2<String, String, String>() {
-      public String apply(String r, String t) {
-        return r + t;
-      }
-    }, system.dispatcher());
+    Future<String> result =
+        Futures.reduce(
+            listFutures,
+            new Function2<String, String, String>() {
+              public String apply(String r, String t) {
+                return r + t;
+              }
+            },
+            system.dispatcher());
 
     assertEquals(expected.toString(), Await.result(result, timeout));
   }
 
   @Test
-  public void traverseForJavaApiMustWork() throws Exception{
+  public void traverseForJavaApiMustWork() throws Exception {
     LinkedList<String> listStrings = new LinkedList<>();
     LinkedList<String> expectedStrings = new LinkedList<>();
 
@@ -247,36 +284,49 @@ public class JavaFutureTests extends JUnitSuite {
       listStrings.add("test");
     }
 
-    Future<Iterable<String>> result = Futures.traverse(listStrings, new Function<String, Future<String>>() {
-      public Future<String> apply(final String r) {
-        return Futures.future(new Callable<String>() {
-          public String call() {
-            return r.toUpperCase();
-          }
-        }, system.dispatcher());
-      }
-    }, system.dispatcher());
+    Future<Iterable<String>> result =
+        Futures.traverse(
+            listStrings,
+            new Function<String, Future<String>>() {
+              public Future<String> apply(final String r) {
+                return Futures.future(
+                    new Callable<String>() {
+                      public String call() {
+                        return r.toUpperCase();
+                      }
+                    },
+                    system.dispatcher());
+              }
+            },
+            system.dispatcher());
 
     assertEquals(expectedStrings, Await.result(result, timeout));
   }
 
   @Test
-  public void findForJavaApiMustWork() throws Exception{
+  public void findForJavaApiMustWork() throws Exception {
     LinkedList<Future<Integer>> listFutures = new LinkedList<>();
     for (int i = 0; i < 10; i++) {
       final Integer fi = i;
-      listFutures.add(Futures.future(new Callable<Integer>() {
-        public Integer call() {
-          return fi;
-        }
-      }, system.dispatcher()));
+      listFutures.add(
+          Futures.future(
+              new Callable<Integer>() {
+                public Integer call() {
+                  return fi;
+                }
+              },
+              system.dispatcher()));
     }
     final Integer expect = 5;
-    Future<Option<Integer>> f = Futures.find(listFutures, new Function<Integer, Boolean>() {
-      public Boolean apply(Integer i) {
-        return i == 5;
-      }
-    }, system.dispatcher());
+    Future<Option<Integer>> f =
+        Futures.find(
+            listFutures,
+            new Function<Integer, Boolean>() {
+              public Boolean apply(Integer i) {
+                return i == 5;
+              }
+            },
+            system.dispatcher());
 
     assertEquals(expect, Await.result(f, timeout).get());
   }
@@ -304,31 +354,35 @@ public class JavaFutureTests extends JUnitSuite {
   public void recoverToMustBeCallable() throws Exception {
     final IllegalStateException fail = new IllegalStateException("OHNOES");
     Promise<Object> p = Futures.promise();
-    Future<Object> f = p.future().recover(new Recover<Object>() {
-      public Object recover(Throwable t) throws Throwable {
-        if (t == fail)
-          return "foo";
-        else
-          throw t;
-      }
-    }, system.dispatcher());
+    Future<Object> f =
+        p.future()
+            .recover(
+                new Recover<Object>() {
+                  public Object recover(Throwable t) throws Throwable {
+                    if (t == fail) return "foo";
+                    else throw t;
+                  }
+                },
+                system.dispatcher());
     Duration d = Duration.create(1, TimeUnit.SECONDS);
     p.failure(fail);
     assertEquals("foo", Await.result(f, d));
   }
 
   @Test
-  public void recoverWithToMustBeCallable() throws Exception{
+  public void recoverWithToMustBeCallable() throws Exception {
     final IllegalStateException fail = new IllegalStateException("OHNOES");
     Promise<Object> p = Futures.promise();
-    Future<Object> f = p.future().recoverWith(new Recover<Future<Object>>() {
-      public Future<Object> recover(Throwable t) throws Throwable {
-        if (t == fail)
-          return Futures.successful("foo");
-        else
-          throw t;
-      }
-    }, system.dispatcher());
+    Future<Object> f =
+        p.future()
+            .recoverWith(
+                new Recover<Future<Object>>() {
+                  public Future<Object> recover(Throwable t) throws Throwable {
+                    if (t == fail) return Futures.successful("foo");
+                    else throw t;
+                  }
+                },
+                system.dispatcher());
     Duration d = Duration.create(1, TimeUnit.SECONDS);
     p.failure(fail);
     assertEquals("foo", Await.result(f, d));


### PR DESCRIPTION
Motivation:
Add these files so they are not been formatted when run `sbt javafmtAll`.

Result:
There files are ignored.