### PR TITLE
chore: fix typo in stream-customize.md (#2392)

### DIFF
--- a/docs/src/main/paradox/stream/stream-customize.md
+++ b/docs/src/main/paradox/stream/stream-customize.md
@@ -112,7 +112,7 @@ From the @apidoc[stage.GraphStageLogic] the following operations are available o
 The events corresponding to an *output* port can be received in an @scala[@scaladoc[OutHandler](pekko.stream.stage.OutHandler)]@java[@javadoc[AbstractOutHandler](pekko.stream.stage.AbstractOutHandler)] instance registered to the
 output port using `setHandler(out,handler)`. This handler has two callbacks:
 
- * @apidoc[onPull()](stream.stage.OutHandler) {scala="#onPull():Unit" java="#onPull()"] is called when the output port is ready to emit the next element, `push(out, elem)` is now allowed
+ * @apidoc[onPull()](stream.stage.OutHandler) {scala="#onPull():Unit" java="#onPull()"} is called when the output port is ready to emit the next element, `push(out, elem)` is now allowed
 to be called on this port.
  * @apidoc[onDownstreamFinish()](stream.stage.OutHandler) {scala="#onDownstreamFinish(cause:Throwable):Unit" java="#onDownstreamFinish(java.lang.Throwable)"} is called once the downstream has cancelled and no longer allows messages to be pushed to it.
 No more `onPull()` will arrive after this event. If not overridden this will default to stopping the operator.


### PR DESCRIPTION
(cherry picked from commit 1e2075c82e703af1cb2bae652d546c0921078b26) #2392