### PR TITLE
Configuration typo fixes

### DIFF
--- a/actor-typed/src/main/resources/reference.conf
+++ b/actor-typed/src/main/resources/reference.conf
@@ -26,7 +26,7 @@ pekko.actor.typed {
   # buffer. If the capacity is exceed then additional incoming messages are dropped.
   restart-stash-capacity = 1000
 
-  # Typed mailbox defaults to the single consumber mailbox as balancing dispatcher is not supported
+  # Typed mailbox defaults to the single consumer mailbox as balancing dispatcher is not supported
   default-mailbox {
     mailbox-type = "org.apache.pekko.dispatch.SingleConsumerOnlyUnboundedMailbox"
   }
@@ -73,7 +73,7 @@ pekko.reliable-delivery {
     # To avoid head of line blocking from serialization and transfer
     # of large messages this can be enabled.
     # Large messages are chunked into pieces of the given size in bytes. The
-    # chunked messages are sent separatetely and assembled on the consumer side.
+    # chunked messages are sent separately and assembled on the consumer side.
     # Serialization and deserialization is performed by the ProducerController and
     # ConsumerController respectively instead of in the remote transport layer.
     chunk-large-messages = off

--- a/actor/src/main/resources/reference.conf
+++ b/actor/src/main/resources/reference.conf
@@ -323,8 +323,8 @@ pekko {
           # Probability of doing an exploration v.s. optimization.
           chance-of-exploration = 0.4
 
-          # When downsizing after a long streak of underutilization, the resizer
-          # will downsize the pool to the highest utiliziation multiplied by a
+          # When downsizing after a long streak of under-utilization, the resizer
+          # will downsize the pool to the highest utilization multiplied by a
           # a downsize ratio. This downsize ratio determines the new pools size
           # in comparison to the highest utilization.
           # E.g. if the highest utilization is 10, and the down size ratio
@@ -1349,7 +1349,7 @@ pekko {
       # In order to skip this additional delay set as 0
       random-factor = 0.0
 
-      # A allowlist of fqcn of Exceptions that the CircuitBreaker
+      # A allow-list of fqcn of Exceptions that the CircuitBreaker
       # should not consider failures. By default all exceptions are
       # considered failures.
       exception-allowlist = []

--- a/cluster-sharding-typed/src/main/resources/reference.conf
+++ b/cluster-sharding-typed/src/main/resources/reference.conf
@@ -15,10 +15,10 @@ pekko.cluster.sharding {
 
 
 pekko.cluster.sharded-daemon-process {
-  # Settings for the sharded dameon process internal usage of sharding are using the pekko.cluste.sharding defaults.
-  # Some of the settings can be overriden specifically for the sharded daemon process here. For example can the
+  # Settings for the sharded daemon process internal usage of sharding are using the pekko.cluster.sharding defaults.
+  # Some of the settings can be overridden specifically for the sharded daemon process here. For example can the
   # `role` setting limit what nodes the daemon processes and the keep alive pingers will run on.
-  # Some settings can not be changed (remember-entitites and related settings, passivation, number-of-shards),
+  # Some settings can not be changed (remember-entities and related settings, passivation, number-of-shards),
   # overriding those settings will be ignored.
   sharding = ${pekko.cluster.sharding}
 

--- a/cluster-sharding/src/main/resources/reference.conf
+++ b/cluster-sharding/src/main/resources/reference.conf
@@ -22,7 +22,7 @@ pekko.cluster.sharding {
 
   # When this is set to 'on' the active entity actors will automatically be restarted
   # upon Shard restart. i.e. if the Shard is started on a different ShardRegion
-  # due to rebalanced or crash.
+  # due to rebalance or crash.
   remember-entities = off
 
   # When 'remember-entities' is enabled and the state store mode is ddata this controls

--- a/cluster-sharding/src/main/resources/reference.conf
+++ b/cluster-sharding/src/main/resources/reference.conf
@@ -22,7 +22,7 @@ pekko.cluster.sharding {
 
   # When this is set to 'on' the active entity actors will automatically be restarted
   # upon Shard restart. i.e. if the Shard is started on a different ShardRegion
-  # due to rebalance or crash.
+  # due to rebalanced or crash.
   remember-entities = off
 
   # When 'remember-entities' is enabled and the state store mode is ddata this controls
@@ -61,7 +61,7 @@ pekko.cluster.sharding {
       # Default limit of 100k active entities in a shard region (in a cluster node).
       active-entity-limit = 100000
 
-      # Admisson window with LRU policy and adaptive sizing, and a frequency sketch admission filter to the main area.
+      # Admission window with LRU policy and adaptive sizing, and a frequency sketch admission filter to the main area.
       admission {
         window {
           policy = least-recently-used

--- a/cluster-tools/src/main/resources/reference.conf
+++ b/cluster-tools/src/main/resources/reference.conf
@@ -130,7 +130,7 @@ pekko.cluster.client {
   # Maximum allowed buffer size is 10000.
   buffer-size = 1000
 
-  # If connection to the receiptionist is lost and the client has not been
+  # If connection to the receptionist is lost and the client has not been
   # able to acquire a new connection for this long the client will stop itself.
   # This duration makes it possible to watch the cluster client and react on a more permanent
   # loss of connection with the cluster, for example by accessing some kind of

--- a/cluster/src/main/resources/reference.conf
+++ b/cluster/src/main/resources/reference.conf
@@ -233,7 +233,7 @@ pekko {
     multi-data-center {
 
       # Defines which data center this node belongs to. It is typically used to make islands of the
-      # cluster that are collocated. This can be used to make the cluster aware that it is running
+      # cluster that are co-located. This can be used to make the cluster aware that it is running
       # across multiple availability zones or regions. It can also be used for other logical
       # grouping of nodes.
       self-data-center = "default"

--- a/cluster/src/main/resources/reference.conf
+++ b/cluster/src/main/resources/reference.conf
@@ -233,7 +233,7 @@ pekko {
     multi-data-center {
 
       # Defines which data center this node belongs to. It is typically used to make islands of the
-      # cluster that are colocated. This can be used to make the cluster aware that it is running
+      # cluster that are collocated. This can be used to make the cluster aware that it is running
       # across multiple availability zones or regions. It can also be used for other logical
       # grouping of nodes.
       self-data-center = "default"

--- a/remote/src/main/resources/reference.conf
+++ b/remote/src/main/resources/reference.conf
@@ -221,7 +221,7 @@ pekko {
       unreachable-nodes-reaper-interval = 1s
 
       # After the heartbeat request has been sent the first failure detection
-      # will start after this period, even though no heartbeat mesage has
+      # will start after this period, even though no heartbeat message has
       # been received.
       expected-response-after = 1 s
 
@@ -308,7 +308,7 @@ pekko {
       # enabled-transports section) need longer time to be loaded.
       startup-timeout = 10 s
 
-      # Timout after which the graceful shutdown of the remoting subsystem is
+      # Timeout after which the graceful shutdown of the remoting subsystem is
       # considered to be failed. After the timeout the remoting system is
       # forcefully shut down. Increase this value if your transport drivers
       # (see the enabled-transports section) need longer time to stop properly.
@@ -492,7 +492,7 @@ pekko {
         applied-adapters = []
 
         # The default remote server port clients should connect to.
-        # Default is 7355 (PEKK on a telephone keypad), use 0 if you want a random available port
+        # Default is 7355 (Pekko on a telephone keypad), use 0 if you want a random available port
         # This port needs to be unique for each actor system on the same machine.
         port = 7355
 
@@ -584,7 +584,7 @@ pekko {
         # Enables the TCP_NODELAY flag, i.e. disables Nagle’s algorithm
         tcp-nodelay = on
 
-        # Enables TCP Keepalive, subject to the O/S kernel’s configuration
+        # Enables TCP Keep-alive, subject to the O/S kernel’s configuration
         tcp-keepalive = on
 
         # Enables SO_REUSEADDR, which determines when an ActorSystem can open
@@ -852,7 +852,7 @@ pekko {
         # collected, which is not as efficient as reusing buffers in the pool.
         large-buffer-pool-size = 32
 
-        # For enabling testing features, such as blackhole in pekko-remote-testkit.
+        # For enabling testing features, such as black-hole in pekko-remote-testkit.
         test-mode = off
 
         # Settings for the materializer that is used for the remote streams.
@@ -890,7 +890,7 @@ pekko {
         # the queue becomes full. This may happen if you send a burst of many messages
         # without end-to-end flow control. Note that there is one such queue per
         # outbound association. The trade-off of using a larger queue size is that
-        # it consumes more memory, since the queue is based on preallocated array with
+        # it consumes more memory, since the queue is based on pre-allocated array with
         # fixed size.
         outbound-message-queue-size = 3072
 
@@ -951,7 +951,7 @@ pekko {
         # need to survive.
         # The value must also be greater than stop-idle-outbound-after.
         # Once every 1/10 of this duration an extra handshake message will be sent.
-        # Therfore it's also recommended to use a value that is greater than 10 times
+        # Therefore it's also recommended to use a value that is greater than 10 times
         # the stop-idle-outbound-after, since otherwise the idle streams will not be
         # stopped.
         quarantine-idle-outbound-after = 6 hours
@@ -968,7 +968,7 @@ pekko {
         # and also unused for this duration before it's removed. When removed the historical
         # information about which UIDs that were quarantined for that hostname:port is
         # gone which could result in communication with a previously quarantined node
-        # if it wakes up again. Therfore this shouldn't be set too low.
+        # if it wakes up again. Therefore this shouldn't be set too low.
         remove-quarantined-association-after = 1 h
 
         # during ActorSystem termination the remoting will wait this long for
@@ -976,7 +976,7 @@ pekko {
         # remote messages has been completed
         shutdown-flush-timeout = 1 second
 
-        # Before sending notificaiton of terminated actor (DeathWatchNotification) other messages
+        # Before sending notification of terminated actor (DeathWatchNotification) other messages
         # will be flushed to make sure that the Terminated message arrives after other messages.
         # It will wait this long for the flush acknowledgement before continuing.
         # The flushing can be disabled by setting this to `off`.
@@ -1035,7 +1035,7 @@ pekko {
         # have a public constructor with empty parameters or one ExtendedActorSystem
         # parameter.
         # A new instance of RemoteInstrument will be created for each encoder and decoder.
-        # It's only called from the stage, so if it dosn't delegate to any shared instance
+        # It's only called from the stage, so if it doesn't delegate to any shared instance
         # it doesn't have to be thread-safe.
         # Refer to `org.apache.pekko.remote.artery.RemoteInstrument` for more information.
         instruments = ${?pekko.remote.artery.advanced.instruments} []
@@ -1081,7 +1081,7 @@ pekko {
           # Only used when transport is aeron-udp.
           client-liveness-timeout = 20 seconds
 
-          # Timout after after which an uncommitted publication will be unblocked
+          # Timeout after after which an uncommitted publication will be unblocked
           # Only used when transport is aeron-udp.
           publication-unblock-timeout = 40 seconds
 
@@ -1194,7 +1194,7 @@ pekko {
         # at least one common subject name (CN or SAN).
         # The Key setup this implementation supports has some limitations:
         #   1. the private key must be provided on a PKCS#1 or a non-encrypted PKCS#8 PEM-formatted file
-        #   2. the private key must be be of an algorythm supported by `pekko-pki` tools (e.g. "RSA", not "EC")
+        #   2. the private key must be be of an algorithm supported by `pekko-pki` tools (e.g. "RSA", not "EC")
         #   3. the node certificate must be issued by a root CA (not an intermediate CA)
         #   4. both the node and the CA certificates must be provided in PEM-formatted files
         rotating-keys-engine {
@@ -1206,7 +1206,7 @@ pekko {
           key-file = ${pekko.remote.artery.ssl.rotating-keys-engine.secret-mount-point}/tls.key
           # The absolute path to the PEM file of the certificate for the private key above.
           cert-file = ${pekko.remote.artery.ssl.rotating-keys-engine.secret-mount-point}/tls.crt
-          # The absolute path to the PEM file of the certificate of the CA that emited
+          # The absolute path to the PEM file of the certificate of the CA that emitted
           # the node certificate above.
           ca-cert-file = ${pekko.remote.artery.ssl.rotating-keys-engine.secret-mount-point}/ca.crt
 

--- a/remote/src/main/resources/reference.conf
+++ b/remote/src/main/resources/reference.conf
@@ -492,7 +492,7 @@ pekko {
         applied-adapters = []
 
         # The default remote server port clients should connect to.
-        # Default is 7355 (Pekko on a telephone keypad), use 0 if you want a random available port
+        # Default is 7355 (PEKK on a telephone keypad), use 0 if you want a random available port
         # This port needs to be unique for each actor system on the same machine.
         port = 7355
 
@@ -852,7 +852,7 @@ pekko {
         # collected, which is not as efficient as reusing buffers in the pool.
         large-buffer-pool-size = 32
 
-        # For enabling testing features, such as black-hole in pekko-remote-testkit.
+        # For enabling testing features, such as blackhole in pekko-remote-testkit.
         test-mode = off
 
         # Settings for the materializer that is used for the remote streams.

--- a/stream/src/main/resources/reference.conf
+++ b/stream/src/main/resources/reference.conf
@@ -47,7 +47,7 @@ pekko {
         mode = cancel
 
         # time after which a subscriber / publisher is considered stale and eligible
-        # for cancelation (see `pekko.stream.subscription-timeout.mode`)
+        # for cancellation (see `pekko.stream.subscription-timeout.mode`)
         timeout = 5s
       }
 


### PR DESCRIPTION
Separate PR and cherry-pick from #1096, and solve all module typos.