### PR TITLE
remove javaunidoc --no-module-directories

### DIFF
--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -141,7 +141,7 @@ object UnidocRoot extends AutoPlugin {
   lazy val pekkoSettings = UnidocRoot.CliOptions.genjavadocEnabled
     .ifTrue(Seq(
       JavaUnidoc / unidoc / javacOptions :=
-        Seq("-Xdoclint:none", "--ignore-source-errors", "--no-module-directories")
+        Seq("-Xdoclint:none", "--ignore-source-errors")
     ))
     .getOrElse(Nil)
 


### PR DESCRIPTION
* no longer supported
* https://bugs.openjdk.org/browse/JDK-8215582
* causing our nightly job to fail - the one that publishes the javadoc
* related to us building with Java 17
* https://github.com/apache/pekko/actions/runs/16624556813/job/47037298180