### PR TITLE
Update typesafe:config to 1.4.5 (#2191)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -62,7 +62,7 @@ object Dependencies {
   object Compile {
     // Compile
 
-    val config = "com.typesafe" % "config" % "1.4.4"
+    val config = "com.typesafe" % "config" % "1.4.5"
     val `netty-transport` = "io.netty" % "netty-transport" % nettyVersion
     val `netty-handler` = "io.netty" % "netty-handler" % nettyVersion
 


### PR DESCRIPTION
cherry pick 4405e736c1f7a72dd816f792d7a1d7d3d88c31b3 #2191

config 1.4.5 is a bug fix release 