### PR TITLE
Remove explicit inliner setting override

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,9 +21,6 @@ ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 
 ThisBuild / pekkoCoreProject := true
 
-// pekkoInlineEnabled must be set to false when this is backported to 1.0.x branch
-ThisBuild / pekkoInlineEnabled := true
-
 enablePlugins(
   UnidocRoot,
   UnidocWithPrValidation,


### PR DESCRIPTION
This is being done because currently its actually disabling the [knob](https://github.com/pjfanning/sbt-pekko-build/blob/main/src/main/scala/com/github/pjfanning/pekkobuild/PekkoInlinePlugin.scala#L56) that allows you to toggle inlining locally incase you want to diagnose whats going on.

It also defeats the whole purpose of having the inliner configuration in sbt-pekko-build in the first place, i.e. the point of sbt-pekko-build is to centralize common build logic to avoid boilerplate and keep things consistent between Pekko projects.

Note that I am also currently in the process of adding a log statement to sbt-pekko-build which will print whether the inliner is enabled or not to avoid surprises for developers, just waiting on https://discord.com/channels/632150470000902164/922600050989875282/1201426261122240562