### PR TITLE
chore: Add Scala 3.3 to nightly build matrix.

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -112,7 +112,7 @@ jobs:
         # No need to specify the full Scala version. Only the Scala
         # binary version is required and Pekko build will set the right
         # full version from it.
-        scalaVersion: ["2.12", "2.13"]
+        scalaVersion: ["2.12", "2.13", "3.3"]
         javaVersion: [8, 11, 17, 21]
     steps:
       - name: Checkout


### PR DESCRIPTION
Motivation:
Add Scala 3.3 to build matrix.

Result:
It now nightly builds 2.12, 2.13, and 3.3.