### PR TITLE
update docs for calculateDelay

### DIFF
--- a/actor/src/main/mima-filters/2.0.x.backwards.excludes/backoff-calculation.excludes
+++ b/actor/src/main/mima-filters/2.0.x.backwards.excludes/backoff-calculation.excludes
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Move BackoffSupervisor.calculateDelay to RetrySupport
+# Was removed in Pekko 1.2.0 but added back in 1.2.1 due to breakages
+# in pekko-persistence-cassandra - this method is deprecated in 1.2.1+
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.pattern.BackoffSupervisor.calculateDelay")

--- a/actor/src/main/scala/org/apache/pekko/pattern/BackoffSupervisor.scala
+++ b/actor/src/main/scala/org/apache/pekko/pattern/BackoffSupervisor.scala
@@ -96,20 +96,4 @@ object BackoffSupervisor {
    */
   @InternalApi
   private[pekko] case class ResetRestartCount(current: Int) extends DeadLetterSuppression
-
-  /**
-   * INTERNAL API
-   *
-   * Calculates an exponential back off delay.
-   *
-   * Was removed in 1.2.0 but added back in 1.2.1 for binary compatibility reasons.
-   */
-  @deprecated("Use RetrySupport.calculateDelay instead", since = "1.2.1")
-  private[pekko] def calculateDelay(
-      restartCount: Int,
-      minBackoff: FiniteDuration,
-      maxBackoff: FiniteDuration,
-      randomFactor: Double): FiniteDuration =
-    RetrySupport.calculateDelay(restartCount, minBackoff, maxBackoff, randomFactor)
-
 }


### PR DESCRIPTION
* includes a forward fit of #2195
* but then removes the calculateDelay again since we can break compatibility in 2.0.0
* the main point of this PR is to update the mima-filter and also bring forward the doc updates