### PR TITLE
Cache output of assembly

### DIFF
--- a/project/Protobuf.scala
+++ b/project/Protobuf.scala
@@ -38,7 +38,7 @@ object Protobuf {
     outputPaths := Seq((Compile / sourceDirectory).value, (Test / sourceDirectory).value).map(_ / "java"),
     importPath := None,
     // this keeps intellij happy for files that use the shaded protobuf
-    Compile / unmanagedJars += (LocalProject("protobuf-v3") / assembly).value,
+    Compile / unmanagedJars += (LocalProject("protobuf-v3") / Compile / packageBin).value,
     protoc := "protoc",
     protocVersion := "3.11.4",
     generate := {


### PR DESCRIPTION

Previously, the build would rebuild over and over the uber jar with the
shaded protobuf3 distribution. With this patch, this is no longer the
case, as the output is cached locally.

------

The issue with assembly re-creating the same uber-jar on (nearly) every run was discovered using the Develocity Timeline feature, which displays task executions on different swimlanes.

Before this fix, the assembly task is clearly shown as being a bottleneck in the build process:
![Screenshot 2024-02-02 at 16 19 38](https://github.com/apache/incubator-pekko/assets/1765926/a922b8c8-c5a8-40e7-9632-f7c49477df35)

After this patch is applied, the bottleneck is gone:
![Screenshot 2024-02-02 at 16 19 51](https://github.com/apache/incubator-pekko/assets/1765926/2d5c5b9c-1c3e-4ebb-ba1b-68e74053bc51)

After the bottleneck is gone, common tasks (eg. `test`) start faster: Gathering all tests’ names goes from 3.7s to 3.2s (-15%).
