### PR TITLE
use indexOf to run ByteString contains check

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -920,6 +920,32 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       byteStringLong.indexOf('z', 2) should ===(25)
       byteStringLong.indexOf('a', 2) should ===(-1)
     }
+    "contains" in {
+      ByteString.empty.contains(5) should ===(false)
+      val byteString1 = ByteString1.fromString("abc")
+      byteString1.contains('a') should ===(true)
+      byteString1.contains('c') should ===(true)
+      byteString1.contains('d') should ===(false)
+      val byteString2 = byteString1 ++ ByteString1.fromString("def")
+      byteString2.contains('a') should ===(true)
+      byteString2.contains('c') should ===(true)
+      byteString2.contains('d') should ===(true)
+      byteString2.contains('f') should ===(true)
+      byteString1.contains('z') should ===(false)
+    }
+    "contains (specialized)" in {
+      ByteString.empty.contains(5.toByte) should ===(false)
+      val byteString1 = ByteString1.fromString("abc")
+      byteString1.contains('a'.toByte) should ===(true)
+      byteString1.contains('c'.toByte) should ===(true)
+      byteString1.contains('d'.toByte) should ===(false)
+      val byteString2 = byteString1 ++ ByteString1.fromString("def")
+      byteString2.contains('a'.toByte) should ===(true)
+      byteString2.contains('c'.toByte) should ===(true)
+      byteString2.contains('d'.toByte) should ===(true)
+      byteString2.contains('f'.toByte) should ===(true)
+      byteString1.contains('z'.toByte) should ===(false)
+    }
     "indexOf from/to" in {
       ByteString.empty.indexOf(5.toByte, -1, 10) should ===(-1)
       ByteString.empty.indexOf(5.toByte, 0, 1) should ===(-1)

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -1056,6 +1056,15 @@ sealed abstract class ByteString
    */
   def indexOf(elem: Byte): Int = indexOf(elem, 0)
 
+  override def contains[B >: Byte](elem: B): Boolean = indexOf(elem, 0) != -1
+
+  /**
+   * Checks if this ByteString contains a specific byte.
+   * Similar to Seq's contains function, but it avoids boxing if the value is already a byte.
+   * @since 2.0.0
+   */
+  def contains(elem: Byte): Boolean = indexOf(elem, 0) != -1
+
   override def grouped(size: Int): Iterator[ByteString] = {
     if (size <= 0) {
       throw new IllegalArgumentException(s"size=$size must be positive")


### PR DESCRIPTION
ByteString inherits the contains function from Seq but Seq has a default implementation that uses the `exists` function (`exists(_ == elem)`).

We have an optimised version of indexOf in ByteString and it just seems better to use that for `contains` check too.
```
def contains[B :> Byte](b: B) = indexOf(b) != -1 
```