### PR TITLE
chore: remove the inline modifier from pekko util.

### DIFF
--- a/actor/src/main/scala-3/org/apache/pekko/util/FutureConverters.scala
+++ b/actor/src/main/scala-3/org/apache/pekko/util/FutureConverters.scala
@@ -28,7 +28,7 @@ private[pekko] object FutureConverters {
   def asJava[T](f: Future[T]): CompletionStage[T] = javaapi.FutureConverters.asJava(f)
 
   implicit final class FutureOps[T](private val f: Future[T]) extends AnyVal {
-    inline def asJava: CompletionStage[T] = javaapi.FutureConverters.asJava(f)
+    def asJava: CompletionStage[T] = javaapi.FutureConverters.asJava(f)
   }
 
   // Ideally this should have the Scala 3 inline keyword but then Java sources are
@@ -36,6 +36,6 @@ private[pekko] object FutureConverters {
   def asScala[T](cs: CompletionStage[T]): Future[T] = javaapi.FutureConverters.asScala(cs)
 
   implicit final class CompletionStageOps[T](private val cs: CompletionStage[T]) extends AnyVal {
-    inline def asScala: Future[T] = javaapi.FutureConverters.asScala(cs)
+    def asScala: Future[T] = javaapi.FutureConverters.asScala(cs)
   }
 }

--- a/actor/src/main/scala-3/org/apache/pekko/util/JavaDurationConverters.scala
+++ b/actor/src/main/scala-3/org/apache/pekko/util/JavaDurationConverters.scala
@@ -29,10 +29,10 @@ private[pekko] object JavaDurationConverters {
   def asFiniteDuration(duration: JDuration): FiniteDuration = duration.asScala
 
   final implicit class JavaDurationOps(val self: JDuration) extends AnyVal {
-    inline def asScala: FiniteDuration = Duration.fromNanos(self.toNanos)
+    def asScala: FiniteDuration = Duration.fromNanos(self.toNanos)
   }
 
   final implicit class ScalaDurationOps(val self: Duration) extends AnyVal {
-    inline def asJava: JDuration = JDuration.ofNanos(self.toNanos)
+    def asJava: JDuration = JDuration.ofNanos(self.toNanos)
   }
 }

--- a/actor/src/main/scala-3/org/apache/pekko/util/OptionConverters.scala
+++ b/actor/src/main/scala-3/org/apache/pekko/util/OptionConverters.scala
@@ -35,45 +35,45 @@ private[pekko] object OptionConverters {
   final def toJava[A](o: Option[A]): Optional[A] = scala.jdk.javaapi.OptionConverters.toJava(o)
 
   implicit final class RichOptional[A](private val o: java.util.Optional[A]) extends AnyVal {
-    inline def toScala: Option[A] = scala.jdk.OptionConverters.RichOptional(o).toScala
+    def toScala: Option[A] = scala.jdk.OptionConverters.RichOptional(o).toScala
 
-    inline def toJavaPrimitive[O](implicit shape: OptionShape[A, O]): O =
+    def toJavaPrimitive[O](implicit shape: OptionShape[A, O]): O =
       scala.jdk.OptionConverters.RichOptional(o).toJavaPrimitive
   }
 
   implicit final class RichOption[A](private val o: Option[A]) extends AnyVal {
-    inline def toJava: Optional[A] = scala.jdk.OptionConverters.RichOption(o).toJava
+    def toJava: Optional[A] = scala.jdk.OptionConverters.RichOption(o).toJava
 
-    inline def toJavaPrimitive[O](implicit shape: OptionShape[A, O]): O =
+    def toJavaPrimitive[O](implicit shape: OptionShape[A, O]): O =
       scala.jdk.OptionConverters.RichOption(o).toJavaPrimitive
   }
 
   implicit class RichOptionalDouble(private val o: OptionalDouble) extends AnyVal {
 
     /** Convert a Java `OptionalDouble` to a Scala `Option` */
-    inline def toScala: Option[Double] = scala.jdk.OptionConverters.RichOptionalDouble(o).toScala
+    def toScala: Option[Double] = scala.jdk.OptionConverters.RichOptionalDouble(o).toScala
 
     /** Convert a Java `OptionalDouble` to a generic Java `Optional` */
-    inline def toJavaGeneric: Optional[Double] = scala.jdk.OptionConverters.RichOptionalDouble(o).toJavaGeneric
+    def toJavaGeneric: Optional[Double] = scala.jdk.OptionConverters.RichOptionalDouble(o).toJavaGeneric
   }
 
   /** Provides conversions from `OptionalInt` to Scala `Option` and the generic `Optional` */
   implicit class RichOptionalInt(private val o: OptionalInt) extends AnyVal {
 
     /** Convert a Java `OptionalInt` to a Scala `Option` */
-    inline def toScala: Option[Int] = scala.jdk.OptionConverters.RichOptionalInt(o).toScala
+    def toScala: Option[Int] = scala.jdk.OptionConverters.RichOptionalInt(o).toScala
 
     /** Convert a Java `OptionalInt` to a generic Java `Optional` */
-    inline def toJavaGeneric: Optional[Int] = scala.jdk.OptionConverters.RichOptionalInt(o).toJavaGeneric
+    def toJavaGeneric: Optional[Int] = scala.jdk.OptionConverters.RichOptionalInt(o).toJavaGeneric
   }
 
   /** Provides conversions from `OptionalLong` to Scala `Option` and the generic `Optional` */
   implicit class RichOptionalLong(private val o: OptionalLong) extends AnyVal {
 
     /** Convert a Java `OptionalLong` to a Scala `Option` */
-    inline def toScala: Option[Long] = scala.jdk.OptionConverters.RichOptionalLong(o).toScala
+    def toScala: Option[Long] = scala.jdk.OptionConverters.RichOptionalLong(o).toScala
 
     /** Convert a Java `OptionalLong` to a generic Java `Optional` */
-    inline def toJavaGeneric: Optional[Long] = scala.jdk.OptionConverters.RichOptionalLong(o).toJavaGeneric
+    def toJavaGeneric: Optional[Long] = scala.jdk.OptionConverters.RichOptionalLong(o).toJavaGeneric
   }
 }


### PR DESCRIPTION
Motivation: 

These method is used in other pekko projects, and can not be used in Java.
Remove the `inline def` in scala 3

Or we have to find another way 
refs: https://github.com/apache/incubator-pekko-connectors/pull/412
refs: https://github.com/apache/incubator-pekko-connectors/actions/runs/7686045276/job/20944445485?pr=412#step:5:506

Or we just update the Java code. @mdedetrich Ping with a scala forwarder in these projects.
refs: https://github.com/lampepfl/dotty/issues/19346

Or we need release another 1.0.x version of pekko-http which compiles with the `inline def` version of pekko `1.0.x`, otherwise will encounter this issue in pekko-http anyway.

Asked on: https://contributors.scala-lang.org/t/can-we-still-generate-bytecode-when-inline-def-method-been-called-from-java/6500

This will cause the `pekko-http` 1.0.x can not been used with `pekko` 1.1.x on Scala 3.