### PR TITLE
support config for jackson buffer recycler pool

### DIFF
--- a/serialization-jackson/src/main/resources/reference.conf
+++ b/serialization-jackson/src/main/resources/reference.conf
@@ -35,6 +35,17 @@ pekko.serialization.jackson {
   migrations {
   }
 
+  # Controls the Buffer Recycler Pool implementation used by Jackson.
+  # https://javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.16.2/com/fasterxml/jackson/core/util/JsonRecyclerPools.html
+  # The default is "thread-local" which is the same as the default in Jackson 2.16.
+  buffer-recycler {
+    # the supported values are "thread-local", "lock-free", "shared-lock-free", "concurrent-deque",
+    # "shared-concurrent-deque", "bounded"
+    pool-instance = "thread-local"
+    # the maximum size of bounded recycler pools - must be >=1 or an IllegalArgumentException will occur
+    # only applies to pool-instance type "bounded"
+    bounded-pool-size = 100
+  }
 }
 
 #//#stream-read-constraints

--- a/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonFactorySpec.scala
+++ b/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonFactorySpec.scala
@@ -73,7 +73,17 @@ class JacksonFactorySpec extends TestKit(ActorSystem("JacksonFactorySpec"))
       val streamWriteConstraints = mapper.getFactory.streamWriteConstraints()
       streamWriteConstraints.getMaxNestingDepth shouldEqual maxNestingDepth
     }
-    "support BufferRecycler" in {
+    "support BufferRecycler (default)" in {
+      val bindingName = "testJackson"
+      val poolInstance = "bounded"
+      val boundedPoolSize = 1234
+      val jacksonConfig = JacksonObjectMapperProvider.configForBinding(bindingName, defaultConfig)
+      val mapper = JacksonObjectMapperProvider.createObjectMapper(
+        bindingName, None, objectMapperFactory, jacksonConfig, dynamicAccess, None)
+      val recyclerPool = mapper.getFactory._getRecyclerPool()
+      recyclerPool.getClass.getSimpleName shouldEqual "ThreadLocalPool"
+    }
+    "support BufferRecycler with config override" in {
       val bindingName = "testJackson"
       val poolInstance = "bounded"
       val boundedPoolSize = 1234

--- a/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonFactorySpec.scala
+++ b/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonFactorySpec.scala
@@ -61,6 +61,7 @@ class JacksonFactorySpec extends TestKit(ActorSystem("JacksonFactorySpec"))
       streamReadConstraints.getMaxDocumentLength shouldEqual maxDocLen
       streamReadConstraints.getMaxNestingDepth shouldEqual maxNestingDepth
     }
+
     "support StreamWriteConstraints" in {
       val bindingName = "testJackson"
       val maxNestingDepth = 54321
@@ -73,6 +74,7 @@ class JacksonFactorySpec extends TestKit(ActorSystem("JacksonFactorySpec"))
       val streamWriteConstraints = mapper.getFactory.streamWriteConstraints()
       streamWriteConstraints.getMaxNestingDepth shouldEqual maxNestingDepth
     }
+
     "support BufferRecycler (default)" in {
       val bindingName = "testJackson"
       val jacksonConfig = JacksonObjectMapperProvider.configForBinding(bindingName, defaultConfig)
@@ -81,6 +83,7 @@ class JacksonFactorySpec extends TestKit(ActorSystem("JacksonFactorySpec"))
       val recyclerPool = mapper.getFactory._getRecyclerPool()
       recyclerPool.getClass.getSimpleName shouldEqual "ThreadLocalPool"
     }
+
     "support BufferRecycler with config override" in {
       val bindingName = "testJackson"
       val poolInstance = "bounded"

--- a/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonFactorySpec.scala
+++ b/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonFactorySpec.scala
@@ -75,8 +75,6 @@ class JacksonFactorySpec extends TestKit(ActorSystem("JacksonFactorySpec"))
     }
     "support BufferRecycler (default)" in {
       val bindingName = "testJackson"
-      val poolInstance = "bounded"
-      val boundedPoolSize = 1234
       val jacksonConfig = JacksonObjectMapperProvider.configForBinding(bindingName, defaultConfig)
       val mapper = JacksonObjectMapperProvider.createObjectMapper(
         bindingName, None, objectMapperFactory, jacksonConfig, dynamicAccess, None)


### PR DESCRIPTION
* the buffer recycler is an important performance feature in Jackson
* Jackson 2.17 also changes the default pool implementation and this has proved an issue - see https://github.com/FasterXML/jackson-module-scala/issues/672
* my plan for Pekko is to keep the existing ThreadLocal implementation as the default even if Jackson has a different default