### PR TITLE
chore: Drop ActorMaterializer class.

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/ActorMaterializerSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/ActorMaterializerSpec.scala
@@ -45,7 +45,7 @@ object IndirectMaterializerCreation extends ExtensionId[IndirectMaterializerCrea
 @nowarn
 class IndirectMaterializerCreation(ex: ExtendedActorSystem) extends Extension {
   // extension instantiation blocked on materializer (which has Await.result inside)
-  implicit val mat: ActorMaterializer = ActorMaterializer()(ex)
+  implicit val mat: Materializer = ActorMaterializer()(ex)
 
   def futureThing(n: Int): Future[Int] = {
     Source.single(n).runWith(Sink.head)
@@ -171,7 +171,7 @@ object ActorMaterializerSpec {
   class ActorWithMaterializer(p: TestProbe) extends Actor {
     private val settings: ActorMaterializerSettings =
       ActorMaterializerSettings(context.system).withDispatcher("pekko.test.stream-dispatcher")
-    implicit val mat: ActorMaterializer = ActorMaterializer(settings)(context)
+    implicit val mat: Materializer = ActorMaterializer(settings)(context)
 
     Source
       .repeat("hello")

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/DslConsistencySpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/DslConsistencySpec.scala
@@ -114,7 +114,7 @@ class DslConsistencySpec extends AnyWordSpec with Matchers {
     sRunnableGraphClass -> Set("builder"))
 
   @nowarn
-  def materializing(m: Method): Boolean = m.getParameterTypes.contains(classOf[ActorMaterializer])
+  def materializing(m: Method): Boolean = m.getParameterTypes.contains(classOf[Materializer])
 
   def assertHasMethod(c: Class[_], name: String): Unit = {
     // include class name to get better error message

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/FileSinkSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/FileSinkSpec.scala
@@ -39,7 +39,7 @@ import org.scalatest.concurrent.ScalaFutures
 class FileSinkSpec extends StreamSpec(UnboundedMailboxConfig) with ScalaFutures {
 
   val settings = ActorMaterializerSettings(system).withDispatcher("pekko.actor.default-dispatcher")
-  implicit val materializer: ActorMaterializer = ActorMaterializer(settings)
+  implicit val materializer: Materializer = ActorMaterializer(settings)
   val fs = Jimfs.newFileSystem("FileSinkSpec", Configuration.unix())
 
   val TestLines = {

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/FileSourceSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/FileSourceSpec.scala
@@ -44,7 +44,7 @@ object FileSourceSpec {
 class FileSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
 
   val settings = ActorMaterializerSettings(system).withDispatcher("pekko.actor.default-dispatcher")
-  implicit val materializer: ActorMaterializer = ActorMaterializer(settings)
+  implicit val materializer: Materializer = ActorMaterializer(settings)
 
   val fs = Jimfs.newFileSystem("FileSourceSpec", Configuration.unix())
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/InputStreamSourceSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/InputStreamSourceSpec.scala
@@ -21,7 +21,13 @@ import scala.util.Success
 
 import org.apache.pekko
 import pekko.Done
-import pekko.stream.{ AbruptStageTerminationException, ActorMaterializer, ActorMaterializerSettings, IOResult }
+import pekko.stream.{
+  AbruptStageTerminationException,
+  ActorMaterializer,
+  ActorMaterializerSettings,
+  IOResult,
+  Materializer
+}
 import pekko.stream.scaladsl.{ Keep, Sink, StreamConverters }
 import pekko.stream.testkit._
 import pekko.stream.testkit.Utils._
@@ -32,7 +38,7 @@ import pekko.util.ByteString
 class InputStreamSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
 
   val settings = ActorMaterializerSettings(system).withDispatcher("pekko.actor.default-dispatcher")
-  implicit val materializer: ActorMaterializer = ActorMaterializer(settings)
+  implicit val materializer: Materializer = ActorMaterializer(settings)
 
   private def inputStreamFor(bytes: Array[Byte]): InputStream =
     new ByteArrayInputStream(bytes)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/OutputStreamSinkSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/OutputStreamSinkSpec.scala
@@ -20,7 +20,7 @@ import scala.util.Success
 
 import org.apache.pekko
 import pekko.Done
-import pekko.stream.{ ActorMaterializer, ActorMaterializerSettings, IOOperationIncompleteException }
+import pekko.stream.{ ActorMaterializer, ActorMaterializerSettings, IOOperationIncompleteException, Materializer }
 import pekko.stream.scaladsl.{ Source, StreamConverters }
 import pekko.stream.testkit._
 import pekko.stream.testkit.Utils._
@@ -33,7 +33,7 @@ import org.scalatest.concurrent.ScalaFutures
 class OutputStreamSinkSpec extends StreamSpec(UnboundedMailboxConfig) with ScalaFutures {
 
   val settings = ActorMaterializerSettings(system).withDispatcher("pekko.actor.default-dispatcher")
-  implicit val materializer: ActorMaterializer = ActorMaterializer(settings)
+  implicit val materializer: Materializer = ActorMaterializer(settings)
 
   "OutputStreamSink" must {
     "write bytes to void OutputStream" in {

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/AttributesSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/AttributesSpec.scala
@@ -143,7 +143,7 @@ class AttributesSpec
 
   val settings = ActorMaterializerSettings(system).withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val materializer: ActorMaterializer = ActorMaterializer(settings)
+  implicit val materializer: Materializer = ActorMaterializer(settings)
 
   "an attributes instance" must {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowDispatcherSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowDispatcherSpec.scala
@@ -19,6 +19,7 @@ import org.apache.pekko
 import pekko.stream.ActorMaterializer
 import pekko.stream.ActorMaterializerSettings
 import pekko.stream.testkit.StreamSpec
+import pekko.stream.Materializer
 import pekko.testkit.TestProbe
 
 @nowarn("msg=deprecated")
@@ -30,7 +31,7 @@ class FlowDispatcherSpec extends StreamSpec(s"my-dispatcher = $${pekko.test.stre
       settings: ActorMaterializerSettings = defaultSettings,
       dispatcher: String = "pekko.test.stream-dispatcher") = {
 
-    implicit val materializer: ActorMaterializer = ActorMaterializer(settings)
+    implicit val materializer: Materializer = ActorMaterializer(settings)
 
     val probe = TestProbe()
     Source(List(1, 2, 3)).map(i => { probe.ref ! Thread.currentThread().getName(); i }).to(Sink.ignore).run()

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowRecoverWithSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowRecoverWithSpec.scala
@@ -29,7 +29,7 @@ class FlowRecoverWithSpec extends StreamSpec {
 
   val settings = ActorMaterializerSettings(system).withInputBuffer(initialSize = 1, maxSize = 1)
 
-  implicit val materializer: ActorMaterializer = ActorMaterializer(settings)
+  implicit val materializer: Materializer = ActorMaterializer(settings)
 
   val ex = new RuntimeException("ex") with NoStackTrace
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowSlidingSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowSlidingSpec.scala
@@ -20,7 +20,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import org.apache.pekko
 import pekko.pattern.pipe
-import pekko.stream.{ ActorMaterializer, ActorMaterializerSettings }
+import pekko.stream.{ ActorMaterializer, ActorMaterializerSettings, Materializer }
 import pekko.stream.testkit._
 
 @nowarn
@@ -28,7 +28,7 @@ class FlowSlidingSpec extends StreamSpec with ScalaCheckPropertyChecks {
   import system.dispatcher
   val settings = ActorMaterializerSettings(system).withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val materializer: ActorMaterializer = ActorMaterializer(settings)
+  implicit val materializer: Materializer = ActorMaterializer(settings)
 
   "Sliding" must {
     import org.scalacheck.Shrink.shrinkAny

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowSpec.scala
@@ -53,7 +53,7 @@ class FlowSpec extends StreamSpec(ConfigFactory.parseString("pekko.actor.debug.r
 
   val settings = ActorMaterializerSettings(system).withInputBuffer(initialSize = 2, maxSize = 2)
 
-  implicit val materializer: ActorMaterializer = ActorMaterializer(settings)
+  implicit val materializer: Materializer = ActorMaterializer(settings)
 
   val identity: Flow[Any, Any, NotUsed] => Flow[Any, Any, NotUsed] = in => in.map(e => e)
   val identity2: Flow[Any, Any, NotUsed] => Flow[Any, Any, NotUsed] = in => identity(in)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphBackedFlowSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphBackedFlowSpec.scala
@@ -56,7 +56,7 @@ class GraphFlowSpec extends StreamSpec {
 
   val settings = ActorMaterializerSettings(system).withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val materializer: ActorMaterializer = ActorMaterializer(settings)
+  implicit val materializer: Materializer = ActorMaterializer(settings)
 
   def validateProbe(probe: TestSubscriber.ManualProbe[Int], requests: Int, result: Set[Int]): Unit = {
     val subscription = probe.expectSubscription()

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/TakeLastSinkSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/TakeLastSinkSpec.scala
@@ -18,7 +18,7 @@ import scala.collection.immutable
 import scala.concurrent.{ Await, Future }
 
 import org.apache.pekko
-import pekko.stream.{ AbruptTerminationException, ActorMaterializer, ActorMaterializerSettings }
+import pekko.stream.{ AbruptTerminationException, ActorMaterializer, ActorMaterializerSettings, Materializer }
 import pekko.stream.testkit.{ StreamSpec, TestPublisher }
 
 @nowarn
@@ -26,7 +26,7 @@ class TakeLastSinkSpec extends StreamSpec {
 
   val settings = ActorMaterializerSettings(system).withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val mat: ActorMaterializer = ActorMaterializer(settings)
+  implicit val mat: Materializer = ActorMaterializer(settings)
 
   "Sink.takeLast" must {
     "return the last 3 elements" in {

--- a/stream/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-methods.excludes
+++ b/stream/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-methods.excludes
@@ -192,3 +192,12 @@ ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.stream.OverflowStr
 ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.stream.OverflowStrategies$DropNew$")
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.stream.OverflowStrategy.dropNew")
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.stream.stage.GraphStageLogic.lastCancellationCause_=")
+ProblemFilters.exclude[FinalClassProblem]("org.apache.pekko.stream.ActorMaterializer")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.stream.ActorMaterializer.create")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.stream.ActorMaterializer.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.stream.ActorMaterializer.settings")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.stream.ActorMaterializer.shutdown")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.stream.ActorMaterializer.isShutdown")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.stream.ActorMaterializer.system")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.stream.ActorMaterializer.this")
+

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/ActorMaterializerImpl.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/ActorMaterializerImpl.scala
@@ -39,7 +39,8 @@ import pekko.util.OptionVal
  * INTERNAL API
  */
 @nowarn("msg=deprecated")
-@DoNotInherit private[pekko] abstract class ExtendedActorMaterializer extends ActorMaterializer {
+@DoNotInherit private[pekko] abstract class ExtendedActorMaterializer extends Materializer
+    with MaterializerLoggingProvider {
 
   override def withNamePrefix(name: String): ExtendedActorMaterializer
 


### PR DESCRIPTION
Motivation:

Drop ActorMaterializer , because Materializer has all its methods.

