### PR TITLE
chore: Run JDK9Test compiling to validate syntax. 

### DIFF
--- a/.github/workflows/generate-doc-check.yml
+++ b/.github/workflows/generate-doc-check.yml
@@ -48,5 +48,5 @@ jobs:
         run: |-
           sudo apt-get install graphviz
 
-      - name: Compile docs&paradox for all Scala versions
-        run: sbt ";Test / compile ;TestJdk9 / compile ;docs/paradox ;+compile:doc"
+      - name: Compile testClass&docs for all Scala versions
+        run: sbt ";TestJdk9 / compile ; +compile:doc"

--- a/.github/workflows/generate-doc-check.yml
+++ b/.github/workflows/generate-doc-check.yml
@@ -48,5 +48,5 @@ jobs:
         run: |-
           sudo apt-get install graphviz
 
-      - name: Compile docs for all Scala versions
-        run: sbt +compile:doc
+      - name: Compile docs&paradox for all Scala versions
+        run: sbt ";Test / compile ;TestJdk9 / compile ;docs/paradox ;+compile:doc"

--- a/docs/src/test/java-jdk9-only/jdocs/stream/operators/source/AsSubscriber.java
+++ b/docs/src/test/java-jdk9-only/jdocs/stream/operators/source/AsSubscriber.java
@@ -20,7 +20,6 @@ import java.util.concurrent.Flow.Publisher;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.javadsl.JavaFlowSupport;
-
 //#imports
 public interface AsSubscriber {
     // We are 'faking' the JavaFlowSupport API here so we can include the signature as a snippet in the API,

--- a/docs/src/test/scala/docs/stream/operators/sink/AsPublisher.scala
+++ b/docs/src/test/scala/docs/stream/operators/sink/AsPublisher.scala
@@ -13,9 +13,10 @@
 
 package docs.stream.operators.sink
 
-import scala.concurrent.{ ExecutionContextExecutor, Future }
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.scaladsl.{ Sink, Source }
+
+import scala.concurrent.ExecutionContextExecutor
 
 object AsPublisher {
   implicit val system: ActorSystem = ???


### PR DESCRIPTION
See #958 - should improve the testing of the doc oriented test code