### PR TITLE
Compute OSGi imports for Pekko packages dynamically #2312

### DIFF
--- a/project/OSGi.scala
+++ b/project/OSGi.scala
@@ -126,7 +126,7 @@ object OSGi {
   def exports(packages: Seq[String] = Seq(), imports: Seq[String] = Nil) =
     osgiSettings ++ Seq(
       OsgiKeys.importPackage := imports ++ scalaVersion(defaultImports).value ++
-        Seq(version(v => pekkoImport(v)).value, "*"),
+      Seq(version(v => pekkoImport(v)).value, "*"),
       OsgiKeys.exportPackage := packages)
   def defaultImports(scalaVersion: String) =
     Seq(


### PR DESCRIPTION
When generating OSGi import declarations for Pekko packages, do not use a hard-coded version range, but derive the version range from the current project version. This should prevent incorrect references to outdated versions when there is a minor version bump.