### PR TITLE
add partition operator in stream graph docs

### DIFF
--- a/docs/src/main/paradox/stream/stream-graphs.md
+++ b/docs/src/main/paradox/stream/stream-graphs.md
@@ -39,6 +39,7 @@ Pekko Streams currently provide these junctions (for a detailed list see the @re
 
     * @scala[`Broadcast[T]`]@java[`Broadcast<T>`] – *(1 input, N outputs)* given an input element emits to each output
     * @scala[`Balance[T]`]@java[`Balance<T>`] – *(1 input, N outputs)* given an input element emits to one of its output ports
+    * @scala[`Partition[T]]`]@java[`Partition<T>`] – *(1 input, N outputs)* given an input element emits to specified output based on a partition function
     * @scala[`UnzipWith[In,A,B,...]`]@java[`UnzipWith<In,A,B,...>`] – *(1 input, N outputs)* takes a function of 1 input that given a value for each input emits N output elements (where N <= 20)
     * @scala[`UnZip[A,B]`]@java[`UnZip<A,B>`] – *(1 input, 2 outputs)* splits a stream of @scala[`(A,B)`]@java[`Pair<A,B>`] tuples into two streams, one of type `A` and one of type `B`
 


### PR DESCRIPTION
Partition is a very common and useful operator, Many popular projects have such capabilities(such as Kafka and Flink.）we should mention it in stream graph documentation.

We could complete all fan in/out operators into this documentation, but I think that's increased user burden, the additional partition was enough, because it made us have enough basic functions for fan out(this is kind of like load balance):

- 1 to all
- 1 to random one
- 1 to specific one