### PR TITLE
Change Source.fromArray to Source.apply

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/DslFactoriesConsistencySpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/DslFactoriesConsistencySpec.scala
@@ -55,6 +55,7 @@ class DslFactoriesConsistencySpec extends AnyWordSpec with Matchers {
     ("apply" -> "fromGraph") ::
     ("apply" -> "fromIterator") ::
     ("apply" -> "fromFunctions") ::
+    ("apply" -> "fromArray") ::
     Nil
 
   // format: OFF

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SourceSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SourceSpec.scala
@@ -62,6 +62,18 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
       c.expectComplete()
     }
 
+    "product elements with Array" in {
+      val p = Source(Array(1, 2, 3)).runWith(Sink.asPublisher(false))
+      val c = TestSubscriber.manualProbe[Int]()
+      p.subscribe(c)
+      val sub = c.expectSubscription()
+      sub.request(3)
+      c.expectNext(1)
+      c.expectNext(2)
+      c.expectNext(3)
+      c.expectComplete()
+    }
+
     "reject later subscriber" in {
       val p = Source.single(1).runWith(Sink.asPublisher(false))
       val c1 = TestSubscriber.manualProbe[Int]()

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -199,7 +199,7 @@ object Source {
    *
    * @since 1.1.0
    */
-  def fromArray[T](array: Array[T]): javadsl.Source[T, NotUsed] = new Source(scaladsl.Source.fromArray(array))
+  def fromArray[T](array: Array[T]): javadsl.Source[T, NotUsed] = new Source(scaladsl.Source(array))
 
   /**
    * Create a `Source` from an `Optional` value, emitting the value if it is present.

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Source.scala
@@ -406,6 +406,21 @@ object Source {
     fromGraph(new IterableSource[T](iterable)).withAttributes(DefaultAttributes.iterableSource)
 
   /**
+   * Creates a `Source` from an array, if the array is empty, the stream is completed immediately,
+   * otherwise, every element of the array will be emitted sequentially.
+   *
+   * @since 1.3.0
+   */
+  def apply[T](array: Array[T]): Source[T, NotUsed] = {
+    if (array.length == 0)
+      empty
+    else if (array.length == 1)
+      single(array(0))
+    else
+      Source.fromGraph(new ArraySource[T](array))
+  }
+
+  /**
    * Elements are emitted periodically with the specified interval.
    * The tick element will be delivered to downstream consumers that has requested any elements.
    * If a consumer has not requested any elements at the point in time when the tick
@@ -421,22 +436,6 @@ object Source {
    */
   def single[T](element: T): Source[T, NotUsed] =
     fromGraph(new GraphStages.SingleSource(element))
-
-  /**
-   * Creates a `Source` from an array, if the array is empty, the stream is completed immediately,
-   * otherwise, every element of the array will be emitted sequentially.
-   *
-   * @since 1.3.0
-   */
-  def fromArray[T](array: Array[T]): Source[T, NotUsed] = {
-    if (array.length == 0) {
-      empty
-    } else if (array.length == 1) {
-      single(array(0))
-    } else {
-      Source.fromGraph(new ArraySource[T](array))
-    }
-  }
 
   /**
    * Create a `Source` from an `Option` value, emitting the value if it is defined.


### PR DESCRIPTION
Its not idiomatic in Scala to have multiple different named methods from constructors of a data type, instead we should use `def apply` with overloaded alternatives.

I also wrote a test to make sure that everything compiles fine and also behaves as expected.

@He-Pin This is what I mean