### PR TITLE
Add 'message-driven' to project tags

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -13,6 +13,7 @@ github:
     - distributed-actors
     - distributed-systems
     - high-performance
+    - message-driven
 
   protected_tags:
     - "v*.*.*"


### PR DESCRIPTION
The 1.3.x branch is unprotected. I think the branch didn't exist when we modified the .asf.yaml file.
This is just a random edit to force the ASF automations to rerun and to hopefully add the protection to 1.3.x branch in the process.