### PR TITLE
pekko-stream: change default TLS protocol from TLSv1.2 to TLSv1.3

### DIFF
--- a/stream/src/main/resources/reference.conf
+++ b/stream/src/main/resources/reference.conf
@@ -182,7 +182,7 @@ pekko {
 
   # configure overrides to ssl-configuration here (to be used by pekko-streams, and pekko-http – i.e. when serving https connections)
   ssl-config {
-    protocol = "TLSv1.2"
+    protocol = "TLSv1.3"
   }
 
   actor {


### PR DESCRIPTION
#1901 only really covers pekko-remote use cases - pekko-stream has its own setting that presumably also affects pekko-http