### PR TITLE
remove unsupported feature from 1.0 build

### DIFF
--- a/.github/workflows/nightly-1.0-builds.yml
+++ b/.github/workflows/nightly-1.0-builds.yml
@@ -126,9 +126,6 @@ jobs:
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts
 
-      - name: Check if the dependency task in the built correctly
-        run: sbt dependWalkerCheck
-
       - name: Compile and Test
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-


### PR DESCRIPTION
The build added in #1120 includes items from the main branch nightly build. The `sbt dependWalkerCheck` check is only something that was added on main branch so it causes the 1.0 build to break.