### PR TITLE
change pekko.ssl-config.protocol default to TLSv1.3

### DIFF
--- a/stream/src/main/resources/reference.conf
+++ b/stream/src/main/resources/reference.conf
@@ -182,7 +182,7 @@ pekko {
 
   # configure overrides to ssl-configuration here (to be used by pekko-streams, and pekko-http – i.e. when serving https connections)
   ssl-config {
-    protocol = "TLSv1.2"
+    protocol = "TLSv1.3"
   }
 
   actor {


### PR DESCRIPTION
* affects deprecated code (PekkoSSLConfig) but code that is used in deprecated pekko-http 1.x code - so users may still be using it
* this code is removed from main branch
* see #2358 for discussion