### PR TITLE
Update sbt-boilerplate to 0.7.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.3")
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
-addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
+addSbtPlugin("com.github.sbt" % "sbt-boilerplate" % "0.7.0")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
 addSbtPlugin("com.github.sbt" % "sbt-pull-request-validator" % "2.0.0")


### PR DESCRIPTION
cherry pick 4f2f9e3e81c6c75ced2cd6780c5d665a00fb2636 

Last 1.0.x build failed because the old version of this lib could not be found (the old version is in the typesafe rrepo, not maven central - and the typesafe repo is becoming brittle)