### PR TITLE
Update sbt-pekko-build to 0.3.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,6 @@ ThisBuild / scalafixScalaBinaryVersion := scalaBinaryVersion.value
 
 scalaVersion := Dependencies.allScalaVersions.head
 
-ThisBuild / apacheSonatypeProjectProfile := "pekko"
 ThisBuild / versionScheme := Some(VersionScheme.SemVerSpec)
 sourceDistName := "apache-pekko"
 sourceDistIncubating := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -26,8 +26,7 @@ addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.31")
 
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.11")
-addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.10")
-addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.3.0")
+addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.3.1")
 addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.4.0")
 addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.6.1")
 


### PR DESCRIPTION
Updates sbt-pekko-build to 0.3.1 which brings in the pom.xml `name` field fix