### PR TITLE
feat: Add AutoCloseable shortcut on mapWithResource

### DIFF
--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/mapWithResource.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/mapWithResource.md
@@ -6,12 +6,12 @@ Map elements with the help of a resource that can be opened, transform each elem
 
 ## Signature
 
-@apidoc[Flow.mapWithResource](Flow) { scala="#mapWithResource%5BS%2C%20T%5D%28create%3A%20%28%29%20%3D%3E%20S%29%28f%3A%20%28S%2C%20Out%29%20%3D%3E%20T%2C%20close%3A%20S%20%3D%3E%20Option%5BT%5D%29%3A%20Repr%5BT%5D" java="#mapWithResource(org.apache.pekko.japi.function.Creator,org.apache.pekko.japi.function.Function2,org.apache.pekko.japi.function.Function)" }
+@apidoc[Flow.mapWithResource](Flow) { scala="#mapWithResource[S,T](create:()=%3ES)(f:(S,Out)=%3ET,close:S=%3EOption[T]):Repr[T]" java="#mapWithResource(org.apache.pekko.japi.function.Creator,org.apache.pekko.japi.function.Function2,org.apache.pekko.japi.function.Function)" }
 1. `create`: Open or Create the resource.
 2. `f`: Transform each element inputs with the help of resource.
 3. `close`: Close the resource, invoked on end of stream or if the stream fails, optionally outputting a last element.
 
-@apidoc[Flow.mapWithResource](Flow) { scala="#mapWithResource%5BS%20%3C%3A%20AutoCloseable%2C%20T%5D%28create%3A%20%28%29%20%3D%3E%20S%2C%20f%3A%20%28S%2C%20Out%29%20%3D%3E%20T%29%3A%20Repr%5BT%5D" java="#mapWithResource(org.apache.pekko.japi.function.Creator,org.apache.pekko.japi.function.Function2)" }
+@apidoc[Flow.mapWithResource](Flow) { scala="#mapWithResource[S%3C:AutoCloseable,T](create:()=%3ES,f:(S,Out)=%3ET):Repr[T]" java="#mapWithResource(org.apache.pekko.japi.function.Creator,org.apache.pekko.japi.function.Function2)" }
 1. `create`: Open or Create the autocloseable resource.
 2. `f`: Transform each element inputs with the help of resource.
 

--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/mapWithResource.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/mapWithResource.md
@@ -11,6 +11,10 @@ Map elements with the help of a resource that can be opened, transform each elem
 2. `f`: Transform each element inputs with the help of resource.
 3. `close`: Close the resource, invoked on end of stream or if the stream fails, optionally outputting a last element.
 
+@apidoc[Flow.mapWithResource](Flow) { scala="#mapWithResource%5BS%20%3C%3A%20AutoCloseable%2C%20T%5D%28create%3A%20%28%29%20%3D%3E%20S%2C%20f%3A%20%28S%2C%20Out%29%20%3D%3E%20T%29%3A%20Repr%5BT%5D" java="#mapWithResource(org.apache.pekko.japi.function.Creator,org.apache.pekko.japi.function.Function2)" }
+1. `create`: Open or Create the autocloseable resource.
+2. `f`: Transform each element inputs with the help of resource.
+
 ## Description
 
 Transform each stream element with the help of a resource.

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/FlowTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/FlowTest.java
@@ -249,7 +249,6 @@ public class FlowTest extends StreamTest {
                     () -> (AutoCloseable) closed::incrementAndGet, (resource, elem) -> elem))
         .runWith(Sink.foreach(elem -> probe.getRef().tell(elem, ActorRef.noSender())), system);
 
-    Assert.assertEquals(closed.get(), 0);
     probe.expectMsgAllOf("1", "2", "3");
     Assert.assertEquals(closed.get(), 1);
   }

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/FlowTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/FlowTest.java
@@ -37,6 +37,7 @@ import org.apache.pekko.testkit.PekkoJUnitActorSystemResource;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -235,6 +236,21 @@ public class FlowTest extends StreamTest {
         .expectNext("1", "2", "3", "end")
         .expectComplete();
     Assert.assertFalse(gate.get());
+  }
+
+  @Test
+  public void mustBeAbleToUseMapWithAutoCloseableResource() {
+    final AtomicInteger closed = new AtomicInteger();
+    Source.from(Arrays.asList("1", "2", "3"))
+        .via(
+            Flow.of(String.class)
+                .mapWithResource(
+                    () -> (AutoCloseable) closed::incrementAndGet, (resource, elem) -> elem))
+        .runWith(TestSink.create(system), system)
+        .request(4)
+        .expectNext("1", "2", "3")
+        .expectComplete();
+    Assert.assertEquals(closed.get(), 3);
   }
 
   @Test

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/FlowTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/FlowTest.java
@@ -240,17 +240,18 @@ public class FlowTest extends StreamTest {
 
   @Test
   public void mustBeAbleToUseMapWithAutoCloseableResource() {
+    final TestKit probe = new TestKit(system);
     final AtomicInteger closed = new AtomicInteger();
     Source.from(Arrays.asList("1", "2", "3"))
         .via(
             Flow.of(String.class)
                 .mapWithResource(
                     () -> (AutoCloseable) closed::incrementAndGet, (resource, elem) -> elem))
-        .runWith(TestSink.create(system), system)
-        .request(4)
-        .expectNext("1", "2", "3")
-        .expectComplete();
-    Assert.assertEquals(closed.get(), 3);
+        .runWith(Sink.foreach(elem -> probe.getRef().tell(elem, ActorRef.noSender())), system);
+
+    Assert.assertEquals(closed.get(), 0);
+    probe.expectMsgAllOf("1", "2", "3");
+    Assert.assertEquals(closed.get(), 1);
   }
 
   @Test

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
@@ -824,7 +824,6 @@ public class SourceTest extends StreamTest {
         .mapWithResource(() -> (AutoCloseable) closed::incrementAndGet, (resource, elem) -> elem)
         .runWith(Sink.foreach(elem -> probe.getRef().tell(elem, ActorRef.noSender())), system);
 
-    Assert.assertEquals(closed.get(), 0);
     probe.expectMsgAllOf("1", "2", "3");
     Assert.assertEquals(closed.get(), 1);
   }

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -829,7 +829,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
         resource => close.apply(resource).toScala))
 
   /**
-   * Transform each stream element with the help of a [[AutoCloseable]] resource and close it when the stream finishes or fails.
+   * Transform each stream element with the help of an [[AutoCloseable]] resource and close it when the stream finishes or fails.
    *
    * The resource creation function is invoked once when the stream is materialized and the returned resource is passed to
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -829,7 +829,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
         resource => close.apply(resource).toScala))
 
   /**
-   * Transform each stream element with the help of a [[AutoCloseable]] resource and close it.
+   * Transform each stream element with the help of a [[AutoCloseable]] resource and close it when the stream finishes or fails.
    *
    * The resource creation function is invoked once when the stream is materialized and the returned resource is passed to
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -841,7 +841,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
    *
-   * You can configure the default dispatcher for this Source by changing the `akka.stream.materializer.blocking-io-dispatcher` or
+   * You can configure the default dispatcher for this Source by changing the `pekko.stream.materializer.blocking-io-dispatcher` or
    * set it for a given Source by using [[ActorAttributes]].
    *
    * '''Emits when''' the mapping function returns an element and downstream is ready to consume it

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -2542,7 +2542,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
         resource => close.apply(resource).toScala))
 
   /**
-   * Transform each stream element with the help of a [[AutoCloseable]] resource and close it.
+   * Transform each stream element with the help of a [[AutoCloseable]] resource and close it when the stream finishes or fails.
    *
    * The resource creation function is invoked once when the stream is materialized and the returned resource is passed to
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -2542,7 +2542,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
         resource => close.apply(resource).toScala))
 
   /**
-   * Transform each stream element with the help of a [[AutoCloseable]] resource and close it when the stream finishes or fails.
+   * Transform each stream element with the help of an [[AutoCloseable]] resource and close it when the stream finishes or fails.
    *
    * The resource creation function is invoked once when the stream is materialized and the returned resource is passed to
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -2554,7 +2554,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
    *
-   * You can configure the default dispatcher for this Source by changing the `akka.stream.materializer.blocking-io-dispatcher` or
+   * You can configure the default dispatcher for this Source by changing the `pekko.stream.materializer.blocking-io-dispatcher` or
    * set it for a given Source by using [[ActorAttributes]].
    *
    * '''Emits when''' the mapping function returns an element and downstream is ready to consume it

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -2542,6 +2542,45 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
         resource => close.apply(resource).toScala))
 
   /**
+   * Transform each stream element with the help of a [[AutoCloseable]] resource and close it.
+   *
+   * The resource creation function is invoked once when the stream is materialized and the returned resource is passed to
+   * the mapping function for mapping the first element. The mapping function returns a mapped element to emit
+   * downstream. The returned `T` MUST NOT be `null` as it is illegal as stream element - according to the Reactive Streams specification.
+   *
+   * The [[AutoCloseable]] resource is closed only once when the upstream or downstream finishes or fails.
+   *
+   * Early completion can be done with combination of the [[takeWhile]] operator.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   *
+   * You can configure the default dispatcher for this Source by changing the `akka.stream.materializer.blocking-io-dispatcher` or
+   * set it for a given Source by using [[ActorAttributes]].
+   *
+   * '''Emits when''' the mapping function returns an element and downstream is ready to consume it
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @tparam R the type of the resource
+   * @tparam T the type of the output elements
+   * @param create function that creates the resource
+   * @param f function that transforms the upstream element and the resource to output element
+   * @since 1.1.0
+   */
+  def mapWithResource[R <: AutoCloseable, T](
+      create: function.Creator[R],
+      f: function.Function2[R, Out, T]): javadsl.Source[T, Mat] =
+    mapWithResource(create, f,
+      (resource: AutoCloseable) => {
+        resource.close()
+        Optional.empty()
+      })
+
+  /**
    * Transform each input element into an `Iterable` of output elements that is
    * then flattened into the output stream. The transformation is meant to be stateful,
    * which is enabled by creating the transformation function anew for every materialization —

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -286,7 +286,7 @@ class SubFlow[In, Out, Mat](
         resource => close.apply(resource).toScala))
 
   /**
-   * Transform each stream element with the help of a [[AutoCloseable]] resource and close it.
+   * Transform each stream element with the help of a [[AutoCloseable]] resource and close it when the stream finishes or fails.
    *
    * The resource creation function is invoked once when the stream is materialized and the returned resource is passed to
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -286,7 +286,7 @@ class SubFlow[In, Out, Mat](
         resource => close.apply(resource).toScala))
 
   /**
-   * Transform each stream element with the help of a [[AutoCloseable]] resource and close it when the stream finishes or fails.
+   * Transform each stream element with the help of an [[AutoCloseable]] resource and close it when the stream finishes or fails.
    *
    * The resource creation function is invoked once when the stream is materialized and the returned resource is passed to
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -298,7 +298,7 @@ class SubFlow[In, Out, Mat](
    *
    * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
    *
-   * You can configure the default dispatcher for this Source by changing the `akka.stream.materializer.blocking-io-dispatcher` or
+   * You can configure the default dispatcher for this Source by changing the `pekko.stream.materializer.blocking-io-dispatcher` or
    * set it for a given Source by using [[ActorAttributes]].
    *
    * '''Emits when''' the mapping function returns an element and downstream is ready to consume it

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -286,6 +286,45 @@ class SubFlow[In, Out, Mat](
         resource => close.apply(resource).toScala))
 
   /**
+   * Transform each stream element with the help of a [[AutoCloseable]] resource and close it.
+   *
+   * The resource creation function is invoked once when the stream is materialized and the returned resource is passed to
+   * the mapping function for mapping the first element. The mapping function returns a mapped element to emit
+   * downstream. The returned `T` MUST NOT be `null` as it is illegal as stream element - according to the Reactive Streams specification.
+   *
+   * The [[AutoCloseable]] resource is closed only once when the upstream or downstream finishes or fails.
+   *
+   * Early completion can be done with combination of the [[takeWhile]] operator.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   *
+   * You can configure the default dispatcher for this Source by changing the `akka.stream.materializer.blocking-io-dispatcher` or
+   * set it for a given Source by using [[ActorAttributes]].
+   *
+   * '''Emits when''' the mapping function returns an element and downstream is ready to consume it
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @tparam R the type of the resource
+   * @tparam T the type of the output elements
+   * @param create function that creates the resource
+   * @param f function that transforms the upstream element and the resource to output element
+   * @since 1.1.0
+   */
+  def mapWithResource[R <: AutoCloseable, T](
+      create: function.Creator[R],
+      f: function.Function2[R, Out, T]): javadsl.SubFlow[In, T, Mat] =
+    mapWithResource(create, f,
+      (resource: AutoCloseable) => {
+        resource.close()
+        Optional.empty()
+      })
+
+  /**
    * Transform each input element into an `Iterable` of output elements that is
    * then flattened into the output stream. The transformation is meant to be stateful,
    * which is enabled by creating the transformation function anew for every materialization —

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -289,7 +289,7 @@ class SubSource[Out, Mat](
    *
    * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
    *
-   * You can configure the default dispatcher for this Source by changing the `akka.stream.materializer.blocking-io-dispatcher` or
+   * You can configure the default dispatcher for this Source by changing the `pekko.stream.materializer.blocking-io-dispatcher` or
    * set it for a given Source by using [[ActorAttributes]].
    *
    * '''Emits when''' the mapping function returns an element and downstream is ready to consume it

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -277,7 +277,7 @@ class SubSource[Out, Mat](
         resource => close.apply(resource).toScala))
 
   /**
-   * Transform each stream element with the help of a [[AutoCloseable]] resource and close it when the stream finishes or fails.
+   * Transform each stream element with the help of an [[AutoCloseable]] resource and close it when the stream finishes or fails.
    *
    * The resource creation function is invoked once when the stream is materialized and the returned resource is passed to
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -277,7 +277,7 @@ class SubSource[Out, Mat](
         resource => close.apply(resource).toScala))
 
   /**
-   * Transform each stream element with the help of a [[AutoCloseable]] resource and close it.
+   * Transform each stream element with the help of a [[AutoCloseable]] resource and close it when the stream finishes or fails.
    *
    * The resource creation function is invoked once when the stream is materialized and the returned resource is passed to
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -277,6 +277,45 @@ class SubSource[Out, Mat](
         resource => close.apply(resource).toScala))
 
   /**
+   * Transform each stream element with the help of a [[AutoCloseable]] resource and close it.
+   *
+   * The resource creation function is invoked once when the stream is materialized and the returned resource is passed to
+   * the mapping function for mapping the first element. The mapping function returns a mapped element to emit
+   * downstream. The returned `T` MUST NOT be `null` as it is illegal as stream element - according to the Reactive Streams specification.
+   *
+   * The [[AutoCloseable]] resource is closed only once when the upstream or downstream finishes or fails.
+   *
+   * Early completion can be done with combination of the [[takeWhile]] operator.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   *
+   * You can configure the default dispatcher for this Source by changing the `akka.stream.materializer.blocking-io-dispatcher` or
+   * set it for a given Source by using [[ActorAttributes]].
+   *
+   * '''Emits when''' the mapping function returns an element and downstream is ready to consume it
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @tparam R the type of the resource
+   * @tparam T the type of the output elements
+   * @param create function that creates the resource
+   * @param f function that transforms the upstream element and the resource to output element
+   * @since 1.1.0
+   */
+  def mapWithResource[R <: AutoCloseable, T](
+      create: function.Creator[R],
+      f: function.Function2[R, Out, T]): javadsl.SubSource[T, Mat] =
+    mapWithResource(create, f,
+      (resource: AutoCloseable) => {
+        resource.close()
+        Optional.empty()
+      })
+
+  /**
    * Transform each input element into an `Iterable` of output elements that is
    * then flattened into the output stream. The transformation is meant to be stateful,
    * which is enabled by creating the transformation function anew for every materialization —

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -1143,6 +1143,43 @@ trait FlowOps[+Out, +Mat] {
         .withAttributes(DefaultAttributes.mapWithResource))
 
   /**
+   * Transform each stream element with the help of a [[AutoCloseable]] resource and close it.
+   *
+   * The resource creation function is invoked once when the stream is materialized and the returned resource is passed to
+   * the mapping function for mapping the first element. The mapping function returns a mapped element to emit
+   * downstream. The returned `T` MUST NOT be `null` as it is illegal as stream element - according to the Reactive Streams specification.
+   *
+   * The [[AutoCloseable]] resource is closed only once when the upstream or downstream finishes or fails.
+   *
+   * Early completion can be done with combination of the [[takeWhile]] operator.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   *
+   * You can configure the default dispatcher for this Source by changing the `akka.stream.materializer.blocking-io-dispatcher` or
+   * set it for a given Source by using [[ActorAttributes]].
+   *
+   * '''Emits when''' the mapping function returns an element and downstream is ready to consume it
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @tparam R the type of the resource
+   * @tparam T the type of the output elements
+   * @param create function that creates the resource
+   * @param f function that transforms the upstream element and the resource to output element
+   * @since 1.1.0
+   */
+  def mapWithResource[R <: AutoCloseable, T](create: () => R, f: (R, Out) => T): Repr[T] =
+    mapWithResource(create)(f,
+      (resource: AutoCloseable) => {
+        resource.close()
+        None
+      })
+
+  /**
    * Transform each input element into an `Iterable` of output elements that is
    * then flattened into the output stream. The transformation is meant to be stateful,
    * which is enabled by creating the transformation function anew for every materialization —

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -1155,7 +1155,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
    *
-   * You can configure the default dispatcher for this Source by changing the `akka.stream.materializer.blocking-io-dispatcher` or
+   * You can configure the default dispatcher for this Source by changing the `pekko.stream.materializer.blocking-io-dispatcher` or
    * set it for a given Source by using [[ActorAttributes]].
    *
    * '''Emits when''' the mapping function returns an element and downstream is ready to consume it

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -1143,7 +1143,7 @@ trait FlowOps[+Out, +Mat] {
         .withAttributes(DefaultAttributes.mapWithResource))
 
   /**
-   * Transform each stream element with the help of a [[AutoCloseable]] resource and close it.
+   * Transform each stream element with the help of a [[AutoCloseable]] resource and close it when the stream finishes or fails.
    *
    * The resource creation function is invoked once when the stream is materialized and the returned resource is passed to
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -1143,7 +1143,7 @@ trait FlowOps[+Out, +Mat] {
         .withAttributes(DefaultAttributes.mapWithResource))
 
   /**
-   * Transform each stream element with the help of a [[AutoCloseable]] resource and close it when the stream finishes or fails.
+   * Transform each stream element with the help of an [[AutoCloseable]] resource and close it when the stream finishes or fails.
    *
    * The resource creation function is invoked once when the stream is materialized and the returned resource is passed to
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit


### PR DESCRIPTION
### Motivation
- Pekko has `mapwithResource` now, would be better to support `AutoCloseable` in Java/Scala dsl too.

### Modification
- Add `AutoCloseable` shortcut on `mapWithResource`

### Result
- Now `mapWithResource` will close the `AutoCloseable` so user don't need to pass close function
- Closes https://github.com/apache/incubator-pekko/issues/1044