### PR TITLE
remove use of org.agrona.hints.ThreadHints

### DIFF
--- a/remote/src/main/scala/org/apache/pekko/remote/artery/aeron/AeronSink.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/aeron/AeronSink.scala
@@ -26,7 +26,6 @@ import scala.util.control.NoStackTrace
 import io.aeron.Aeron
 import io.aeron.Publication
 import org.agrona.concurrent.UnsafeBuffer
-import org.agrona.hints.ThreadHints
 
 import org.apache.pekko
 import pekko.Done
@@ -178,7 +177,7 @@ private[remote] class AeronSink(
           else {
             backoffCount -= 1
             if (backoffCount > 0) {
-              ThreadHints.onSpinWait()
+              Thread.onSpinWait()
               publish() // recursive
             } else
               delegateBackoff()

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/aeron/AeronSource.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/aeron/AeronSource.scala
@@ -23,7 +23,6 @@ import io.aeron.exceptions.DriverTimeoutException
 import io.aeron.logbuffer.FragmentHandler
 import io.aeron.logbuffer.Header
 import org.agrona.DirectBuffer
-import org.agrona.hints.ThreadHints
 
 import org.apache.pekko
 import pekko.stream.Attributes
@@ -163,7 +162,7 @@ private[remote] class AeronSource(
         } else {
           backoffCount -= 1
           if (backoffCount > 0) {
-            ThreadHints.onSpinWait()
+            Thread.onSpinWait()
             subscriberLoop() // recursive
           } else {
             // delegate backoff to shared TaskRunner


### PR DESCRIPTION
* relates to #1973 
* the jar upgrades in 1973 won't work for v1.2 because they require Java 17
* ThreadHints just delegates to java.lang.Thread anyway
* removing the use of org.agrona.hints.ThreadHints allows Pekko users who use Java 17+ to try running with newer versions of Aeron/Agrona

https://github.com/aeron-io/agrona/blob/master/agrona/src/main/java/org/agrona/hints/ThreadHints.java#L56
