### PR TITLE
chore: Remove deprecated disassociate method.

### DIFF
--- a/remote/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-methods.excludes
+++ b/remote/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-methods.excludes
@@ -29,3 +29,5 @@ ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.remote.serializati
 ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.remote.serialization.LongSerializer")
 ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.remote.serialization.StringSerializer")
 ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.remote.transport.FailureInjectorTransportAdapter$All*")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.remote.transport.AssociationHandle.disassociate")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.remote.transport.TestAssociationHandle.disassociate")

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/FailureInjectorTransportAdapter.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/FailureInjectorTransportAdapter.scala
@@ -189,13 +189,6 @@ private[remote] final case class FailureInjectorHandle(
   override def disassociate(reason: String, log: LoggingAdapter): Unit =
     wrappedHandle.disassociate(reason, log)
 
-  @deprecated(
-    message = "Use method that states reasons to make sure disassociation reasons are logged.",
-    since = "Akka 2.5.3")
-  @nowarn("msg=deprecated")
-  override def disassociate(): Unit =
-    wrappedHandle.disassociate()
-
   override def notify(ev: HandleEvent): Unit =
     if (!gremlinAdapter.shouldDropInbound(wrappedHandle.remoteAddress, ev, "handler.notify"))
       upstreamListener.notify(ev)

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/PekkoProtocolTransport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/PekkoProtocolTransport.scala
@@ -238,8 +238,6 @@ private[remote] class PekkoProtocolHandle(
 
   override def write(payload: ByteString): Boolean = wrappedHandle.write(codec.constructPayload(payload))
 
-  override def disassociate(): Unit = disassociate(Unknown)
-
   def disassociate(info: DisassociateInfo): Unit = stateActor ! DisassociateUnderlying(info)
 }
 

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/TestTransport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/TestTransport.scala
@@ -23,6 +23,7 @@ import com.typesafe.config.Config
 
 import org.apache.pekko
 import pekko.actor._
+import pekko.event.LoggingAdapter
 import pekko.remote.transport.AssociationHandle._
 import pekko.remote.transport.Transport._
 import pekko.util.ByteString
@@ -484,7 +485,10 @@ final case class TestAssociationHandle(
   override def write(payload: ByteString): Boolean =
     if (writable) transport.write(this, payload) else false
 
-  override def disassociate(): Unit = transport.disassociate(this)
+  override def disassociate(reason: String, log: LoggingAdapter): Unit = {
+    super.disassociate(reason, log)
+    transport.disassociate(this)
+  }
 
   /**
    * Key used in [[pekko.remote.transport.TestTransport.AssociationRegistry]] to identify associations. Contains an

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/ThrottlerTransportAdapter.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/ThrottlerTransportAdapter.scala
@@ -28,6 +28,7 @@ import scala.annotation.nowarn
 
 import org.apache.pekko
 import pekko.actor._
+import pekko.event.LoggingAdapter
 import pekko.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
 import pekko.dispatch.ExecutionContexts
 import pekko.dispatch.sysmsg.{ Unwatch, Watch }
@@ -646,7 +647,10 @@ private[transport] final case class ThrottlerHandle(_wrappedHandle: AssociationH
 
   }
 
-  override def disassociate(): Unit = throttlerActor ! PoisonPill
+  override def disassociate(reason: String, log: LoggingAdapter): Unit = {
+    super.disassociate(reason, log)
+    throttlerActor ! PoisonPill
+  }
 
   def disassociateWithFailure(reason: DisassociateInfo): Unit = {
     throttlerActor ! ThrottledAssociation.FailWith(reason)

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/Transport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/Transport.scala
@@ -16,8 +16,6 @@ package org.apache.pekko.remote.transport
 import scala.concurrent.{ Future, Promise }
 import scala.util.control.NoStackTrace
 
-import scala.annotation.nowarn
-
 import org.apache.pekko
 import pekko.PekkoException
 import pekko.actor.{ ActorRef, Address, NoSerializationVerificationNeeded }
@@ -282,18 +280,6 @@ trait AssociationHandle {
    * be notified, but this is not guaranteed. The Transport that provides the handle MUST guarantee that disassociate()
    * could be called arbitrarily many times.
    */
-  @deprecated(
-    message = "Use method that states reasons to make sure disassociation reasons are logged.",
-    since = "Akka 2.5.3")
-  def disassociate(): Unit
-
-  /**
-   * Closes the underlying transport link, if needed. Some transports might not need an explicit teardown (UDP) and
-   * some transports may not support it (hardware connections). Remote endpoint of the channel or connection MAY
-   * be notified, but this is not guaranteed. The Transport that provides the handle MUST guarantee that disassociate()
-   * could be called arbitrarily many times.
-   */
-  @nowarn("msg=deprecated")
   def disassociate(reason: String, log: LoggingAdapter): Unit = {
     if (log.isDebugEnabled)
       log.debug(
@@ -301,7 +287,5 @@ trait AssociationHandle {
         localAddress,
         remoteAddress,
         reason)
-
-    disassociate()
   }
 }

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/netty/TcpSupport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/netty/TcpSupport.scala
@@ -123,5 +123,8 @@ private[remote] class TcpAssociationHandle(
       true
     } else false
 
-  override def disassociate(): Unit = NettyTransport.gracefulClose(channel)
+  override def disassociate(reason: String, log: LoggingAdapter): Unit = {
+    super.disassociate(reason, log)
+    NettyTransport.gracefulClose(channel)
+  }
 }


### PR DESCRIPTION
Motivation:
Remove deprecated disassociate method.