### PR TITLE
Compare required RC and M versions if present (#2441)

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/PekkoVersionSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/PekkoVersionSpec.scala
@@ -29,21 +29,36 @@ class PekkoVersionSpec extends AnyWordSpec with Matchers {
     "succeed if version is RC and ok" in {
       PekkoVersion.require("PekkoVersionSpec", "2.5.6", "2.5.7-RC10")
       PekkoVersion.require("PekkoVersionSpec", "2.6.0-RC1", "2.6.0-RC1")
+      PekkoVersion.require("PekkoVersionSpec", "2.6.0-RC1", "2.6.0-RC2")
+      PekkoVersion.require("PekkoVersionSpec", "2.6.0-RC1", "2.7.0")
     }
 
     "fail if version is RC and not ok" in {
       intercept[UnsupportedPekkoVersion] {
         PekkoVersion.require("PekkoVersionSpec", "2.5.6", "2.5.6-RC1")
       }
+      intercept[UnsupportedPekkoVersion] {
+        PekkoVersion.require("PekkoVersionSpec", "2.5.6-RC2", "2.5.6-RC1")
+      }
     }
 
     "succeed if version is milestone and ok" in {
       PekkoVersion.require("PekkoVersionSpec", "2.5.6", "2.5.7-M10")
+      PekkoVersion.require("PekkoVersionSpec", "2.5.7-M9", "2.5.7-M9")
+      PekkoVersion.require("PekkoVersionSpec", "2.5.7-M9", "2.5.7-M10")
+      PekkoVersion.require("PekkoVersionSpec", "2.5.7-M9", "2.5.8")
+      PekkoVersion.require("PekkoVersionSpec", "2.5.7-M9", "2.5.7-RC1")
     }
 
     "fail if version is milestone and not ok" in {
       intercept[UnsupportedPekkoVersion] {
         PekkoVersion.require("PekkoVersionSpec", "2.5.6", "2.5.6-M1")
+      }
+      intercept[UnsupportedPekkoVersion] {
+        PekkoVersion.require("PekkoVersionSpec", "2.5.7-M10", "2.5.7-M9")
+      }
+      intercept[UnsupportedPekkoVersion] {
+        PekkoVersion.require("PekkoVersionSpec", "2.5.7-RC1", "2.5.7-M9")
       }
     }
 

--- a/actor/src/main/scala/org/apache/pekko/PekkoVersion.scala
+++ b/actor/src/main/scala/org/apache/pekko/PekkoVersion.scala
@@ -39,20 +39,38 @@ object PekkoVersion {
   @InternalApi
   private[pekko] def require(libraryName: String, requiredVersion: String, currentVersion: String): Unit = {
     if (requiredVersion != currentVersion) {
-      val VersionPattern = """(\d+)\.(\d+)\.(\d+)(-(?:M|RC)\d+)?""".r
+      val VersionPattern = """(\d+)\.(\d+)\.(\d+)(?:-(M|RC)(\d+))?""".r
       currentVersion match {
-        case VersionPattern(currentMajorStr, currentMinorStr, currentPatchStr, mOrRc) =>
+        case VersionPattern(currentMajorStr, currentMinorStr, currentPatchStr, mOrRc, mOrRcNrStr) =>
           requiredVersion match {
-            case requiredVersion @ VersionPattern(requiredMajorStr, requiredMinorStr, requiredPatchStr, _) =>
-              // a M or RC is basically in-between versions, so offset
-              val currentPatch =
-                if (mOrRc ne null) currentPatchStr.toInt - 1
-                else currentPatchStr.toInt
-              if (requiredMajorStr.toInt != currentMajorStr.toInt ||
-                requiredMinorStr.toInt > currentMinorStr.toInt ||
-                (requiredMinorStr == currentMinorStr && requiredPatchStr.toInt > currentPatch))
+            case requiredVersion @ VersionPattern(
+                  requiredMajorStr,
+                  requiredMinorStr,
+                  requiredPatchStr,
+                  requiredMorRc,
+                  requiredMOrRcNrStr) =>
+              def throwUnsupported() =
                 throw new UnsupportedPekkoVersion(
                   s"Current version of Pekko is [$currentVersion], but $libraryName requires version [$requiredVersion]")
+              if (requiredMajorStr == currentMajorStr) {
+                if (requiredMinorStr == currentMinorStr) {
+                  if (requiredPatchStr == currentPatchStr) {
+                    if (requiredMorRc == null && mOrRc != null)
+                      throwUnsupported() // require final but actual is M or RC
+                    else if (requiredMorRc != null) {
+                      (requiredMorRc, requiredMOrRcNrStr, mOrRc, mOrRcNrStr) match {
+                        case ("M", reqN, "M", n)   => if (reqN.toInt > n.toInt) throwUnsupported()
+                        case ("M", _, "RC", _)     => // RC > M, ok!
+                        case ("RC", _, "M", _)     => throwUnsupported()
+                        case ("RC", reqN, "RC", n) => if (reqN.toInt > n.toInt) throwUnsupported()
+                        case (_, _, null, _)       => // requirement on RC or M but actual is final, ok!
+                        case unexpected            =>
+                          throw new IllegalArgumentException(s"Should never happen, comparing M/RC: $unexpected")
+                      }
+                    } // same versions, ok!
+                  } else if (requiredPatchStr.toInt > currentPatchStr.toInt) throwUnsupported()
+                } else if (requiredMinorStr.toInt > currentMinorStr.toInt) throwUnsupported()
+              } else throwUnsupported() // major diff
             case _ => // SNAPSHOT or unknown - you're on your own
           }
 


### PR DESCRIPTION
(cherry picked from commit f86d79ba3cc363bae7b2e0ca57237eca1ecc64d0)