### PR TITLE
feat: Add Source#items

### DIFF
--- a/docs/src/main/paradox/stream/operators/Source/items.md
+++ b/docs/src/main/paradox/stream/operators/Source/items.md
@@ -1,0 +1,26 @@
+# Source.items
+
+Create a `Source` from the given items.
+
+@ref[Source operators](../index.md#source-operators)
+
+## Signature
+
+@apidoc[Source.items](Source$) { scala="#items[T](items:T*):org.apache.pekko.stream.scaladsl.Source[T,org.apache.pekko.NotUsed]" java="#items[T](T)" }
+
+
+## Description
+
+Create a `Source` from the given items.
+
+## Examples
+
+## Reactive Streams semantics
+
+@@@div { .callout }
+
+**emits** the items one by one
+
+**completes** when the last item has been emitted
+
+@@@

--- a/docs/src/main/paradox/stream/operators/index.md
+++ b/docs/src/main/paradox/stream/operators/index.md
@@ -23,6 +23,7 @@ These built-in sources are available from @scala[`org.apache.pekko.stream.scalad
 |Source|<a name="frompublisher"></a>@ref[fromPublisher](Source/fromPublisher.md)|Integration with Reactive Streams, subscribes to a @javadoc[Publisher](java.util.concurrent.Flow.Publisher).|
 |Source|<a name="future"></a>@ref[future](Source/future.md)|Send the single value of the `Future` when it completes and there is demand.|
 |Source|<a name="futuresource"></a>@ref[futureSource](Source/futureSource.md)|Streams the elements of the given future source once it successfully completes.|
+|Source|<a name="items"></a>@ref[items](Source/items.md)|Create a `Source` from the given items.|
 |Source|<a name="iterate"></a>@ref[iterate](Source/iterate.md)|Creates a sequential `Source` by iterating with the given predicate, function and seed.|
 |Source|<a name="lazycompletionstage"></a>@ref[lazyCompletionStage](Source/lazyCompletionStage.md)|Defers creation of a future of a single element source until there is demand.|
 |Source|<a name="lazycompletionstagesource"></a>@ref[lazyCompletionStageSource](Source/lazyCompletionStageSource.md)|Defers creation of a future source until there is demand.|
@@ -512,6 +513,7 @@ For more background see the @ref[Error Handling in Streams](../stream-error.md) 
 * [interleave](Source-or-Flow/interleave.md)
 * [interleaveAll](Source-or-Flow/interleaveAll.md)
 * [intersperse](Source-or-Flow/intersperse.md)
+* [items](Source/items.md)
 * [iterate](Source/iterate.md)
 * [javaCollector](StreamConverters/javaCollector.md)
 * [javaCollectorParallelUnordered](StreamConverters/javaCollectorParallelUnordered.md)

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
@@ -127,6 +127,27 @@ public class SourceTest extends StreamTest {
   }
 
   @Test
+  public void mustBeAbleToUseItems() {
+    Source.items("a", "b", "c")
+        .runWith(TestSink.create(system), system)
+        .ensureSubscription()
+        .request(3)
+        .expectNext("a")
+        .expectNext("b")
+        .expectNext("c")
+        .expectComplete();
+  }
+
+  @Test
+  public void mustBeAbleToUseItemsWhenEmpty() {
+    Source.<String>items()
+        .runWith(TestSink.create(system), system)
+        .ensureSubscription()
+        .request(1)
+        .expectComplete();
+  }
+
+  @Test
   public void mustBeAbleToUseVoidTypeInForeach() {
     final TestKit probe = new TestKit(system);
     final java.lang.Iterable<String> input = Arrays.asList("a", "b", "c");

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -248,6 +248,24 @@ object Source {
     new Source(scaladsl.Source.single(element))
 
   /**
+   * Create a `Source` from the given elements.
+   *
+   * @since 1.3.0
+   */
+  @varargs
+  @SafeVarargs
+  @SuppressWarnings(Array("varargs"))
+  def items[T](items: T*): javadsl.Source[T, NotUsed] = {
+    if (items.isEmpty) {
+      empty()
+    } else if (items.length == 1) {
+      single(items.head)
+    } else {
+      new Source(scaladsl.Source(items))
+    }
+  }
+
+  /**
    * Create a `Source` that will continually emit the given element.
    */
   def repeat[T](element: T): Source[T, NotUsed] =

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Source.scala
@@ -15,7 +15,7 @@ package org.apache.pekko.stream.scaladsl
 
 import java.util.concurrent.CompletionStage
 
-import scala.annotation.tailrec
+import scala.annotation.{ tailrec, varargs }
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.{ immutable, AbstractIterator }
 import scala.concurrent.{ Future, Promise }
@@ -436,6 +436,24 @@ object Source {
    */
   def single[T](element: T): Source[T, NotUsed] =
     fromGraph(new GraphStages.SingleSource(element))
+
+  /**
+   * Create a `Source` from the given elements.
+   *
+   * @since 1.3.0
+   */
+  @varargs
+  @SafeVarargs
+  @SuppressWarnings(Array("varargs"))
+  def items[T](items: T*): Source[T, NotUsed] = {
+    if (items.isEmpty) {
+      empty[T]
+    } else if (items.length == 1) {
+      single(items.head)
+    } else {
+      Source(items)
+    }
+  }
 
   /**
    * Create a `Source` from an `Option` value, emitting the value if it is defined.


### PR DESCRIPTION
Motivation:
refs: https://github.com/apache/pekko/issues/2416

It's named just in Flux and ambArray in Flowable.

@mdedetrich want the Scala method to be `Source.apply`, and then we can call `Source(1,2,3,4)`, wdyt @pjfanning .

if we do that, then `Source(Array(1,2,3)` will emit `1,2,3`, and Source(Array(1,2,3), Array(1,2,3)` will emit `Array(1,2,3), Array(1,2,3)`