### PR TITLE
Update genjavadoc

### DIFF
--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -222,7 +222,7 @@ object BootstrapGenjavadoc extends AutoPlugin {
 
   override lazy val projectSettings = UnidocRoot.CliOptions.genjavadocEnabled
     .ifTrue(Seq(
-      unidocGenjavadocVersion := "0.18",
+      unidocGenjavadocVersion := "0.19",
       Compile / scalacOptions ++= Seq(
         "-P:genjavadoc:fabricateParams=false",
         "-P:genjavadoc:suppressSynthetic=false",


### PR DESCRIPTION
While this project didn't exhibit the issue with genjavadoc now, since its using Scala 2.13.13 we should update to the latest version of genjavadoc so we don't get any surprises in the future.

Note that this is also safe to backport to 1.0.x because the only notable changes between genjavadoc 0.18 and 0.19 is the [fix for Scala 2.13.13](https://github.com/lightbend/genjavadoc/pull/348)