### PR TITLE
fix: Update statefulMap scaladoc and tests

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
@@ -2285,10 +2285,12 @@ private[pekko] final class StatefulMap[S, In, Out](create: () => S, f: (S, In) =
 
       private def resetStateAndPull(): Unit = {
         needInvokeOnCompleteCallback = false
-        onComplete(state)
+        onComplete(state) match {
+          case Some(elem) => push(out, elem)
+          case None       => pull(in)
+        }
         state = create()
         needInvokeOnCompleteCallback = true;
-        pull(in)
       }
 
       private def closeStateAndComplete(): Unit = {

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -751,7 +751,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    *
-   * @tparam S the type of the state
+   * @tparam S the type of the state, `null` is allowed as a valid state value
    * @tparam T the type of the output elements
    * @param create a function that creates the initial state
    * @param f a function that transforms the upstream element and the state into a pair of next state and output element

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -2612,7 +2612,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    *
-   * @tparam S the type of the state
+   * @tparam S the type of the state, `null` is allowed as a valid state value
    * @tparam T the type of the output elements
    * @param create a function that creates the initial state
    * @param f a function that transforms the upstream element and the state into a pair of next state and output element

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -228,7 +228,7 @@ final class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    *
-   * @tparam S the type of the state
+   * @tparam S the type of the state, `null` is allowed as a valid state value
    * @tparam T the type of the output elements
    * @param create a function that creates the initial state
    * @param f a function that transforms the upstream element and the state into a pair of next state and output element

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -219,7 +219,7 @@ final class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    *
-   * @tparam S the type of the state
+   * @tparam S the type of the state, `null` is allowed as a valid state value
    * @tparam T the type of the output elements
    * @param create a function that creates the initial state
    * @param f a function that transforms the upstream element and the state into a pair of next state and output element

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -1155,7 +1155,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels
    *
-   * @tparam S the type of the state
+   * @tparam S the type of the state, `null` is allowed as a valid state value
    * @tparam T the type of the output elements
    * @param create a function that creates the initial state
    * @param f a function that transforms the upstream element and the state into a pair of next state and output element


### PR DESCRIPTION
Motivation:

Update the Scala doc about pekko's statefulmap support `null`, and add a fix with the updated test.