### PR TITLE
fix: poll bind via UDP before starting tests

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/io/dns/AsyncDnsResolverIntegrationSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/io/dns/AsyncDnsResolverIntegrationSpec.scala
@@ -72,7 +72,7 @@ class AsyncDnsResolverIntegrationSpec
       system.log.info("Docker available. Running DNS tests")
     }
 
-    "resolve single A record" in {
+    "resolve a single A record" in {
       val name = "a-single.foo.test"
       val answer = resolve(name, DnsProtocol.Ip(ipv6 = false))
       withClue(answer) {


### PR DESCRIPTION
Potential fix for #2398: perhaps Bind is simply not fully started and ready to respond to queries when we see 'Starting BIND' - potentially more reliable to perform an actual request?