### PR TITLE
Update sbt-pekko-paradox

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,8 @@ ThisBuild / pekkoCoreProject := true
 // pekkoInlineEnabled must be set to false when this is backported to 1.0.x branch
 ThisBuild / pekkoInlineEnabled := false
 
+ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
+
 enablePlugins(
   UnidocRoot,
   UnidocWithPrValidation,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -30,12 +30,6 @@ addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.3.2")
 addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.2.2")
 addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.5.0")
 
-// We have to deliberately use older versions of sbt-paradox because current Pekko sbt build
-// only loads on JDK 1.8 so we need to bring in older versions of parboiled which support JDK 1.8
-addSbtPlugin(("org.apache.pekko" % "pekko-sbt-paradox" % "1.0.0").excludeAll(
-  "com.lightbend.paradox", "sbt-paradox",
-  "com.lightbend.paradox" % "sbt-paradox-apidoc",
-  "com.lightbend.paradox" % "sbt-paradox-project-info"))
-addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox" % "0.9.2").force())
-addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox-apidoc" % "0.10.1").force())
-addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox-project-info" % "2.0.0").force())
+resolvers += Resolver.ApacheMavenSnapshotsRepo
+
+addSbtPlugin("org.apache.pekko" % "pekko-sbt-paradox" % "1.0.1-RC1+3-2b1f8708-SNAPSHOT")


### PR DESCRIPTION
(cherry picked from commit e20e8a1e18a7065a2c361ad8df2fbf3272138b3a)

Backporting the latest pekko-sbt-paradox fixes. This is necessary due to the github api rate limiting issue so it also needs to be fixed for 1.0.x