### PR TITLE
[WIP] use getLong when matching byte sequences in ByteString

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -222,6 +222,7 @@ Copyright EPFL and Lightbend, Inc.
 pekko-actor contains code from Netty which was released under an Apache 2.0 license.
 Copyright 2014 The Netty Project
 - actor/src/main/scala/org/apache/pekko/io/dns/DnsSettings.scala
+- actor/src/main/scala/org/apache/pekko/util/ByteString.scala
 - actor/src/main/scala/org/apache/pekko/util/SWARUtil.scala
 
 ---------------

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -617,7 +617,9 @@ object ByteString {
 
     // Derived from code in Netty
     // https://github.com/netty/netty/blob/d28a0fc6598b50fbe8f296831777cf4b653a475f/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java#L366-L408
-    override private[util] def bytesMatch(fromIndex: Int, checkBytes: Array[Byte], bytesFromIndex: Int,
+    override private[util] def bytesMatch(fromIndex: Int,
+        checkBytes: Array[Byte],
+        bytesFromIndex: Int,
         checkLength: Int): Boolean = {
       var aIndex = fromIndex + startIndex
       var bIndex = bytesFromIndex
@@ -977,8 +979,10 @@ object ByteString {
       }
     }
 
-    private[util] def bytesMatch(fromIndex: Int, checkBytes: Array[Byte], checkBytesFromIndex: Int, checkLength: Int)
-        : Boolean = {
+    private[util] def bytesMatch(fromIndex: Int,
+        checkBytes: Array[Byte],
+        checkBytesFromIndex: Int,
+        checkLength: Int): Boolean = {
       if (checkLength > 1 && bytestrings.nonEmpty && bytestrings.head.length >= fromIndex + checkLength - 1) {
         bytestrings.head.bytesMatch(fromIndex, checkBytes, checkBytesFromIndex, checkLength)
       } else {
@@ -1230,8 +1234,10 @@ sealed abstract class ByteString
    * Tests whether the bytes in a segment of this ByteString match the provided bytes.
    * Internal use only. ByteString1 and ByteString1C have optimized versions.
    */
-  private[util] def bytesMatch(fromIndex: Int, checkBytes: Array[Byte], checkBytesFromIndex: Int, checkLength: Int)
-      : Boolean
+  private[util] def bytesMatch(fromIndex: Int,
+      checkBytes: Array[Byte],
+      checkBytesFromIndex: Int,
+      checkLength: Int): Boolean
 
   override def grouped(size: Int): Iterator[ByteString] = {
     if (size <= 0) {

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -11,6 +11,21 @@
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package org.apache.pekko.util
 
 import java.io.{ InputStream, ObjectInputStream, ObjectOutputStream, SequenceInputStream }
@@ -314,6 +329,31 @@ object ByteString {
       else -1
     }
 
+    // Derived from code in Netty
+    // https://github.com/netty/netty/blob/d28a0fc6598b50fbe8f296831777cf4b653a475f/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java#L366-L408
+    override private[util] def bytesMatch(fromIndex: Int, checkBytes: Array[Byte], bytesFromIndex: Int,
+        checkLength: Int): Boolean = {
+      var aIndex = fromIndex
+      var bIndex = bytesFromIndex
+      val longCount = checkLength >>> 3
+      val byteCount = checkLength & 7
+      var i = 0
+      while (i < longCount) {
+        if (SWARUtil.getLong(bytes, aIndex) != SWARUtil.getLong(checkBytes, bIndex)) return false
+        aIndex += 8
+        bIndex += 8
+        i += 1
+      }
+      i = 0
+      while (i < byteCount) {
+        if (apply(aIndex) != checkBytes(bIndex)) return false
+        aIndex += 1
+        bIndex += 1
+        i += 1
+      }
+      true
+    }
+
     override def slice(from: Int, until: Int): ByteString =
       if (from <= 0 && until >= length) this
       else if (from >= length || until <= 0 || from >= until) ByteString.empty
@@ -573,6 +613,31 @@ object ByteString {
       else if (byteCount == 6) -1
       else if (bytes(fromIndex + 6) == value) fromIndex + 6
       else -1
+    }
+
+    // Derived from code in Netty
+    // https://github.com/netty/netty/blob/d28a0fc6598b50fbe8f296831777cf4b653a475f/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java#L366-L408
+    override private[util] def bytesMatch(fromIndex: Int, checkBytes: Array[Byte], bytesFromIndex: Int,
+        checkLength: Int): Boolean = {
+      var aIndex = fromIndex + startIndex
+      var bIndex = bytesFromIndex
+      val longCount = checkLength >>> 3
+      val byteCount = checkLength & 7
+      var i = 0
+      while (i < longCount) {
+        if (SWARUtil.getLong(bytes, aIndex) != SWARUtil.getLong(checkBytes, bIndex)) return false
+        aIndex += 8
+        bIndex += 8
+        i += 1
+      }
+      i = 0
+      while (i < byteCount) {
+        if (apply(aIndex) != checkBytes(bIndex)) return false
+        aIndex += 1
+        bIndex += 1
+        i += 1
+      }
+      true
     }
 
     override def copyToArray[B >: Byte](dest: Array[B], start: Int, len: Int): Int = {
@@ -912,6 +977,20 @@ object ByteString {
       }
     }
 
+    private[util] def bytesMatch(fromIndex: Int, checkBytes: Array[Byte], checkBytesFromIndex: Int, checkLength: Int)
+        : Boolean = {
+      if (checkLength > 1 && bytestrings.nonEmpty && bytestrings.head.length >= fromIndex + checkLength - 1) {
+        bytestrings.head.bytesMatch(fromIndex, checkBytes, checkBytesFromIndex, checkLength)
+      } else {
+        var i = 0
+        while (i < checkLength) {
+          if (apply(fromIndex + i) != checkBytes(checkBytesFromIndex + i)) return false
+          i += 1
+        }
+        true
+      }
+    }
+
     protected def writeReplace(): AnyRef = new SerializationProxy(this)
   }
 
@@ -1093,22 +1172,10 @@ sealed abstract class ByteString
    * @since 2.0.0
    */
   def indexOfSlice(slice: Array[Byte], from: Int): Int = {
-    // this is only called if the first byte matches, so we can skip that check
-    def check(startPos: Int): Boolean = {
-      var i = startPos + 1
-      var j = 1
-      // let's trust the calling code has ensured that we have enough bytes in this ByteString
-      while (j < slice.length) {
-        if (apply(i) != slice(j)) return false
-        i += 1
-        j += 1
-      }
-      true
-    }
     @tailrec def rec(from: Int): Int = {
       val startPos = indexOf(slice.head, from, length - slice.length + 1)
       if (startPos == -1) -1
-      else if (check(startPos)) startPos
+      else if (bytesMatch(startPos, slice, 0, slice.length)) startPos
       else rec(startPos + 1)
     }
     val sliceLength = slice.length
@@ -1147,18 +1214,7 @@ sealed abstract class ByteString
    */
   def startsWith(bytes: Array[Byte], offset: Int): Boolean = {
     if (length - offset < bytes.length) false
-    else {
-      var i = offset
-      var j = 0
-      while (j < bytes.length) {
-        // we know that byteString is at least as long as bytes,
-        // so no need to check i < length
-        if (apply(i) != bytes(j)) return false
-        i += 1
-        j += 1
-      }
-      true
-    }
+    else bytesMatch(offset, bytes, 0, bytes.length)
   }
 
   /**
@@ -1169,6 +1225,13 @@ sealed abstract class ByteString
    * @since 2.0.0
    */
   def startsWith(bytes: Array[Byte]): Boolean = startsWith(bytes, 0)
+
+  /**
+   * Tests whether the bytes in a segment of this ByteString match the provided bytes.
+   * Internal use only. ByteString1 and ByteString1C have optimized versions.
+   */
+  private[util] def bytesMatch(fromIndex: Int, checkBytes: Array[Byte], checkBytesFromIndex: Int, checkLength: Int)
+      : Boolean
 
   override def grouped(size: Int): Iterator[ByteString] = {
     if (size <= 0) {

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -346,7 +346,7 @@ object ByteString {
       }
       i = 0
       while (i < byteCount) {
-        if (apply(aIndex) != checkBytes(bIndex)) return false
+        if (bytes(aIndex) != checkBytes(bIndex)) return false
         aIndex += 1
         bIndex += 1
         i += 1
@@ -634,7 +634,7 @@ object ByteString {
       }
       i = 0
       while (i < byteCount) {
-        if (apply(aIndex) != checkBytes(bIndex)) return false
+        if (bytes(aIndex) != checkBytes(bIndex)) return false
         aIndex += 1
         bIndex += 1
         i += 1

--- a/actor/src/main/scala/org/apache/pekko/util/SWARUtil.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/SWARUtil.scala
@@ -77,6 +77,7 @@ private[util] object SWARUtil {
    * @param array the byte array to read from
    * @param index the index to read from
    * @return the long value at the specified index
+   * @throws IndexOutOfBoundsException if index is out of bounds
    */
   def getLong(array: Array[Byte], index: Int): Long = {
     if (longBeArrayViewSupported) {

--- a/legal/pekko-actor-jar-license.txt
+++ b/legal/pekko-actor-jar-license.txt
@@ -222,6 +222,7 @@ Copyright EPFL and Lightbend, Inc.
 pekko-actor contains code from Netty which was released under an Apache 2.0 license.
 Copyright 2014 The Netty Project
 - actor/src/main/scala/org/apache/pekko/io/dns/DnsSettings.scala
+- actor/src/main/scala/org/apache/pekko/util/ByteString.scala
 - actor/src/main/scala/org/apache/pekko/util/SWARUtil.scala
 
 ---------------


### PR DESCRIPTION
* see #2321
* there are more changes that could be attempted based on what is in Netty ByteBufUtil but we've also seen getLong helping quite a bit with indexOf
* aim is to benchmark this and if it helps, get it merged before possibly trying further Netty ByteBufUtil approaches 
https://github.com/netty/netty/blob/a5343227b10456ec889a3fdc5fa4246f036a216d/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java#L242
* the CI issue is due to a package private method causing a mima issue - it can be easily filtered later