### PR TITLE
add default for pekko.remote.akka.version

### DIFF
--- a/cluster/src/main/scala/org/apache/pekko/cluster/SeedNodeProcess.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/SeedNodeProcess.scala
@@ -57,10 +57,8 @@ private[cluster] abstract class SeedNodeProcess(joinConfigCompatChecker: JoinCon
     val cfg = context.system.settings.config
     if (cfg.hasPath("akka.version")) {
       cfg.getString("akka.version")
-    } else if (cfg.hasPath("pekko.cluster.akka.version")) {
-      cfg.getString("pekko.cluster.akka.version")
     } else {
-      "2.6.21"
+      cfg.getString("pekko.remote.akka.version")
     }
   }
 

--- a/cluster/src/main/scala/org/apache/pekko/cluster/SeedNodeProcess.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/SeedNodeProcess.scala
@@ -57,8 +57,10 @@ private[cluster] abstract class SeedNodeProcess(joinConfigCompatChecker: JoinCon
     val cfg = context.system.settings.config
     if (cfg.hasPath("akka.version")) {
       cfg.getString("akka.version")
-    } else {
+    } else if (cfg.hasPath("pekko.cluster.akka.version")) {
       cfg.getString("pekko.cluster.akka.version")
+    } else {
+      "2.6.21"
     }
   }
 

--- a/remote/src/main/resources/reference.conf
+++ b/remote/src/main/resources/reference.conf
@@ -185,9 +185,12 @@ pekko {
     warn-unsafe-watch-outside-cluster = on
 
     # When receiving requests from other remote actors, what are the valid
-    # prefix's to check against. Useful for when dealing with rolling cluster
+    # prefixes to check against. Useful for when dealing with rolling cluster
     # migrations with compatible systems such as Lightbend's Akka.
-    accept-protocol-names = ["pekko", "akka"]
+    # By default, we only support "pekko" protocol.
+    # If you want to also support Akka, change this config to:
+    # pekko.remote.accept-protocol-names = ["pekko", "akka"]
+    accept-protocol-names = ["pekko"]
 
     # The protocol name to use when sending requests to other remote actors.
     # Useful when dealing with rolling migration, i.e. temporarily change
@@ -197,6 +200,12 @@ pekko {
     # Pekko and then change the protocol-name back to "pekko" once all
     # nodes have been are running on Apache Pekko
     protocol-name = "pekko"
+
+    # When pekko.remote.accept-protocol-names contains "akka", then we
+    # need to know the Akka version. If you include the Akka jars on the classpath,
+    # we can use the akka.version from their configuration. This configuration
+    # setting is only used if we cabn't find an akka.version setting.
+    akka.version = "2.6.21"
 
     # Settings for the Phi accrual failure detector (http://www.jaist.ac.jp/~defago/files/pdf/IS_RR_2004_010.pdf
     # [Hayashibara et al]) used for remote death watch.

--- a/remote/src/main/resources/reference.conf
+++ b/remote/src/main/resources/reference.conf
@@ -204,7 +204,7 @@ pekko {
     # When pekko.remote.accept-protocol-names contains "akka", then we
     # need to know the Akka version. If you include the Akka jars on the classpath,
     # we can use the akka.version from their configuration. This configuration
-    # setting is only used if we cabn't find an akka.version setting.
+    # setting is only used if we can't find an akka.version setting.
     akka.version = "2.6.21"
 
     # Settings for the Phi accrual failure detector (http://www.jaist.ac.jp/~defago/files/pdf/IS_RR_2004_010.pdf

--- a/remote/src/main/resources/reference.conf
+++ b/remote/src/main/resources/reference.conf
@@ -190,6 +190,8 @@ pekko {
     # By default, we only support "pekko" protocol.
     # If you want to also support Akka, change this config to:
     # pekko.remote.accept-protocol-names = ["pekko", "akka"]
+    # A ConfigurationException will be thrown at runtime if the array is empty
+    # or contains values other than "pekko" and/or "akka".
     accept-protocol-names = ["pekko"]
 
     # The protocol name to use when sending requests to other remote actors.
@@ -198,7 +200,9 @@ pekko {
     # such as Lightbend's "akka" (whilst making sure accept-protocol-names
     # contains "akka") so that you can gracefully migrate all nodes to Apache
     # Pekko and then change the protocol-name back to "pekko" once all
-    # nodes have been are running on Apache Pekko
+    # nodes have been are running on Apache Pekko.
+    # A ConfigurationException will be thrown at runtime if the value is not
+    # set to "pekko" or "akka".
     protocol-name = "pekko"
 
     # When pekko.remote.accept-protocol-names contains "akka", then we

--- a/remote/src/main/scala/org/apache/pekko/remote/RemoteSettings.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/RemoteSettings.scala
@@ -216,7 +216,7 @@ final class RemoteSettings(val config: Config) {
       throw new ConfigurationException("pekko.remote.accept-protocol-names setting must not be empty. " +
         "The setting is an array and the only acceptable values are \"pekko\" and \"akka\".")
     }
-    val filteredSet = set.filterNot(s => s == "akka" || s == "pekko")
+    val filteredSet = set.filterNot(AllowableProtocolNames.contains)
     if (filteredSet.nonEmpty) {
       throw new ConfigurationException("pekko.remote.accept-protocol-names is an array setting " +
         "that only accepts the values \"pekko\" and \"akka\".")

--- a/remote/src/test/scala/org/apache/pekko/remote/classic/RemoteSettingsSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/classic/RemoteSettingsSpec.scala
@@ -18,7 +18,10 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import org.apache.pekko.remote.RemoteSettings
+import org.apache.pekko
+import pekko.ConfigurationException
+import pekko.remote.RemoteSettings
+import pekko.testkit.PekkoSpec
 
 @nowarn("msg=deprecated")
 class RemoteSettingsSpec extends AnyWordSpec with Matchers {
@@ -33,6 +36,32 @@ class RemoteSettingsSpec extends AnyWordSpec with Matchers {
         ConfigFactory
           .parseString("pekko.remote.classic.log-frame-size-exceeding = 100b")
           .withFallback(ConfigFactory.load())).LogFrameSizeExceeding shouldEqual Some(100)
+    }
+    "fail if unknown protocol name is used" in {
+      val cfg = ConfigFactory.parseString("pekko.remote.protocol-name=unknown")
+        .withFallback(PekkoSpec.testConf)
+      val ex = intercept[ConfigurationException] {
+        new RemoteSettings(ConfigFactory.load(cfg))
+      }  
+      ex.getMessage shouldEqual
+        """The only allowed values for pekko.remote.protocol-name are "pekko" and "akka"."""
+    }
+    "fail if empty accept-protocol-names is used" in {
+      val cfg = ConfigFactory.parseString("pekko.remote.accept-protocol-names=[]")
+        .withFallback(PekkoSpec.testConf)
+      val ex = intercept[ConfigurationException] {
+        new RemoteSettings(ConfigFactory.load(cfg))
+      }  
+      ex.getMessage should startWith("pekko.remote.accept-protocol-names setting must not be empty")
+    }
+    "fail if invalid accept-protocol-names value is used" in {
+      val cfg = ConfigFactory.parseString("""pekko.remote.accept-protocol-names=["pekko", "unknown"]""")
+        .withFallback(PekkoSpec.testConf)
+      val ex = intercept[ConfigurationException] {
+        new RemoteSettings(ConfigFactory.load(cfg))
+      }  
+      ex.getMessage shouldEqual
+        """pekko.remote.accept-protocol-names is an array setting that only accepts the values "pekko" and "akka"."""
     }
   }
 

--- a/remote/src/test/scala/org/apache/pekko/remote/classic/RemoteSettingsSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/classic/RemoteSettingsSpec.scala
@@ -42,16 +42,16 @@ class RemoteSettingsSpec extends AnyWordSpec with Matchers {
         .withFallback(PekkoSpec.testConf)
       val ex = intercept[ConfigurationException] {
         new RemoteSettings(ConfigFactory.load(cfg))
-      }  
+      }
       ex.getMessage shouldEqual
-        """The only allowed values for pekko.remote.protocol-name are "pekko" and "akka"."""
+      """The only allowed values for pekko.remote.protocol-name are "pekko" and "akka"."""
     }
     "fail if empty accept-protocol-names is used" in {
       val cfg = ConfigFactory.parseString("pekko.remote.accept-protocol-names=[]")
         .withFallback(PekkoSpec.testConf)
       val ex = intercept[ConfigurationException] {
         new RemoteSettings(ConfigFactory.load(cfg))
-      }  
+      }
       ex.getMessage should startWith("pekko.remote.accept-protocol-names setting must not be empty")
     }
     "fail if invalid accept-protocol-names value is used" in {
@@ -59,9 +59,9 @@ class RemoteSettingsSpec extends AnyWordSpec with Matchers {
         .withFallback(PekkoSpec.testConf)
       val ex = intercept[ConfigurationException] {
         new RemoteSettings(ConfigFactory.load(cfg))
-      }  
+      }
       ex.getMessage shouldEqual
-        """pekko.remote.accept-protocol-names is an array setting that only accepts the values "pekko" and "akka"."""
+      """pekko.remote.accept-protocol-names is an array setting that only accepts the values "pekko" and "akka"."""
     }
   }
 


### PR DESCRIPTION
This property is only needed if you have pekko.remote.accept-protocol-names set up to include "akka". This is the case in the test config for pekko-remote and we get a lot of logging about pekko.cluster.akka.version as a result.

Relates to #765 and can only be merged to 1.0.x because #765 is only merged to that branch.

spotted in https://github.com/apache/incubator-pekko/actions/runs/7854077720 - we don't run the nightly tests on 1.0.x branch (and we should probably fix that too)

As part of the change, I have renamed the config to pekko.remote.akka.version so that the config is with the other new configs.