### PR TITLE
Get avoid snapshot interval calculate int overflow

### DIFF
--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/RetentionCriteriaImpl.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/RetentionCriteriaImpl.scala
@@ -36,14 +36,14 @@ import pekko.persistence.typed.scaladsl
 
   def deleteUpperSequenceNr(lastSequenceNr: Long): Long = {
     // Delete old events, retain the latest
-    math.max(0, lastSequenceNr - (keepNSnapshots * snapshotEveryNEvents))
+    math.max(0, lastSequenceNr - (keepNSnapshots.toLong * snapshotEveryNEvents))
   }
 
   def deleteLowerSequenceNr(upperSequenceNr: Long): Long = {
     // We could use 0 as fromSequenceNr to delete all older snapshots, but that might be inefficient for
     // large ranges depending on how it's implemented in the snapshot plugin. Therefore we use the
     // same window as defined for how much to keep in the retention criteria
-    math.max(0, upperSequenceNr - (keepNSnapshots * snapshotEveryNEvents))
+    math.max(0, upperSequenceNr - (keepNSnapshots.toLong * snapshotEveryNEvents))
   }
 
   override def withDeleteEventsOnSnapshot: SnapshotCountRetentionCriteriaImpl =


### PR DESCRIPTION
## Motivation

When the user uses `Integer.MAX_VALUE` as keepNSnapshots, it will touch integer overflow, and persistence will never delete those events.

This change will not change anything besides avoid overflow, because the persistence actor version already designed as a long type.

This screenshot was  happened in the real world:

![image](https://github.com/apache/incubator-pekko/assets/26020358/09d6282d-a143-473a-86c0-de4e514ce6cf)
