### PR TITLE
chore: Fix up ForAll comping in nightly build.

### DIFF
--- a/docs/src/test/scala/docs/stream/operators/sink/Fold.scala
+++ b/docs/src/test/scala/docs/stream/operators/sink/Fold.scala
@@ -21,7 +21,7 @@ import scala.concurrent.{ ExecutionContextExecutor, Future }
 object Fold {
   implicit val system: ActorSystem = ???
   implicit val ec: ExecutionContextExecutor = system.dispatcher
-  def foldExample: Future[Unit] = {
+  def foldExample(): Future[Unit] = {
     // #fold
     val source = Source(1 to 100)
     val result: Future[Int] = source.runWith(Sink.fold(0)((acc, element) => acc + element))

--- a/docs/src/test/scala/docs/stream/operators/sink/ForAll.scala
+++ b/docs/src/test/scala/docs/stream/operators/sink/ForAll.scala
@@ -26,7 +26,7 @@ import scala.concurrent.{ Await, ExecutionContextExecutor, Future }
 object ForAll {
   implicit val system: ActorSystem = ???
   implicit val ec: ExecutionContextExecutor = system.dispatcher
-  def foldExample: Unit = {
+  def forAllExample(): Unit = {
     // #forall
     val result: Future[Boolean] =
       Source(1 to 100)


### PR DESCRIPTION
Motivation:
Fix up forall comping in paradox.

```scala
[01-29 01:12:37.903] [error] /home/runner/work/incubator-pekko/incubator-pekko/docs/src/test/scala/docs/stream/operators/sink/ForAll.scala:29:7: side-effecting nullary methods are discouraged: suggest defining as `def foldExample()` instead
[01-29 01:12:37.903] [error]   def foldExample: Unit = {
```