### PR TITLE
chore: Remove useless contractor parameters in doc tests.

### DIFF
--- a/docs/src/test/scala/docs/actor/ActorDocSpec.scala
+++ b/docs/src/test/scala/docs/actor/ActorDocSpec.scala
@@ -345,7 +345,7 @@ class ActorDocSpec extends PekkoSpec("""
       }
       // #import-context
 
-      val first = system.actorOf(Props(classOf[FirstActor], this), name = "first")
+      val first = system.actorOf(Props(classOf[FirstActor]), name = "first")
       system.stop(first)
     }
   }
@@ -599,7 +599,7 @@ class ActorDocSpec extends PekkoSpec("""
       }
       // #watch
 
-      val victim = system.actorOf(Props(classOf[WatchActor], this))
+      val victim = system.actorOf(Props(classOf[WatchActor]))
       victim.tell("kill", testActor)
       expectMsg("finished")
     }

--- a/docs/src/test/scala/docs/actor/ActorDocSpec.scala
+++ b/docs/src/test/scala/docs/actor/ActorDocSpec.scala
@@ -664,7 +664,7 @@ class ActorDocSpec extends PekkoSpec("""
       // #identify
 
       val a = system.actorOf(Props.empty)
-      val b = system.actorOf(Props(classOf[Follower], this))
+      val b = system.actorOf(Props(classOf[Follower]))
       watch(b)
       system.stop(a)
       expectMsgType[pekko.actor.Terminated].actor should be(b)

--- a/docs/src/test/scala/docs/dispatcher/DispatcherDocSpec.scala
+++ b/docs/src/test/scala/docs/dispatcher/DispatcherDocSpec.scala
@@ -431,7 +431,7 @@ class DispatcherDocSpec extends PekkoSpec(DispatcherDocSpec.config) {
           case x => log.info(x.toString)
         }
       }
-      val a = system.actorOf(Props(classOf[Logger], this).withDispatcher("control-aware-dispatcher"))
+      val a = system.actorOf(Props(classOf[Logger]).withDispatcher("control-aware-dispatcher"))
 
       /*
        * Logs:

--- a/docs/src/test/scala/docs/dispatcher/DispatcherDocSpec.scala
+++ b/docs/src/test/scala/docs/dispatcher/DispatcherDocSpec.scala
@@ -395,7 +395,7 @@ class DispatcherDocSpec extends PekkoSpec(DispatcherDocSpec.config) {
           case x => log.info(x.toString)
         }
       }
-      val a = system.actorOf(Props(classOf[Logger], this).withDispatcher("prio-dispatcher"))
+      val a = system.actorOf(Props(classOf[Logger]).withDispatcher("prio-dispatcher"))
 
       /*
        * Logs:


### PR DESCRIPTION
Motivation:
Fix the nightly build on Scala 3.3

https://github.com/apache/incubator-pekko/actions/runs/7714027653/job/21025328188

I tested it locally, the tests passed.

I Have no idea why it works on Scala 2.13, as there is an additional argument, and should fail as Scala 3.