### PR TITLE
fix: Fix close in cancel for statefulMap and update statefulMap scaladoc and tests #2385

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
@@ -2299,10 +2299,12 @@ private[pekko] final class StatefulMap[S, In, Out](create: () => S, f: (S, In) =
 
       private def resetStateAndPull(): Unit = {
         needInvokeOnCompleteCallback = false
-        onComplete(state)
+        onComplete(state) match {
+          case Some(elem) => push(out, elem)
+          case None       => pull(in)
+        }
         state = create()
         needInvokeOnCompleteCallback = true;
-        pull(in)
       }
 
       private def closeStateAndComplete(): Unit = {

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -821,7 +821,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    *
-   * @tparam S the type of the state
+   * @tparam S the type of the state, `null` is allowed as a valid state value
    * @tparam T the type of the output elements
    * @param create a function that creates the initial state
    * @param f a function that transforms the upstream element and the state into a pair of next state and output element

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -2812,7 +2812,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    *
-   * @tparam S the type of the state
+   * @tparam S the type of the state, `null` is allowed as a valid state value
    * @tparam T the type of the output elements
    * @param create a function that creates the initial state
    * @param f a function that transforms the upstream element and the state into a pair of next state and output element

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -232,7 +232,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    *
-   * @tparam S the type of the state
+   * @tparam S the type of the state, `null` is allowed as a valid state value
    * @tparam T the type of the output elements
    * @param create a function that creates the initial state
    * @param f a function that transforms the upstream element and the state into a pair of next state and output element

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -223,7 +223,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    *
-   * @tparam S the type of the state
+   * @tparam S the type of the state, `null` is allowed as a valid state value
    * @tparam T the type of the output elements
    * @param create a function that creates the initial state
    * @param f a function that transforms the upstream element and the state into a pair of next state and output element

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -1224,7 +1224,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels
    *
-   * @tparam S the type of the state
+   * @tparam S the type of the state, `null` is allowed as a valid state value
    * @tparam T the type of the output elements
    * @param create a function that creates the initial state
    * @param f a function that transforms the upstream element and the state into a pair of next state and output element


### PR DESCRIPTION
backport https://github.com/apache/pekko/pull/2385

also includes some test changes from #2365 - that PR has some changes that originate from Akka 2.7.0 code that has recently become available under the Apache License, Version 2.0.