### PR TITLE
chore: Make timeoutCompletionStage accept java Duration.

### DIFF
--- a/actor-tests/src/test/java/org/apache/pekko/pattern/PatternsTest.java
+++ b/actor-tests/src/test/java/org/apache/pekko/pattern/PatternsTest.java
@@ -536,7 +536,7 @@ public class PatternsTest extends JUnitSuite {
       delayedStage.toCompletableFuture().get(3, SECONDS);
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof TimeoutException);
-      assertEquals("Timeout of 200 milliseconds expired", e.getCause().getMessage());
+      assertEquals("Timeout of PT0.2S expired", e.getCause().getMessage());
     }
   }
 

--- a/actor/src/main/scala/org/apache/pekko/pattern/Patterns.scala
+++ b/actor/src/main/scala/org/apache/pekko/pattern/Patterns.scala
@@ -480,7 +480,7 @@ object Patterns {
       scheduler: Scheduler,
       context: ExecutionContext,
       value: Callable[CompletionStage[T]]): CompletionStage[T] =
-    timeoutCompletionStage(duration.asScala, scheduler)(value.call())(context)
+    timeoutCompletionStage(duration, scheduler)(value.call())(context)
 
   /**
    * Returns an internally retrying [[java.util.concurrent.CompletionStage]]


### PR DESCRIPTION
Motivation:

This method should accept Java's duration

Should be backported to 1.2.0 too