### PR TITLE
chore: Add @since 1.0.0 to flatten operator.

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -2678,6 +2678,8 @@ trait FlowOps[+Out, +Mat] {
    * '''Completes when''' upstream completes and all consumed substreams complete
    *
    * '''Cancels when''' downstream cancels
+   * 
+   * @since 1.1.0
    */
   def flatten[T, M](implicit ev: Out <:< Graph[SourceShape[T], M]): Repr[T] = flatMap(ev)
 


### PR DESCRIPTION
Motivation:
Add `@since 1.1.0` to flatten operator.