### PR TITLE
Pin sbt-paradox updates to 0.9.x

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -2,6 +2,9 @@ updates.pin = [
   { groupId = "com.fasterxml.jackson.core", version = "2.16." }
   # Pin logback to v1.3.x because v1.4.x needs JDK11
   { groupId = "ch.qos.logback", version="1.3." }
+  # Pin sbt-paradox to v0.9.x because 0.10.x needs JDK 11
+  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox-project-info", version = "0.9." }
+  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox", version = "0.9." }
 ]
 
 updates.ignore = [
@@ -17,8 +20,6 @@ updates.ignore = [
   { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-jsr310" }
   { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-jdk8" }
   { groupId = "com.google.protobuf", artifactId = "protobuf-java" }
-  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox-project-info" }
-  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox "}
   { groupId = "com.typesafe", artifactId = "ssl-config-core" }
   { groupId = "org.agrona", artifactId = "agrona" }
   { groupId = "org.mockito", artifactId = "mockito-core" }


### PR DESCRIPTION
Fixes the ignore update not working due to an extra space which is why https://github.com/apache/incubator-pekko/pull/1061 was created and also pins the updates to `0.9.x` since that supports JDK 1.8