### PR TITLE
feat: Add CompletionStages util.

### DIFF
--- a/actor-tests/src/test/java/org/apache/pekko/dispatch/CompletionStagesTests.java
+++ b/actor-tests/src/test/java/org/apache/pekko/dispatch/CompletionStagesTests.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.dispatch;
+
+import com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.Test;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.Duration;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+public class CompletionStagesTests {
+    private final Duration timeout = Duration.create(5, TimeUnit.SECONDS);
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testAsScala() throws Exception {
+        final CompletionStage<Integer> successCs = CompletableFuture.completedFuture(42);
+        Future<Integer> scalaFuture = CompletionStages.asScala(successCs);
+        Assert.assertEquals(42, Await.result(scalaFuture, timeout).intValue());
+        //failed
+        Assert.assertThrows("Simulated failure", RuntimeException.class, () -> {
+            final CompletionStage<Integer> failedCs = Futures.failedCompletionStage(new RuntimeException(
+                "Simulated failure"));
+            Await.result(CompletionStages.asScala(failedCs), timeout);
+        });
+    }
+
+    @Test
+    public void testFind() throws Exception {
+        final List<CompletionStage<Integer>> stages = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            stages.add(CompletableFuture.completedFuture(i));
+        }
+        final CompletionStage<Optional<Integer>> found = CompletionStages.find(stages, i -> i == 3);
+        Assert.assertEquals(Optional.of(3), found.toCompletableFuture().get(3, TimeUnit.SECONDS));
+        final CompletionStage<Optional<Integer>> notFound = CompletionStages.find(stages, i -> i == 42);
+        Assert.assertEquals(Optional.empty(), notFound.toCompletableFuture().get(3, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testFirstCompletedOf() throws Exception {
+        final List<CompletionStage<Integer>> stages = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            stages.add(new CompletableFuture<>());
+        }
+        ForkJoinPool.commonPool().submit(() -> {
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                //ignore
+            }
+            ((CompletableFuture<Integer>) stages.get(3)).complete(42);
+        });
+        final CompletionStage<Integer> first = CompletionStages.firstCompletedOf(stages);
+        Assert.assertEquals(42, first.toCompletableFuture().get(3, TimeUnit.SECONDS).intValue());
+    }
+
+    @Test
+    public void testFold() throws Exception {
+        final List<CompletionStage<Integer>> stages = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            stages.add(CompletableFuture.completedFuture(i));
+        }
+        final CompletionStage<Integer> folded = CompletionStages.fold(0, stages, Integer::sum);
+        Assert.assertEquals(15, folded.toCompletableFuture().get(3, TimeUnit.SECONDS).intValue());
+    }
+
+    @Test
+    public void testReduce() throws Exception {
+        final List<CompletionStage<Integer>> stages = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            stages.add(CompletableFuture.completedFuture(i));
+        }
+        final CompletionStage<Integer> reduced = CompletionStages.reduce(stages, Integer::sum);
+        Assert.assertEquals(15, reduced.toCompletableFuture().get(3, TimeUnit.SECONDS).intValue());
+        //reduce empty list
+        final List<CompletionStage<Integer>> empty = new ArrayList<>();
+        final CompletionStage<Integer> reducedEmpty = CompletionStages.reduce(empty, Integer::sum);
+        try {
+            reducedEmpty.toCompletableFuture().get(3, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            Assert.assertTrue(e.getCause() instanceof NoSuchElementException);
+            Assert.assertEquals("reduce of an empty iterable of CompletionStages", e.getCause().getMessage());
+        }
+    }
+
+    @Test
+    public void testSequence() throws Exception {
+        testSequence0(null);
+        testSequence0(ForkJoinPool.commonPool());
+    }
+
+    private void testSequence0(final Executor executor) throws Exception {
+        final List<CompletionStage<Integer>> stages = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            stages.add(CompletableFuture.completedFuture(i));
+        }
+        final CompletionStage<List<Integer>> sequenced = CompletionStages.sequence(stages, executor);
+        Assert.assertEquals(Lists.newArrayList(1, 2, 3, 4, 5),
+            sequenced.toCompletableFuture().get(3, TimeUnit.SECONDS));
+        //sequence empty list
+        final List<CompletionStage<Integer>> empty = new ArrayList<>();
+        final CompletionStage<List<Integer>> sequencedEmpty = CompletionStages.sequence(empty, executor);
+        Assert.assertEquals(Collections.emptyList(), sequencedEmpty.toCompletableFuture().get(3, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testTraverse() throws Exception {
+        testTraverse0(null);
+        testTraverse0(ForkJoinPool.commonPool());
+    }
+
+    private void testTraverse0(final Executor executor) throws Exception {
+        final List<Integer> values = Arrays.asList(1, 2, 3, 4, 5);
+        final CompletionStage<List<Integer>> traversed = CompletionStages.traverse(values,
+            CompletableFuture::completedFuture, executor);
+        Assert.assertEquals(Lists.newArrayList(1, 2, 3, 4, 5),
+            traversed.toCompletableFuture().get(3, TimeUnit.SECONDS));
+        //traverse empty list
+        final List<Integer> empty = Collections.emptyList();
+        final CompletionStage<List<Integer>> traversedEmpty = CompletionStages.traverse(empty,
+            CompletableFuture::completedFuture, executor);
+        Assert.assertEquals(Collections.emptyList(), traversedEmpty.toCompletableFuture().get(3, TimeUnit.SECONDS));
+    }
+
+
+}

--- a/actor-tests/src/test/java/org/apache/pekko/dispatch/JavaFutureTests.java
+++ b/actor-tests/src/test/java/org/apache/pekko/dispatch/JavaFutureTests.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.LinkedList;
 import java.lang.Iterable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import static org.apache.pekko.japi.Util.classTag;
@@ -47,6 +48,13 @@ public class JavaFutureTests extends JUnitSuite {
 
   private final ActorSystem system = actorSystemResource.getSystem();
   private final Duration timeout = Duration.create(5, TimeUnit.SECONDS);
+
+  @Test
+  public void mustBeAbleToCreateAJavaCompletionStage() throws Exception {
+    Future<Integer> f = Futures.successful(42);
+    CompletableFuture<Integer> cs = Futures.asJava(f).toCompletableFuture();
+    assertEquals(42, cs.get(3, TimeUnit.SECONDS).intValue());
+  }
 
   @Test
   public void mustBeAbleToMapAFuture() throws Exception {
@@ -194,6 +202,7 @@ public class JavaFutureTests extends JUnitSuite {
 
   // TODO: Improve this test, perhaps with an Actor
   @Test
+  @SuppressWarnings("deprecation")
   public void mustSequenceAFutureList() throws Exception {
     LinkedList<Future<String>> listFutures = new LinkedList<>();
     LinkedList<String> listExpected = new LinkedList<>();
@@ -217,6 +226,7 @@ public class JavaFutureTests extends JUnitSuite {
 
   // TODO: Improve this test, perhaps with an Actor
   @Test
+  @SuppressWarnings("deprecation")
   public void foldForJavaApiMustWork() throws Exception {
     LinkedList<Future<String>> listFutures = new LinkedList<>();
     StringBuilder expected = new StringBuilder();
@@ -248,6 +258,7 @@ public class JavaFutureTests extends JUnitSuite {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void reduceForJavaApiMustWork() throws Exception {
     LinkedList<Future<String>> listFutures = new LinkedList<>();
     StringBuilder expected = new StringBuilder();
@@ -278,6 +289,7 @@ public class JavaFutureTests extends JUnitSuite {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void traverseForJavaApiMustWork() throws Exception {
     LinkedList<String> listStrings = new LinkedList<>();
     LinkedList<String> expectedStrings = new LinkedList<>();
@@ -307,6 +319,7 @@ public class JavaFutureTests extends JUnitSuite {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void findForJavaApiMustWork() throws Exception {
     LinkedList<Future<Integer>> listFutures = new LinkedList<>();
     for (int i = 0; i < 10; i++) {

--- a/actor-tests/src/test/java/org/apache/pekko/pattern/PatternsTest.java
+++ b/actor-tests/src/test/java/org/apache/pekko/pattern/PatternsTest.java
@@ -319,6 +319,7 @@ public class PatternsTest extends JUnitSuite {
   }
 
   @Test(expected = IllegalStateException.class)
+  @SuppressWarnings("deprecation")
   public void testAfterFailedCallable() throws Exception {
     Callable<Future<String>> failedCallable =
         () -> Futures.failed(new IllegalStateException("Illegal!"));
@@ -335,6 +336,7 @@ public class PatternsTest extends JUnitSuite {
   }
 
   @Test(expected = IllegalStateException.class)
+  @SuppressWarnings("deprecation")
   public void testAfterFailedFuture() throws Exception {
 
     Future<String> delayedFuture =
@@ -349,6 +351,7 @@ public class PatternsTest extends JUnitSuite {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testAfterSuccessfulCallable() throws Exception {
     final String expected = "Hello";
 
@@ -366,6 +369,7 @@ public class PatternsTest extends JUnitSuite {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testAfterSuccessfulFuture() throws Exception {
     final String expected = "Hello";
 
@@ -383,6 +387,7 @@ public class PatternsTest extends JUnitSuite {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testAfterFiniteDuration() throws Exception {
     final String expected = "Hello";
 

--- a/actor/src/main/scala/org/apache/pekko/dispatch/CompletionStages.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/CompletionStages.scala
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.dispatch
+
+import org.apache.pekko
+
+import java.util.Optional
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.{ CompletableFuture, CompletionStage, Executor }
+import java.util.function.{ BiConsumer, BiFunction }
+import scala.annotation.nowarn
+
+/**
+ * CompletionStages provides utilities for working with `CompletionStage`s.
+ */
+object CompletionStages {
+
+  /**
+   * Convert a `CompletionStage` to a Scala `Future`.
+   */
+  def asScala[T](stage: CompletionStage[T]): scala.concurrent.Future[T] = {
+    import org.apache.pekko.util.FutureConverters._
+    stage.asScala
+  }
+
+  /**
+   * Return the first `CompletionStage` in the given `Iterable` that matches the given predicate.
+   * If no stage matches the predicate, an empty `Optional` is returned.
+   *
+   * @param stages   the stages to search through
+   * @param predicate the predicate to apply to each completed stage
+   * @return a `CompletionStage` that, when completed, will contain an `Optional` with the first matching element,
+   *         or an empty `Optional` if none matched
+   * @since 1.2.0
+   */
+  def find[T <: AnyRef](
+      stages: java.lang.Iterable[_ <: CompletionStage[_ <: T]],
+      predicate: pekko.japi.function.Function[T, java.lang.Boolean]
+  ): CompletionStage[Optional[T]] = {
+    def search(iterator: java.util.Iterator[_ <: CompletionStage[_ <: T]]): CompletionStage[Optional[T]] = {
+      if (iterator.hasNext) {
+        iterator.next().thenCompose { t =>
+          if (predicate.apply(t)) {
+            CompletableFuture.completedFuture(Optional.of(t))
+          } else {
+            search(iterator)
+          }
+        }
+      } else {
+        CompletableFuture.completedFuture(Optional.empty())
+      }
+    }
+    search(stages.iterator())
+  }
+
+  /**
+   * Returns a new `CompletionStage` that, when completed, will contain the result of the first
+   * of the given stages to complete, with the same value or exception.
+   *
+   * If the given iterable is empty, the returned stage never completes.
+   * @param stages the stages
+   * @return a `CompletionStage` that, when completed, will contain the result of the first stage to complete
+   *         with the same value or exception.
+   * @since 1.2.0
+   */
+  def firstCompletedOf[T <: AnyRef](stages: java.lang.Iterable[_ <: CompletionStage[_ <: T]]): CompletionStage[T] = {
+    val iterator = stages.iterator()
+    if (!iterator.hasNext) {
+      new CompletableFuture[T]() // never completes
+    } else {
+      val promise = new CompletableFuture[T]()
+      val holder = new AtomicReference[CompletableFuture[T]](promise) with BiConsumer[T, Throwable] {
+        override def accept(t: T, ex: Throwable): Unit = {
+          val current = getAndSet(null)
+          if (current ne null) {
+            if (ex != null) current.completeExceptionally(ex)
+            else current.complete(t)
+          }
+        }
+      }
+      while (iterator.hasNext && (holder.get() ne null)) {
+        iterator.next().whenComplete(holder)
+      }
+      promise
+    }
+  }
+
+  private def foldWithNext[T, R](
+      iterator: java.util.Iterator[_ <: CompletionStage[_ <: T]],
+      previous: R,
+      function: pekko.japi.function.Function2[R, T, R]): CompletionStage[R] = {
+    if (iterator.hasNext) {
+      iterator.next().thenCompose { t =>
+        val next = function.apply(previous, t)
+        foldWithNext[T, R](iterator, next, function)
+      }
+    } else {
+      CompletableFuture.completedFuture(previous)
+    }
+  }
+
+  /**
+   * Aggregate the results of the given stages using the given associative function and a zero value.
+   * The stages are processed in the order they are given.
+   *
+   * @param zero     the zero value
+   * @param stages   the stages to aggregate
+   * @param function the associative function to use for aggregation
+   * @return a `CompletionStage` that, when completed, will contain the aggregated result
+   * @since 1.2.0
+   */
+  def fold[T <: AnyRef, R](
+      zero: R,
+      stages: java.lang.Iterable[_ <: CompletionStage[_ <: T]],
+      function: pekko.japi.function.Function2[R, T, R]): CompletionStage[R] = {
+    foldWithNext[T, R](stages.iterator(), zero, function)
+  }
+
+  /**
+   * Reduce the results of the given stages using the given associative function.
+   * The stages are processed in the order they are given.
+   * If the given iterable is empty, the returned stage is completed with a `NoSuchElementException`.
+   *
+   * @param stages   the stages to reduce
+   * @param function the associative function to use for reduction
+   * @return a `CompletionStage` that, when completed, will contain the reduced result of the stages
+   *         or a `NoSuchElementException` if the given iterable is empty
+   * @since 1.2.0
+   */
+  @nowarn("msg=deprecated")
+  def reduce[T <: AnyRef, R >: T](
+      stages: java.lang.Iterable[_ <: CompletionStage[_ <: T]],
+      function: pekko.japi.function.Function2[R, T, R]): CompletionStage[R] = {
+    val iterator: java.util.Iterator[_ <: CompletionStage[_ <: T]] = stages.iterator()
+    if (iterator.hasNext) {
+      iterator.next().thenCompose { v => foldWithNext[T, R](iterator, v, function) }
+    } else {
+      Futures.failedCompletionStage(new NoSuchElementException("reduce of an empty iterable of CompletionStages"))
+    }
+  }
+
+  private val AddToListFunction: BiFunction[java.util.List[Any], Any, java.util.List[Any]] = (list, elem) => {
+    list.add(elem)
+    list
+  }
+
+  private def addToListFunction[R](): BiFunction[java.util.List[R], R, java.util.List[R]] =
+    AddToListFunction.asInstanceOf[BiFunction[java.util.List[R], R, java.util.List[R]]]
+
+  private def combineNext[T](
+      accumulate: CompletionStage[java.util.List[T]],
+      next: CompletionStage[_ <: T],
+      executor: Executor): CompletionStage[java.util.List[T]] = {
+    if (executor eq null) {
+      accumulate.thenCombine(next, addToListFunction())
+    } else {
+      accumulate.thenCombineAsync(next, addToListFunction(), executor)
+    }
+  }
+
+  /**
+   * Transform a `java.lang.Iterable` of `CompletionStage`s into a single `CompletionStage` with a `java.util.List`
+   * of all the results.
+   * The stages are processed in the order they are given.
+   *
+   * @param stages the stages to sequence
+   * @param executor the executor to use for asynchronous execution, or `null` to use synchronous execution
+   * @return a `CompletionStage` that, when completed, will contain a `java.util.List` with all the results
+   * @since 1.2.0
+   */
+  def sequence[T](
+      stages: java.lang.Iterable[_ <: CompletionStage[_ <: T]],
+      executor: Executor): CompletionStage[java.util.List[T]] = {
+    var result: CompletionStage[java.util.List[T]] = CompletableFuture.completedFuture(new java.util.ArrayList[T]())
+    val iterator = stages.iterator()
+    while (iterator.hasNext) {
+      result = combineNext[T](result, iterator.next(), executor)
+    }
+    result
+  }
+
+  /**
+   * Transform a `java.lang.Iterable` of `CompletionStage`s into a single `CompletionStage` with a `java.util.List`
+   * of all the results.
+   * The stages are processed in the order they are given.
+   *
+   * @param input the input iterable
+   * @param function the function to apply to each element
+   * @param executor the executor to use for asynchronous execution, or `null` to use synchronous execution
+   * @return a `CompletionStage` that, when completed, will contain a `java.util.List` with all the results
+   * @since 1.2.0
+   */
+  def traverse[T, R](
+      input: java.lang.Iterable[T],
+      function: pekko.japi.function.Function[T, CompletionStage[R]],
+      executor: Executor): CompletionStage[java.util.List[R]] = {
+    var result: CompletionStage[java.util.List[R]] = CompletableFuture.completedFuture(new java.util.ArrayList[R]())
+    val iterator = input.iterator()
+    while (iterator.hasNext) {
+      result = combineNext[R](result, function.apply(iterator.next()), executor)
+    }
+    result
+  }
+
+}

--- a/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
@@ -107,6 +107,16 @@ object Futures {
   import org.apache.pekko.util.ccompat.JavaConverters._
 
   /**
+   * Convert a Scala Future to a Java CompletionStage.
+   *
+   * @since 1.2.0
+   */
+  def asJava[T](future: Future[T]): CompletionStage[T] = {
+    import org.apache.pekko.util.FutureConverters._
+    future.asJava
+  }
+
+  /**
    * Starts an asynchronous computation and returns a `Future` object with the result of that computation.
    *
    * The result becomes available once the asynchronous computation is completed.
@@ -147,6 +157,7 @@ object Futures {
   /**
    * Returns a Future that will hold the optional result of the first Future with a result that matches the predicate
    */
+  @deprecated("Use `CompletionStages#find` instead.", since = "Pekko 1.2.0")
   def find[T <: AnyRef](
       futures: JIterable[Future[T]],
       predicate: pekko.japi.function.Function[T, java.lang.Boolean],
@@ -160,6 +171,7 @@ object Futures {
   /**
    * Returns a Future to the result of the first future in the list that is completed
    */
+  @deprecated("Use `CompletionStages#firstCompletedOf` instead.", since = "Pekko 1.2.0")
   def firstCompletedOf[T <: AnyRef](futures: JIterable[Future[T]], executor: ExecutionContext): Future[T] =
     Future.firstCompletedOf(futures.asScala)(executor)
 
@@ -169,6 +181,7 @@ object Futures {
    * the result will be the first failure of any of the futures, or any failure in the actual fold,
    * or the result of the fold.
    */
+  @deprecated("Use `CompletionStages#fold` instead.", since = "Pekko 1.2.0")
   def fold[T <: AnyRef, R <: AnyRef](
       zero: R,
       futures: JIterable[Future[T]],
@@ -179,6 +192,7 @@ object Futures {
   /**
    * Reduces the results of the supplied futures and binary function.
    */
+  @deprecated("Use `CompletionStages#reduce` instead.", since = "Pekko 1.2.0")
   def reduce[T <: AnyRef, R >: T](
       futures: JIterable[Future[T]],
       fun: pekko.japi.function.Function2[R, T, R],
@@ -189,6 +203,7 @@ object Futures {
    * Simple version of [[#traverse]]. Transforms a JIterable[Future[A]] into a Future[JIterable[A]].
    * Useful for reducing many Futures into a single Future.
    */
+  @deprecated("Use `CompletionStages#sequence` instead.", since = "Pekko 1.2.0")
   def sequence[A](in: JIterable[Future[A]], executor: ExecutionContext): Future[JIterable[A]] = {
     implicit val d = executor
     in.asScala.foldLeft(Future(new JLinkedList[A]())) { (fr, fa) =>
@@ -201,6 +216,7 @@ object Futures {
    * This is useful for performing a parallel map. For example, to apply a function to all items of a list
    * in parallel.
    */
+  @deprecated("Use `CompletionStages#traverse` instead.", since = "Pekko 1.2.0")
   def traverse[A, B](in: JIterable[A], fn: pekko.japi.function.Function[A, Future[B]], executor: ExecutionContext)
       : Future[JIterable[B]] = {
     implicit val d = executor

--- a/docs/src/test/java/jdocs/future/FutureDocTest.java
+++ b/docs/src/test/java/jdocs/future/FutureDocTest.java
@@ -49,6 +49,7 @@ public class FutureDocTest extends AbstractJavaTest {
   private final ActorSystem<Void> system = toTyped(actorSystemResource.getSystem());
 
   @Test(expected = java.util.concurrent.CompletionException.class)
+  @SuppressWarnings("deprecation")
   public void useAfter() throws Exception {
     final ExecutionContext ec = system.executionContext();
     // #after


### PR DESCRIPTION
Motivation:
refs: https://github.com/apache/pekko/issues/2008

Add a helper for CompletionStages and then we can deprecate the methods in Futures.

This should be backported to 1.2.x