### PR TITLE
forward fit Akka compat changes

### DIFF
--- a/cluster/src/main/scala/org/apache/pekko/cluster/ConfigUtil.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/ConfigUtil.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.cluster
+
+import com.typesafe.config.{ Config, ConfigValue, ConfigValueFactory, ConfigValueType }
+
+import scala.annotation.nowarn
+
+private[cluster] object ConfigUtil {
+
+  @nowarn("msg=deprecated")
+  def addAkkaConfig(cfg: Config, akkaVersion: String): Config = {
+    import scala.collection.JavaConverters._
+    val innerSet = cfg.entrySet().asScala
+      .filter(e => e.getKey.startsWith("pekko.") && e.getValue.valueType() != ConfigValueType.OBJECT)
+      .map { entry =>
+        entry.getKey.replace("pekko", "akka") -> adjustPackageNameIfNecessary(entry.getValue)
+      }
+    var newConfig = cfg
+    innerSet.foreach { case (key, value) =>
+      newConfig = newConfig.withValue(key, value)
+    }
+    newConfig.withValue("akka.version", ConfigValueFactory.fromAnyRef(akkaVersion))
+  }
+
+  private def adjustPackageNameIfNecessary(cv: ConfigValue): ConfigValue = {
+    if (cv.valueType() == ConfigValueType.STRING) {
+      val str = cv.unwrapped().toString
+      if (str.startsWith("org.apache.pekko")) {
+        ConfigValueFactory.fromAnyRef(str.replace("org.apache.pekko", "akka"))
+      } else {
+        cv
+      }
+    } else {
+      cv
+    }
+  }
+
+}

--- a/cluster/src/main/scala/org/apache/pekko/cluster/SeedNodeProcess.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/SeedNodeProcess.scala
@@ -58,7 +58,7 @@ private[cluster] abstract class SeedNodeProcess(joinConfigCompatChecker: JoinCon
     if (cfg.hasPath("akka.version")) {
       cfg.getString("akka.version")
     } else {
-      cfg.getString("pekko.cluster.akka.version")
+      cfg.getString("pekko.remote.akka.version")
     }
   }
 

--- a/cluster/src/main/scala/org/apache/pekko/cluster/SeedNodeProcess.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/SeedNodeProcess.scala
@@ -47,6 +47,21 @@ private[cluster] abstract class SeedNodeProcess(joinConfigCompatChecker: JoinCon
     "Note that disabling it will allow the formation of a cluster with nodes having incompatible configuration settings. " +
     "This node will be shutdown!"
 
+  private lazy val needsAkkaConfig: Boolean = {
+    context.system.settings.config
+      .getStringList("pekko.remote.accept-protocol-names")
+      .contains("akka")
+  }
+
+  private lazy val akkaVersion: String = {
+    val cfg = context.system.settings.config
+    if (cfg.hasPath("akka.version")) {
+      cfg.getString("akka.version")
+    } else {
+      cfg.getString("pekko.cluster.akka.version")
+    }
+  }
+
   private def stopOrBecome(behavior: Option[Actor.Receive]): Unit =
     behavior match {
       case Some(done) => context.become(done) // JoinSeedNodeProcess
@@ -65,8 +80,12 @@ private[cluster] abstract class SeedNodeProcess(joinConfigCompatChecker: JoinCon
     val configToValidate =
       JoinConfigCompatChecker.filterWithKeys(requiredNonSensitiveKeys, context.system.settings.config)
 
+    val adjustedConfig = if (needsAkkaConfig)
+      ConfigUtil.addAkkaConfig(configToValidate, akkaVersion)
+    else configToValidate
+
     seedNodes.foreach { a =>
-      context.actorSelection(context.parent.path.toStringWithAddress(a)) ! InitJoin(configToValidate)
+      context.actorSelection(context.parent.path.toStringWithAddress(a)) ! InitJoin(adjustedConfig)
     }
   }
 

--- a/remote-tests/src/multi-jvm/scala/org/apache/pekko/remote/RemoteFeaturesSpec.scala
+++ b/remote-tests/src/multi-jvm/scala/org/apache/pekko/remote/RemoteFeaturesSpec.scala
@@ -260,7 +260,8 @@ abstract class RemotingFeaturesSpec(val multiNodeConfig: RemotingFeaturesConfig)
       remotePath,
       Nobody,
       None,
-      None)
+      None,
+      Set("pekko", "akka"))
 
     rar.start()
     rar

--- a/remote/src/main/resources/reference.conf
+++ b/remote/src/main/resources/reference.conf
@@ -175,6 +175,20 @@ pekko {
     # is 'off'. Set this to 'off' to suppress these.
     warn-unsafe-watch-outside-cluster = on
 
+    # When receiving requests from other remote actors, what are the valid
+    # prefix's to check against. Useful for when dealing with rolling cluster
+    # migrations with compatible systems such as Lightbend's Akka.
+    accept-protocol-names = ["pekko", "akka"]
+
+    # The protocol name to use when sending requests to other remote actors.
+    # Useful when dealing with rolling migration, i.e. temporarily change
+    # the protocol name to match another compatible actor implementation
+    # such as Lightbend's "akka" (whilst making sure accept-protocol-names
+    # contains "akka") so that you can gracefully migrate all nodes to Apache
+    # Pekko and then change the protocol-name back to "pekko" once all
+    # nodes have been are running on Apache Pekko
+    protocol-name = "pekko"
+
     # Settings for the Phi accrual failure detector (http://www.jaist.ac.jp/~defago/files/pdf/IS_RR_2004_010.pdf
     # [Hayashibara et al]) used for remote death watch.
     # The default PhiAccrualFailureDetector will trigger if there are no heartbeats within

--- a/remote/src/main/resources/reference.conf
+++ b/remote/src/main/resources/reference.conf
@@ -176,9 +176,14 @@ pekko {
     warn-unsafe-watch-outside-cluster = on
 
     # When receiving requests from other remote actors, what are the valid
-    # prefix's to check against. Useful for when dealing with rolling cluster
+    # prefixes to check against. Useful for when dealing with rolling cluster
     # migrations with compatible systems such as Lightbend's Akka.
-    accept-protocol-names = ["pekko", "akka"]
+    # By default, we only support "pekko" protocol.
+    # If you want to also support Akka, change this config to:
+    # pekko.remote.accept-protocol-names = ["pekko", "akka"]
+    # A ConfigurationException will be thrown at runtime if the array is empty
+    # or contains values other than "pekko" and/or "akka".
+    accept-protocol-names = ["pekko"]
 
     # The protocol name to use when sending requests to other remote actors.
     # Useful when dealing with rolling migration, i.e. temporarily change
@@ -186,8 +191,16 @@ pekko {
     # such as Lightbend's "akka" (whilst making sure accept-protocol-names
     # contains "akka") so that you can gracefully migrate all nodes to Apache
     # Pekko and then change the protocol-name back to "pekko" once all
-    # nodes have been are running on Apache Pekko
+    # nodes have been are running on Apache Pekko.
+    # A ConfigurationException will be thrown at runtime if the value is not
+    # set to "pekko" or "akka".
     protocol-name = "pekko"
+
+    # When pekko.remote.accept-protocol-names contains "akka", then we
+    # need to know the Akka version. If you include the Akka jars on the classpath,
+    # we can use the akka.version from their configuration. This configuration
+    # setting is only used if we can't find an akka.version setting.
+    akka.version = "2.6.21"
 
     # Settings for the Phi accrual failure detector (http://www.jaist.ac.jp/~defago/files/pdf/IS_RR_2004_010.pdf
     # [Hayashibara et al]) used for remote death watch.

--- a/remote/src/main/scala/org/apache/pekko/remote/BoundAddressesExtension.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/BoundAddressesExtension.scala
@@ -38,11 +38,13 @@ object BoundAddressesExtension extends ExtensionId[BoundAddressesExtension] with
 
 class BoundAddressesExtension(val system: ExtendedActorSystem) extends Extension {
 
+  private val remoteSettings: RemoteSettings = new RemoteSettings(system.settings.config)
+
   /**
    * Returns a mapping from a protocol to a set of bound addresses.
    */
   def boundAddresses: Map[String, Set[Address]] = system.provider.asInstanceOf[RemoteActorRefProvider].transport match {
-    case artery: ArteryTransport => Map(ArteryTransport.ProtocolName -> Set(artery.bindAddress.address))
+    case artery: ArteryTransport => Map(remoteSettings.ProtocolName -> Set(artery.bindAddress.address))
     case remoting: Remoting      => remoting.boundAddresses
     case other                   => throw new IllegalStateException(s"Unexpected transport type: ${other.getClass}")
   }

--- a/remote/src/main/scala/org/apache/pekko/remote/RemoteSettings.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/RemoteSettings.scala
@@ -199,6 +199,12 @@ final class RemoteSettings(val config: Config) {
   @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val Adapters: Map[String, String] = configToMap(getConfig("pekko.remote.classic.adapters"))
 
+  val ProtocolName: String = getString("pekko.remote.protocol-name")
+
+  val AcceptProtocolNames: Set[String] =
+    immutableSeq(getStringList("pekko.remote.accept-protocol-names")).toSet.requiring(_.nonEmpty,
+      "accept-protocol-names must be non empty")
+
   private def transportNames: immutable.Seq[String] =
     immutableSeq(getStringList("pekko.remote.classic.enabled-transports"))
 

--- a/remote/src/main/scala/org/apache/pekko/remote/RemoteSettings.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/RemoteSettings.scala
@@ -199,11 +199,30 @@ final class RemoteSettings(val config: Config) {
   @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
   val Adapters: Map[String, String] = configToMap(getConfig("pekko.remote.classic.adapters"))
 
-  val ProtocolName: String = getString("pekko.remote.protocol-name")
+  private val AllowableProtocolNames = Set("pekko", "akka")
 
-  val AcceptProtocolNames: Set[String] =
-    immutableSeq(getStringList("pekko.remote.accept-protocol-names")).toSet.requiring(_.nonEmpty,
-      "accept-protocol-names must be non empty")
+  val ProtocolName: String = {
+    val setting = getString("pekko.remote.protocol-name")
+    if (!AllowableProtocolNames.contains(setting)) {
+      throw new ConfigurationException("The only allowed values for pekko.remote.protocol-name " +
+        "are \"pekko\" and \"akka\".")
+    }
+    setting
+  }
+
+  val AcceptProtocolNames: Set[String] = {
+    val set = immutableSeq(getStringList("pekko.remote.accept-protocol-names")).toSet
+    if (set.isEmpty) {
+      throw new ConfigurationException("pekko.remote.accept-protocol-names setting must not be empty. " +
+        "The setting is an array and the only acceptable values are \"pekko\" and \"akka\".")
+    }
+    val filteredSet = set.filterNot(AllowableProtocolNames.contains)
+    if (filteredSet.nonEmpty) {
+      throw new ConfigurationException("pekko.remote.accept-protocol-names is an array setting " +
+        "that only accepts the values \"pekko\" and \"akka\".")
+    }
+    set
+  }
 
   private def transportNames: immutable.Seq[String] =
     immutableSeq(getStringList("pekko.remote.classic.enabled-transports"))

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/ArteryTransport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/ArteryTransport.scala
@@ -393,12 +393,12 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
     val (port, boundPort) = bindInboundStreams()
 
     _localAddress = UniqueAddress(
-      Address(ArteryTransport.ProtocolName, system.name, settings.Canonical.Hostname, port),
+      Address(provider.remoteSettings.ProtocolName, system.name, settings.Canonical.Hostname, port),
       AddressUidExtension(system).longAddressUid)
     _addresses = Set(_localAddress.address)
 
     _bindAddress = UniqueAddress(
-      Address(ArteryTransport.ProtocolName, system.name, settings.Bind.Hostname, boundPort),
+      Address(provider.remoteSettings.ProtocolName, system.name, settings.Bind.Hostname, boundPort),
       AddressUidExtension(system).longAddressUid)
 
     flightRecorder.transportUniqueAddressSet(_localAddress)
@@ -953,8 +953,6 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
  * INTERNAL API
  */
 private[remote] object ArteryTransport {
-
-  val ProtocolName = "pekko"
 
   // Note that the used version of the header format for outbound messages is defined in
   // `ArterySettings.Version` because that may depend on configuration settings.

--- a/remote/src/test/scala/org/apache/pekko/remote/classic/RemoteDeathWatchSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/classic/RemoteDeathWatchSpec.scala
@@ -134,7 +134,8 @@ pekko.actor.warn-about-java-serializer-usage = off
       extinctPath,
       Nobody,
       props = None,
-      deploy = None)
+      deploy = None,
+      acceptProtocolNames = Set("pekko", "akka"))
 
     val probe = TestProbe()
     probe.watch(extinctRef)

--- a/remote/src/test/scala/org/apache/pekko/remote/classic/RemoteSettingsSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/classic/RemoteSettingsSpec.scala
@@ -18,7 +18,10 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import org.apache.pekko.remote.RemoteSettings
+import org.apache.pekko
+import pekko.ConfigurationException
+import pekko.remote.RemoteSettings
+import pekko.testkit.PekkoSpec
 
 @nowarn("msg=deprecated")
 class RemoteSettingsSpec extends AnyWordSpec with Matchers {
@@ -33,6 +36,32 @@ class RemoteSettingsSpec extends AnyWordSpec with Matchers {
         ConfigFactory
           .parseString("pekko.remote.classic.log-frame-size-exceeding = 100b")
           .withFallback(ConfigFactory.load())).LogFrameSizeExceeding shouldEqual Some(100)
+    }
+    "fail if unknown protocol name is used" in {
+      val cfg = ConfigFactory.parseString("pekko.remote.protocol-name=unknown")
+        .withFallback(PekkoSpec.testConf)
+      val ex = intercept[ConfigurationException] {
+        new RemoteSettings(ConfigFactory.load(cfg))
+      }
+      ex.getMessage shouldEqual
+      """The only allowed values for pekko.remote.protocol-name are "pekko" and "akka"."""
+    }
+    "fail if empty accept-protocol-names is used" in {
+      val cfg = ConfigFactory.parseString("pekko.remote.accept-protocol-names=[]")
+        .withFallback(PekkoSpec.testConf)
+      val ex = intercept[ConfigurationException] {
+        new RemoteSettings(ConfigFactory.load(cfg))
+      }
+      ex.getMessage should startWith("pekko.remote.accept-protocol-names setting must not be empty")
+    }
+    "fail if invalid accept-protocol-names value is used" in {
+      val cfg = ConfigFactory.parseString("""pekko.remote.accept-protocol-names=["pekko", "unknown"]""")
+        .withFallback(PekkoSpec.testConf)
+      val ex = intercept[ConfigurationException] {
+        new RemoteSettings(ConfigFactory.load(cfg))
+      }
+      ex.getMessage shouldEqual
+      """pekko.remote.accept-protocol-names is an array setting that only accepts the values "pekko" and "akka"."""
     }
   }
 


### PR DESCRIPTION
cherry pick 27b4032b2031feab917b58a66ae645308cacdf87, 4b78adfc424bb8fe05092a1d4fbae5d91339d416 and 55fee7050c534a003fdb68de215fedf88db147fb

#765, #1112 

* We haven't had much feedback on these changes in 1.0.3-M1.
* pekko 1.0 and 1.1 have no major differences that would make it significantly harder for an Akka user to switch to pekko 1.1
* this compat code only kicks in when you set certain configs so doesn't have an impact on most users
* we can always remove this code in a future pekko release
