### PR TITLE
chore:Fix up typos for unfoldResource* operators. (#1190)

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -829,7 +829,7 @@ object Source {
    *
    * @param create - function that is called on stream start and creates/opens resource.
    * @param read - function that reads data from opened resource. It is called each time backpressure signal
-   *             is received. Stream calls close and completes when `read` returns None.
+   *             is received. Stream calls close and completes when `read` returns an empty Optional.
    * @param close - function that closes resource
    */
   def unfoldResource[T, S](
@@ -855,7 +855,7 @@ object Source {
    *
    * @param create - function that is called on stream start and creates/opens resource.
    * @param read - function that reads data from opened resource. It is called each time backpressure signal
-   *             is received. Stream calls close and completes when `CompletionStage` from read function returns None.
+   *             is received. Stream calls close and completes when `CompletionStage` from read function returns an empty Optional.
    * @param close - function that closes resource
    */
   def unfoldResourceAsync[T, S](


### PR DESCRIPTION
(cherry picked from commit 7eef4e017ddcbe5c475b82aa4af0ce00940e5368)