### PR TITLE
[1.3.x] ssl-config 0.7.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,7 +50,7 @@ object Dependencies {
 
   val reactiveStreamsVersion = "1.0.4"
 
-  val sslConfigVersion = "0.6.1"
+  val sslConfigVersion = "0.7.1"
 
   val scalaTestVersion = "3.2.19"
   val scalaTestScalaCheckVersion = "1-18"


### PR DESCRIPTION
I dropped lots of dead and deprecated code from ssl-config, made sure it works with latest Java 25 and Scala 3.7.
Building it now gives zero warnings, so it should be very much future proof.

I know you (and akka) dropped it already in the main branch, which is totally OK.
I was doing the refactor because we keep using it in play-ws.

Should be a drop-in upgrade.

See
- https://github.com/lightbend/ssl-config/releases/tag/v0.7.0
- https://github.com/lightbend/ssl-config/releases/tag/v0.7.1