### PR TITLE
don't hardcode exact coursier version so that we can pick up patches

### DIFF
--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: 11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        uses: coursier/cache-action@v6
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts

--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-tags: true
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        uses: coursier/cache-action@v6
 
       - name: Setup Java 8
         uses: actions/setup-java@v4
@@ -56,7 +56,7 @@ jobs:
           java-version: 8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        uses: coursier/cache-action@v6
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -20,7 +20,7 @@ jobs:
           java-version: 8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        uses: coursier/cache-action@v6
 
       - name: Check headers
         run: |-

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -29,7 +29,7 @@ jobs:
           java-version: 11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        uses: coursier/cache-action@v6
 
       - name: Setup Coursier
         uses: coursier/setup-action@v1.3.3

--- a/.github/workflows/nightly-builds-aeron.yml
+++ b/.github/workflows/nightly-builds-aeron.yml
@@ -34,7 +34,7 @@ jobs:
           java-version: 11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        uses: coursier/cache-action@v6
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -26,7 +26,7 @@ jobs:
           java-version: 11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        uses: coursier/cache-action@v6
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts
@@ -84,7 +84,7 @@ jobs:
           java-version: 11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        uses: coursier/cache-action@v6
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts
@@ -128,7 +128,7 @@ jobs:
           java-version: ${{ matrix.javaVersion }}
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        uses: coursier/cache-action@v6
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -46,7 +46,7 @@ jobs:
           java-version: 11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        uses: coursier/cache-action@v6
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts

--- a/.github/workflows/scala3-compile.yml
+++ b/.github/workflows/scala3-compile.yml
@@ -44,7 +44,7 @@ jobs:
           java-version: 11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        uses: coursier/cache-action@v6
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -28,7 +28,7 @@ jobs:
           java-version: 11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        uses: coursier/cache-action@v6
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts


### PR DESCRIPTION
want to upgrade node version - see https://github.com/coursier/cache-action/releases/tag/v6.4.5