### PR TITLE
chore: don't auto-update agrona

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -5,6 +5,9 @@ updates.pin = [
   { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
   # sbt-assembly 2.3 causes build issues (https://github.com/apache/pekko/pull/1744)
   { groupId = "com.eed3si9n", artifactId = "sbt-assembly", version = "2.2." }
+  # agrona major+minor version should match the one brought
+  # in by aeron
+  { groupId = "org.agrona", artifactId = "agrona", version = "2.2." }
 ]
 
 updates.ignore = [
@@ -25,8 +28,6 @@ updates.ignore = [
   { groupId = "com.lightbend.sbt", artifactId = "sbt-java-formatter" }
   # lmdbjava 0.9.2 causes issues - https://github.com/apache/pekko/issues/2484
   { groupId = "org.lmdbjava" }
-  # agrona should only be updated when aeron is updated
-  { groupId = "org.agrona", artifactId = "agrona" }
 ]
 
 updatePullRequests = "always"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,8 +30,9 @@ object Dependencies {
   val slf4jVersion = "2.0.17"
   // also update agrona version when updating aeron:
   val aeronVersion = "1.48.7"
-  // needs to be inline with the aeron version, check
+  // Use the major+minor agrona versions matching aeron at
   // https://github.com/aeron-io/aeron/blob/1.x.y/gradle/libs.versions.toml
+  // (remember to also update the scala-steward pin)
   val agronaVersion = "2.2.4"
   val nettyVersion = "4.2.7.Final"
   val logbackVersion = "1.5.20"


### PR DESCRIPTION
As agrona according to the comment must align with the version used in aeron, so it should only be updated when we update aeron.

We already missed that in #2280, #2446 and #2461 so let's exclude it from scala-steward (and see if we can be more careful with aeron updates...)