### PR TITLE
remove pekko.ssl-config

### DIFF
--- a/stream/src/main/resources/reference.conf
+++ b/stream/src/main/resources/reference.conf
@@ -180,11 +180,6 @@ pekko {
     default-blocking-io-dispatcher = "pekko.actor.default-blocking-io-dispatcher"
   }
 
-  # configure overrides to ssl-configuration here (to be used by pekko-streams, and pekko-http – i.e. when serving https connections)
-  ssl-config {
-    protocol = "TLSv1.2"
-  }
-
   actor {
 
     serializers {


### PR DESCRIPTION
config is no longer needed in main branch - the long deprecated code that used it was removed in main branch recently