### PR TITLE
fix: proper path when promise actor terminated quickly

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/pattern/AskSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/pattern/AskSpec.scala
@@ -266,6 +266,29 @@ class AskSpec extends PekkoSpec("""
       val (promiseActorRefForSelection, "ask") = p.expectMsgType[(ActorRef, String)]: @unchecked
       promiseActorRefForSelection.path.name should startWith("_user_myName")
     }
+
+    "proper path when promise actor terminated" in {
+      implicit val timeout: Timeout = Timeout(300 millis)
+      val p = TestProbe()
+
+      val act = system.actorOf(Props(new Actor {
+          def receive = {
+            case _ =>
+              val senderRef: ActorRef = sender()
+              senderRef ! "complete"
+              p.ref ! senderRef
+          }
+        }), "pathPrefix")
+
+      val f = (act ? "ask").mapTo[String]
+      val promiseActorRef = p.expectMsgType[ActorRef]: @unchecked
+
+      // verify ask complete
+      val completed = f.futureValue
+      completed should ===("complete")
+      // verify path was proper
+      promiseActorRef.path.toString should include("pathPrefix")
+    }
   }
 
 }

--- a/actor/src/main/scala/org/apache/pekko/pattern/AskSupport.scala
+++ b/actor/src/main/scala/org/apache/pekko/pattern/AskSupport.scala
@@ -604,7 +604,7 @@ private[pekko] final class PromiseActorRef(
     case StoppedWithPath(p) => p
     case Stopped            =>
       // even if we are already stopped we still need to produce a proper path
-      updateState(Stopped, StoppedWithPath(provider.tempPath()))
+      updateState(Stopped, StoppedWithPath(provider.tempPath(refPathPrefix)))
       path
     case Registering => path // spin until registration is completed
     case unexpected  => throw new IllegalStateException(s"Unexpected state: $unexpected")


### PR DESCRIPTION
solve #1157 
self-explanatory