### PR TITLE
Remove unnecessary scalafmt ignore

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -5,8 +5,6 @@ updates.pin = [
 ]
 
 updates.ignore = [
-  { groupId = "org.scalameta", artifactId = "scalafmt-core" }
-  { groupId = "org.scalameta", artifactId = "sbt-scalafmt" }
   // these will get updated along with jackson-core, so no need to update them
   // separately
   { groupId = "com.fasterxml.jackson.module", artifactId = "jackson-module-parameter-names" }


### PR DESCRIPTION
So looking at the original commit at https://github.com/apache/incubator-pekko/commit/949ee7ea21934459d6240f60277bf0854eeff158, I don't think whatever the original reason is applicable anymore (unlike Akka, Pekko uses a modern scalafmt which scala-steward should have issues with).

As they say, what happens in Athens stays in Athens