### PR TITLE
add extra test coverage to JsonFraming code

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/JsonFramingSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/JsonFramingSpec.scala
@@ -546,7 +546,7 @@ class JsonFramingSpec extends PekkoSpec {
       val input = List(
         """{ "name": "john" }""",
         """{ "name": "jack" }""",
-        """{ "name": "john2" }, { "name": "jack2" }, { "name": "john3" }, { "name": "jack3" }""",        
+        """{ "name": "john2" }, { "name": "jack2" }, { "name": "john3" }, { "name": "jack3" }""",
         """{ "name": "very very long name somehow. how did this happen?" }""").map(s => ByteString(s))
 
       val probe = Source(input).via(JsonFraming.objectScanner(48)).runWith(TestSink.probe)


### PR DESCRIPTION
#44 fixed an issue - this extends test coverage by adding the test changes from https://github.com/akka/akka-core/pull/31600. The fix in akka-31600 is unnecessary because pekko-44 seems to work fine.
The akka change is now Apache licensed because it is 3 years since the Akka 2.7.0 release.