### PR TITLE
Add targetName overloaded methods for Scala 3 inline methods

### DIFF
--- a/actor/src/main/scala-3/org/apache/pekko/compat/PartialFunction.scala
+++ b/actor/src/main/scala-3/org/apache/pekko/compat/PartialFunction.scala
@@ -15,6 +15,8 @@ package org.apache.pekko.compat
 
 import org.apache.pekko.annotation.InternalApi
 
+import scala.annotation.targetName
+
 /**
  * INTERNAL API
  *
@@ -22,10 +24,15 @@ import org.apache.pekko.annotation.InternalApi
  * against Scala 2.12, 2.13, 3.0
  *
  * Remove these classes as soon as support for Scala 2.12 is dropped!
+ * Remove the @targetName bytecode forwarded methods for Pekko 2.0.x since we only care about source compatibility
  */
 @InternalApi private[pekko] object PartialFunction {
 
   inline def fromFunction[A, B](f: A => B): scala.PartialFunction[A, B] =
+    scala.PartialFunction.fromFunction(f)
+
+  @targetName("fromFunction")
+  def _pekko10FromFunction[A, B](f: A => B): scala.PartialFunction[A, B] =
     scala.PartialFunction.fromFunction(f)
 
 }

--- a/actor/src/main/scala-3/org/apache/pekko/dispatch/internal/SameThreadExecutionContext.scala
+++ b/actor/src/main/scala-3/org/apache/pekko/dispatch/internal/SameThreadExecutionContext.scala
@@ -18,12 +18,18 @@ import scala.concurrent.ExecutionContext
 import org.apache.pekko
 import pekko.annotation.InternalApi
 
+import scala.annotation.targetName
+
 /**
  * Factory to create same thread ec. Not intended to be called from any other site than to create [[pekko.dispatch.ExecutionContexts#parasitic]]
+ * Remove the @targetName bytecode forwarded methods for Pekko 2.0.x since we only care about source compatibility
  *
  * INTERNAL API
  */
 @InternalApi
 private[dispatch] object SameThreadExecutionContext {
   inline def apply(): ExecutionContext = ExecutionContext.parasitic
+
+  @targetName("apply")
+  def _pekko1Apply(): ExecutionContext = ExecutionContext.parasitic
 }

--- a/actor/src/main/scala-3/org/apache/pekko/util/FutureConverters.scala
+++ b/actor/src/main/scala-3/org/apache/pekko/util/FutureConverters.scala
@@ -13,11 +13,13 @@ import org.apache.pekko.annotation.InternalStableApi
 
 import java.util.concurrent.CompletionStage
 import scala.concurrent.Future
+import scala.annotation.targetName
 
 /**
  * INTERNAL API
  *
  * Remove this once Scala 2.12 support is dropped since all methods are in Scala 2.13+ stdlib
+ * Remove the @targetName bytecode forwarded methods for Pekko 2.0.x since we only care about source compatibility
  */
 @InternalStableApi
 private[pekko] object FutureConverters {
@@ -29,6 +31,9 @@ private[pekko] object FutureConverters {
 
   implicit final class FutureOps[T](private val f: Future[T]) extends AnyVal {
     inline def asJava: CompletionStage[T] = javaapi.FutureConverters.asJava(f)
+
+    @targetName("asJava")
+    def _pekko1AsJava: CompletionStage[T] = javaapi.FutureConverters.asJava(f)
   }
 
   // Ideally this should have the Scala 3 inline keyword but then Java sources are
@@ -37,5 +42,8 @@ private[pekko] object FutureConverters {
 
   implicit final class CompletionStageOps[T](private val cs: CompletionStage[T]) extends AnyVal {
     inline def asScala: Future[T] = javaapi.FutureConverters.asScala(cs)
+
+    @targetName("asScala")
+    def _pekko1AsScala: Future[T] = javaapi.FutureConverters.asScala(cs)
   }
 }

--- a/actor/src/main/scala-3/org/apache/pekko/util/JavaDurationConverters.scala
+++ b/actor/src/main/scala-3/org/apache/pekko/util/JavaDurationConverters.scala
@@ -12,14 +12,17 @@
  */
 
 package org.apache.pekko.util
+
 import java.time.{ Duration => JDuration }
 
+import scala.annotation.targetName
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 
 import org.apache.pekko.annotation.InternalStableApi
 
 /**
  * INTERNAL API
+ * Remove the @targetName bytecode forwarded methods for Pekko 2.0.x since we only care about source compatibility
  */
 @InternalStableApi
 private[pekko] object JavaDurationConverters {
@@ -30,9 +33,15 @@ private[pekko] object JavaDurationConverters {
 
   final implicit class JavaDurationOps(val self: JDuration) extends AnyVal {
     inline def asScala: FiniteDuration = Duration.fromNanos(self.toNanos)
+
+    @targetName("asScala")
+    def _pekko1AsScala: FiniteDuration = Duration.fromNanos(self.toNanos)
   }
 
   final implicit class ScalaDurationOps(val self: Duration) extends AnyVal {
     inline def asJava: JDuration = JDuration.ofNanos(self.toNanos)
+
+    @targetName("asJava")
+    def _pekko1AsJava: JDuration = JDuration.ofNanos(self.toNanos)
   }
 }

--- a/actor/src/main/scala-3/org/apache/pekko/util/OptionConverters.scala
+++ b/actor/src/main/scala-3/org/apache/pekko/util/OptionConverters.scala
@@ -12,12 +12,14 @@ package org.apache.pekko.util
 import org.apache.pekko.annotation.InternalStableApi
 
 import java.util._
+import scala.annotation.targetName
 import scala.jdk.OptionShape
 
 /**
  * INTERNAL API
  *
- * Remove this once Scala 2.12 support is dropped since all methods are in Scala 2.13+ stdlib
+ * Remove this once Scala 2.12 support is dropped since all methods are in Scala 2.13+ stdlib.
+ * Remove the @targetName bytecode forwarded methods for Pekko 2.0.x since we only care about source compatibility
  */
 @InternalStableApi
 private[pekko] object OptionConverters {
@@ -37,14 +39,28 @@ private[pekko] object OptionConverters {
   implicit final class RichOptional[A](private val o: java.util.Optional[A]) extends AnyVal {
     inline def toScala: Option[A] = scala.jdk.OptionConverters.RichOptional(o).toScala
 
+    @targetName("toScala")
+    def _pekko1ToScala: Option[A] = scala.jdk.OptionConverters.RichOptional(o).toScala
+
     inline def toJavaPrimitive[O](implicit shape: OptionShape[A, O]): O =
+      scala.jdk.OptionConverters.RichOptional(o).toJavaPrimitive
+
+    @targetName("toJavaPrimitive")
+    def _pekko1ToJavaPrimitive[O](implicit shape: OptionShape[A, O]): O =
       scala.jdk.OptionConverters.RichOptional(o).toJavaPrimitive
   }
 
   implicit final class RichOption[A](private val o: Option[A]) extends AnyVal {
     inline def toJava: Optional[A] = scala.jdk.OptionConverters.RichOption(o).toJava
 
+    @targetName("toJava")
+    def _pekko1ToJava: Optional[A] = scala.jdk.OptionConverters.RichOption(o).toJava
+
     inline def toJavaPrimitive[O](implicit shape: OptionShape[A, O]): O =
+      scala.jdk.OptionConverters.RichOption(o).toJavaPrimitive
+
+    @targetName("toJavaPrimitive")
+    def _pekko1ToJavaPrimitive[O](implicit shape: OptionShape[A, O]): O =
       scala.jdk.OptionConverters.RichOption(o).toJavaPrimitive
   }
 
@@ -53,8 +69,14 @@ private[pekko] object OptionConverters {
     /** Convert a Java `OptionalDouble` to a Scala `Option` */
     inline def toScala: Option[Double] = scala.jdk.OptionConverters.RichOptionalDouble(o).toScala
 
+    @targetName("toScala")
+    def _pekko1ToScala: Option[Double] = scala.jdk.OptionConverters.RichOptionalDouble(o).toScala
+
     /** Convert a Java `OptionalDouble` to a generic Java `Optional` */
     inline def toJavaGeneric: Optional[Double] = scala.jdk.OptionConverters.RichOptionalDouble(o).toJavaGeneric
+
+    @targetName("toJavaGeneric")
+    def _pekko1ToJavaGeneric: Optional[Double] = scala.jdk.OptionConverters.RichOptionalDouble(o).toJavaGeneric
   }
 
   /** Provides conversions from `OptionalInt` to Scala `Option` and the generic `Optional` */
@@ -63,8 +85,14 @@ private[pekko] object OptionConverters {
     /** Convert a Java `OptionalInt` to a Scala `Option` */
     inline def toScala: Option[Int] = scala.jdk.OptionConverters.RichOptionalInt(o).toScala
 
+    @targetName("toScala")
+    def _pekko1ToScala: Option[Int] = scala.jdk.OptionConverters.RichOptionalInt(o).toScala
+
     /** Convert a Java `OptionalInt` to a generic Java `Optional` */
     inline def toJavaGeneric: Optional[Int] = scala.jdk.OptionConverters.RichOptionalInt(o).toJavaGeneric
+
+    @targetName("toJavaGeneric")
+    def _pekko1ToJavaGeneric: Optional[Int] = scala.jdk.OptionConverters.RichOptionalInt(o).toJavaGeneric
   }
 
   /** Provides conversions from `OptionalLong` to Scala `Option` and the generic `Optional` */
@@ -73,7 +101,13 @@ private[pekko] object OptionConverters {
     /** Convert a Java `OptionalLong` to a Scala `Option` */
     inline def toScala: Option[Long] = scala.jdk.OptionConverters.RichOptionalLong(o).toScala
 
+    @targetName("toScala")
+    def _pekko1ToScala: Option[Long] = scala.jdk.OptionConverters.RichOptionalLong(o).toScala
+
     /** Convert a Java `OptionalLong` to a generic Java `Optional` */
     inline def toJavaGeneric: Optional[Long] = scala.jdk.OptionConverters.RichOptionalLong(o).toJavaGeneric
+
+    @targetName("toJavaGeneric")
+    def _pekko1ToJavaGeneric: Optional[Long] = scala.jdk.OptionConverters.RichOptionalLong(o).toJavaGeneric
   }
 }


### PR DESCRIPTION
We are currently having the issue where the Scala 3 `inline` keyword actually strips any mention of the method inside the generated JVM bytecode which is causing issues . Thankfully Scala 3 also introduced [targetName annotation](https://docs.scala-lang.org/scala3/reference/other-new-features/targetName.html) which lets you set the target designated symbol name in the bytecode of any method, i.e. directly quoting

> A [`@targetName`](https://scala-lang.org/api/3.x/scala/annotation/targetName.html) annotation on a definition defines an alternate name for the implementation of that definition. Example:

```scala
import scala.annotation.targetName

object VecOps:
  extension [T](xs: Vec[T])
    @targetName("append")
    def ++= [T] (ys: Vec[T]): Vec[T] = ...
```

>Here, the `++=` operation is implemented (in Byte code or native code) under the name `append`. The implementation name affects the code that is generated, and is the name under which code from other languages can call the method. For instance, `++=` could be invoked from Java like this:

```java
VecOps.append(vec1, vec2)
```

>The [`@targetName`](https://scala-lang.org/api/3.x/scala/annotation/targetName.html) annotation has no bearing on Scala usages. Any application of that method in Scala has to use `++=`, not `append`.

The last part is what is critical, `@targetName` methods cannot be called in Scala but they still appear in bytecode with the designated name so they can be called both within Java and they can be linked against at runtime.

We can use this trick to resolve https://github.com/apache/incubator-pekko/issues/1066 by just creating an alias method for every `inline def` and using `targetName` for the original method name and there won't be any conflict in the bytecode since `inline def` methods never generate any JVM bytecode (thats what the original problem is)