### PR TITLE
fix issues with file references in docs

### DIFF
--- a/docs/src/main/paradox/stream/operators/Source/asSubscriber.md
+++ b/docs/src/main/paradox/stream/operators/Source/asSubscriber.md
@@ -41,7 +41,7 @@ backpressure is applied throughout the stream, preventing us from running out of
 rows are consumed slower than they are produced by the database.
 
 Scala
-:  @@snip [AsSubscriber.scala](/docs/src/test/scala-jdk9/docs/stream/operators/source/AsSubscriber.scala) { #imports #example }
+:  @@snip [AsSubscriber.scala](/docs/src/test/scala-jdk9-only/docs/stream/operators/source/AsSubscriber.scala) { #imports #example }
 
 Java
 :  @@snip [AsSubscriber.java](/docs/src/test/java-jdk9-only/jdocs/stream/operators/source/AsSubscriber.java) { #imports #example }

--- a/docs/src/main/paradox/stream/operators/Source/fromPublisher.md
+++ b/docs/src/main/paradox/stream/operators/Source/fromPublisher.md
@@ -38,7 +38,7 @@ backpressure is applied throughout the stream, preventing us from running out of
 rows are consumed slower than they are produced by the database.
 
 Scala
-:  @@snip [FromPublisher.scala](/docs/src/test/scala-jdk9/docs/stream/operators/source/FromPublisher.scala) { #imports #example }
+:  @@snip [FromPublisher.scala](/docs/src/test/scala-jdk9-only/docs/stream/operators/source/FromPublisher.scala) { #imports #example }
 
 Java
 :  @@snip [FromPublisher.java](/docs/src/test/java-jdk9-only/jdocs/stream/operators/source/FromPublisher.java) { #imports #example }


### PR DESCRIPTION
* problem introduced by #2470
* the file structure in main branch has changed because we no longer need to separate out code that won't compile in Java 8 - but 1.3.x still has this split
* example broken build: https://github.com/apache/pekko/actions/runs/19282220370/job/55135583700 
