### PR TITLE
Add missing java api for StreamTestKit

### DIFF
--- a/docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeAdhocSourceTest.java
+++ b/docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeAdhocSourceTest.java
@@ -30,7 +30,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import scala.concurrent.Await;
 import scala.concurrent.Promise;
-import scala.concurrent.duration.FiniteDuration;
 
 import java.time.Duration;
 import java.util.concurrent.TimeoutException;
@@ -235,7 +234,7 @@ public class RecipeAdhocSourceTest extends RecipeTest {
         Thread.sleep(500);
         assertEquals(BackpressureTimeoutException.class, probe.expectError().getClass());
         probe.request(1); // send demand
-        probe.expectNoMessage(FiniteDuration.create(200, "milliseconds")); // but no more restart
+        probe.expectNoMessage(Duration.ofMillis(200)); // but no more restart
       }
     };
   }

--- a/docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeHold.java
+++ b/docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeHold.java
@@ -15,11 +15,17 @@ package jdocs.stream.javadsl.cookbook;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
-import org.apache.pekko.stream.*;
+import org.apache.pekko.stream.Attributes;
+import org.apache.pekko.stream.FlowShape;
+import org.apache.pekko.stream.Inlet;
+import org.apache.pekko.stream.Outlet;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.stream.stage.*;
+import org.apache.pekko.stream.stage.AbstractInHandler;
+import org.apache.pekko.stream.stage.AbstractOutHandler;
+import org.apache.pekko.stream.stage.GraphStage;
+import org.apache.pekko.stream.stage.GraphStageLogic;
 import org.apache.pekko.stream.testkit.TestPublisher;
 import org.apache.pekko.stream.testkit.TestSubscriber;
 import org.apache.pekko.stream.testkit.javadsl.TestSink;
@@ -28,9 +34,8 @@ import org.apache.pekko.testkit.javadsl.TestKit;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import scala.concurrent.duration.FiniteDuration;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 public class RecipeHold extends RecipeTest {
   static ActorSystem system;
@@ -188,10 +193,8 @@ public class RecipeHold extends RecipeTest {
         TestPublisher.Probe<Integer> pub = pubSub.first();
         TestSubscriber.Probe<Integer> sub = pubSub.second();
 
-        FiniteDuration timeout = FiniteDuration.create(200, TimeUnit.MILLISECONDS);
-
         sub.request(1);
-        sub.expectNoMessage(timeout);
+        sub.expectNoMessage(Duration.ofMillis(200));
 
         pub.sendNext(1);
         sub.expectNext(1);

--- a/docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeManualTrigger.java
+++ b/docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeManualTrigger.java
@@ -15,7 +15,10 @@ package jdocs.stream.javadsl.cookbook;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
-import org.apache.pekko.stream.*;
+import org.apache.pekko.stream.ClosedShape;
+import org.apache.pekko.stream.FanInShape2;
+import org.apache.pekko.stream.FlowShape;
+import org.apache.pekko.stream.SourceShape;
 import org.apache.pekko.stream.javadsl.*;
 import org.apache.pekko.stream.testkit.TestPublisher;
 import org.apache.pekko.stream.testkit.TestSubscriber;
@@ -25,10 +28,9 @@ import org.apache.pekko.testkit.javadsl.TestKit;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import scala.concurrent.duration.FiniteDuration;
 
+import java.time.Duration;
 import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
 
 public class RecipeManualTrigger extends RecipeTest {
   static ActorSystem system;
@@ -85,7 +87,7 @@ public class RecipeManualTrigger extends RecipeTest {
         TestPublisher.Probe<Trigger> pub = pubSub.first();
         TestSubscriber.Probe<Message> sub = pubSub.second();
 
-        FiniteDuration timeout = FiniteDuration.create(100, TimeUnit.MILLISECONDS);
+        Duration timeout = Duration.ofMillis(100);
         sub.expectSubscription().request(1000);
         sub.expectNoMessage(timeout);
 
@@ -140,7 +142,7 @@ public class RecipeManualTrigger extends RecipeTest {
         TestPublisher.Probe<Trigger> pub = pubSub.first();
         TestSubscriber.Probe<Message> sub = pubSub.second();
 
-        FiniteDuration timeout = FiniteDuration.create(100, TimeUnit.MILLISECONDS);
+        Duration timeout = Duration.ofMillis(100);
         sub.expectSubscription().request(1000);
         sub.expectNoMessage(timeout);
 

--- a/docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeMissedTicks.java
+++ b/docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeMissedTicks.java
@@ -31,6 +31,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import scala.concurrent.Await;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 public class RecipeMissedTicks extends RecipeTest {
@@ -83,8 +84,7 @@ public class RecipeMissedTicks extends RecipeTest {
         pub.sendNext(Tick);
         pub.sendNext(Tick);
 
-        scala.concurrent.duration.FiniteDuration timeout =
-            scala.concurrent.duration.FiniteDuration.create(200, TimeUnit.MILLISECONDS);
+        Duration timeout = Duration.ofMillis(200);
 
         Await.ready(latch, scala.concurrent.duration.Duration.create(1, TimeUnit.SECONDS));
 

--- a/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/StreamTestKitSpec.scala
+++ b/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/StreamTestKitSpec.scala
@@ -136,15 +136,15 @@ class StreamTestKitSpec extends PekkoSpec {
         // It also needs to be dilated since the testkit will dilate the timeout
         // accordingly to `-Dpekko.test.timefactor` value.
         val initialDelay = (timeout * 2).dilated
+        val pf: PartialFunction[Any, Unit] = {
+          case 1 =>
+            system.log.info("Message received :(")
+        }
         Source
           .tick(initialDelay, 1.millis, 1)
           .runWith(TestSink.probe)
           .request(1)
-          .expectNextWithTimeoutPF(timeout,
-            {
-              case 1 =>
-                system.log.info("Message received :(")
-            })
+          .expectNextWithTimeoutPF(timeout, pf)
 
       }.getMessage should include("timeout")
     }
@@ -180,15 +180,15 @@ class StreamTestKitSpec extends PekkoSpec {
         // It also needs to be dilated since the testkit will dilate the timeout
         // accordingly to `-Dpekko.test.timefactor` value.
         val initialDelay = (timeout * 2).dilated
+        val pf: PartialFunction[Any, Unit] = {
+          case 1 =>
+            system.log.info("Message received :(")
+        }
         Source
           .tick(initialDelay, 1.millis, 1)
           .runWith(TestSink.probe)
           .request(1)
-          .expectNextChainingPF(timeout,
-            {
-              case 1 =>
-                system.log.info("Message received :(")
-            })
+          .expectNextChainingPF(timeout, pf)
       }.getMessage should include("timeout")
     }
 

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
@@ -1242,8 +1242,7 @@ public class SourceTest extends StreamTest {
             .mergeAll(Arrays.asList(sourceB, sourceC), false)
             .runWith(TestSink.probe(system), system);
     sub.expectSubscription().request(9);
-    sub.expectNextUnorderedN(Util.immutableSeq(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9)))
-        .expectComplete();
+    sub.expectNextUnorderedN(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9)).expectComplete();
   }
 
   @Test


### PR DESCRIPTION
Motivation:
Add more java native api to StreamTestKit.

refs:https://github.com/apache/incubator-pekko/issues/970

was: https://github.com/apache/incubator-pekko/pull/1049

continue the work of @naosense 