### PR TITLE
update LICENSE details for commons-io (1.3.x)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -317,8 +317,9 @@ Copyright 2015 Ben Manes. All Rights Reserved.
 
 ---------------
 
-pekko-actor contains code in `org.apache.pekko.io.ByteBufferCleaner` which was based on code
-from Apache commons-io which was developed under the Apache 2.0 license.
+pekko-actor contains code from Apache commons-io which was developed under the
+Apache 2.0 license.
+- actor/src/main/java/org/apache/pekko/io/ByteBufferCleaner.java
 
 ---------------
 

--- a/legal/pekko-actor-jar-license.txt
+++ b/legal/pekko-actor-jar-license.txt
@@ -314,3 +314,9 @@ For more information, please refer to <http://unlicense.org/>
 pekko-actor contains code in `org.apache.pekko.util.FrequencySketch.scala` which was based on code from
 Caffeine <https://github.com/ben-manes/caffeine> which was developed under the Apache 2.0 license.
 Copyright 2015 Ben Manes. All Rights Reserved.
+
+---------------
+
+pekko-actor contains code from Apache commons-io which was developed under the
+Apache 2.0 license.
+- actor/src/main/java/org/apache/pekko/io/ByteBufferCleaner.java


### PR DESCRIPTION
* Partial backport of #2300 
* I spotted in PR2300 that the license file for pekko-actor omitted the commons-io details