### PR TITLE
chore: Run publishLocal on Java 17 & 21 too.

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -173,7 +173,7 @@ jobs:
 
       - name: Publish
         # Publish (osgi bundle) not working with JDK 17, issue #31132
-        if: ${{ matrix.javaVersion == 11 }}
+        if: ${{ contains('11,17,21', matrix.javaVersion) }}
         run: |-
           sudo apt-get install graphviz
           sbt \


### PR DESCRIPTION
Motivation:
In order to make the java 9 check classes be tested on Java 17 & Java 21 too.

Result:
When running with Java 17 and Java 21, check the result jar as Java 11 too.