### PR TITLE
chore: Remove more reflectiveCall.

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringInitializationSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringInitializationSpec.scala
@@ -46,19 +46,17 @@ class ByteStringInitializationSpec extends AnyWordSpec with Matchers {
         }
       }
 
-      import scala.language.reflectiveCalls
-      type WithRun = { def run(): Unit }
       cleanCl
         .loadClass("org.apache.pekko.util.ByteStringInitTest")
         .getDeclaredConstructor()
         .newInstance()
-        .asInstanceOf[WithRun]
+        .asInstanceOf[Runnable]
         .run()
     }
   }
 }
 
-class ByteStringInitTest {
+class ByteStringInitTest extends Runnable {
   def run(): Unit = {
     require(CompactByteString.empty ne null)
     require(ByteString.empty ne null)

--- a/actor-typed-tests/src/test/scala-3/docs/org/apache/pekko/typed/InteractionPatterns3Spec.scala
+++ b/actor-typed-tests/src/test/scala-3/docs/org/apache/pekko/typed/InteractionPatterns3Spec.scala
@@ -46,6 +46,7 @@ object DummyData3 {
 
 class InteractionPatterns3Spec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
   import DummyData3._
+  private class DummyContext[T](val self: ActorRef[T])
 
   "The interaction patterns docs" must {
 
@@ -101,10 +102,7 @@ class InteractionPatterns3Spec extends ScalaTestWithActorTestKit with AnyWordSpe
       val cookieFabric: ActorRef[CookieFabric.Request] = spawn(CookieFabric())
       val probe = createTestProbe[CookieFabric.Response]()
       // shhh, don't tell anyone
-      import scala.language.reflectiveCalls
-      val context: { def self: ActorRef[CookieFabric.Response] } = new {
-        def self = probe.ref
-      }
+      val context = new DummyContext(probe.ref)
 
       // #request-response-send
       cookieFabric ! CookieFabric.Request("give me cookies", context.self)

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/InteractionPatternsSpec.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/InteractionPatternsSpec.scala
@@ -42,7 +42,7 @@ case class Wallet()
 // #per-session-child
 
 class InteractionPatternsSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
-
+  private class DummyContext[T](val self: ActorRef[T])
   "The interaction patterns docs" must {
 
     "contain a sample for fire and forget" in {
@@ -97,10 +97,7 @@ class InteractionPatternsSpec extends ScalaTestWithActorTestKit with AnyWordSpec
       val cookieFabric: ActorRef[CookieFabric.Request] = spawn(CookieFabric())
       val probe = createTestProbe[CookieFabric.Response]()
       // shhh, don't tell anyone
-      import scala.language.reflectiveCalls
-      val context: { def self: ActorRef[CookieFabric.Response] } = new {
-        def self = probe.ref
-      }
+      val context = new DummyContext[CookieFabric.Response](probe.ref)
 
       // #request-response-send
       cookieFabric ! CookieFabric.Request("give me cookies", context.self)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/impl/fusing/AsyncCallbackSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/impl/fusing/AsyncCallbackSpec.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.stream.impl.fusing
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.Promise
-import scala.language.reflectiveCalls
 
 import org.apache.pekko
 import pekko.Done
@@ -40,6 +39,11 @@ class AsyncCallbackSpec extends PekkoSpec("""
   case class Elem(n: Int)
   case object Stopped
 
+  private class GraphStageLogicWithAsyncCallback(shape: Shape) extends GraphStageLogic(shape) {
+    def callback: AsyncCallback[AnyRef] = null
+    def callbacks: Set[AsyncCallback[AnyRef]] = Set.empty
+  }
+
   class AsyncCallbackGraphStage(probe: ActorRef, early: Option[AsyncCallback[AnyRef] => Unit] = None)
       extends GraphStageWithMaterializedValue[FlowShape[Int, Int], AsyncCallback[AnyRef]] {
 
@@ -48,14 +52,13 @@ class AsyncCallbackSpec extends PekkoSpec("""
     val shape = FlowShape(in, out)
 
     def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, AsyncCallback[AnyRef]) = {
-      val logic: GraphStageLogic { val callback: AsyncCallback[AnyRef] } = new GraphStageLogic(shape) {
-        val callback = getAsyncCallback((whatever: AnyRef) => {
-          whatever match {
-            case t: Throwable     => throw t
-            case "fail-the-stage" => failStage(new RuntimeException("failing the stage"))
-            case anythingElse     => probe ! anythingElse
-          }
-        })
+      val logic = new GraphStageLogicWithAsyncCallback(shape) {
+        override val callback = getAsyncCallback {
+          case t: Throwable     => throw t
+          case "fail-the-stage" => failStage(new RuntimeException("failing the stage"))
+          case anythingElse     => probe ! anythingElse
+        }
+
         early.foreach(cb => cb(callback))
 
         override def preStart(): Unit = {
@@ -256,8 +259,8 @@ class AsyncCallbackSpec extends PekkoSpec("""
         val out = Outlet[String]("out")
         val shape = SourceShape(out)
         def createLogicAndMaterializedValue(inheritedAttributes: Attributes) = {
-          val logic: GraphStageLogic { val callbacks: Set[AsyncCallback[AnyRef]] } = new GraphStageLogic(shape) {
-            val callbacks = (0 to 10).map(_ => getAsyncCallback[AnyRef](probe ! _)).toSet
+          val logic = new GraphStageLogicWithAsyncCallback(shape) {
+            override val callbacks = (0 to 10).map(_ => getAsyncCallback[AnyRef](probe ! _)).toSet
             setHandler(out,
               new OutHandler {
                 def onPull(): Unit = ()


### PR DESCRIPTION
Motivation:
Remove more reflectiveCall usage from the codebase.
https://docs.scala-lang.org/scala3/guides/migration/incompat-type-inference.html

Result:
Clean code.
