### PR TITLE
Change default persistence plugin-dispatcher

### DIFF
--- a/docs/src/main/paradox/persistence-journals.md
+++ b/docs/src/main/paradox/persistence-journals.md
@@ -58,7 +58,7 @@ The plugin section of the actor system's config will be passed in the config con
 of the plugin is passed in the `String` parameter.
 
 The `plugin-dispatcher` is the dispatcher used for the plugin actor. If not specified, it defaults to
-`pekko.persistence.dispatchers.default-plugin-dispatcher`.
+`pekko.actor.default-dispatcher`.
 
 Don't run journal tasks/futures on the system default dispatcher, since that might starve other tasks.
 
@@ -90,7 +90,7 @@ The plugin section of the actor system's config will be passed in the config con
 of the plugin is passed in the `String` parameter.
 
 The `plugin-dispatcher` is the dispatcher used for the plugin actor. If not specified, it defaults to
-`pekko.persistence.dispatchers.default-plugin-dispatcher`.
+`pekko.actor.default-dispatcher`.
 
 Don't run snapshot store tasks/futures on the system default dispatcher, since that might starve other tasks.
 

--- a/docs/src/test/scala/docs/persistence/PersistencePluginDocSpec.scala
+++ b/docs/src/test/scala/docs/persistence/PersistencePluginDocSpec.scala
@@ -97,7 +97,7 @@ class PersistencePluginDocSpec extends AnyWordSpec {
           # Class name of the plugin.
           class = "docs.persistence.MySnapshotStore"
           # Dispatcher for the plugin actor.
-          plugin-dispatcher = "pekko.persistence.dispatchers.default-plugin-dispatcher"
+          plugin-dispatcher = "pekko.actor.default-dispatcher"
         }
         //#snapshot-store-plugin-config
       """

--- a/persistence/src/main/resources/reference.conf
+++ b/persistence/src/main/resources/reference.conf
@@ -67,15 +67,15 @@ pekko.persistence {
         # AtLeastOnceDelivery is allowed to hold in memory.
         max-unconfirmed-messages = 100000
     }
+    # Deprecated: These are not used by default from Pekko 2.0.0.
+    # Plugins should define their own custom dispatchers if needed, otherwise the
+    # pekko.actor.default-dispatcher is used by default.
     # Default persistent extension thread pools.
     dispatchers {
-        # Dispatcher used by every plugin which does not declare explicit
-        # `plugin-dispatcher` field.
         default-plugin-dispatcher {
             type = PinnedDispatcher
             executor = "thread-pool-executor"
         }
-        # Default dispatcher for message replay.
         default-replay-dispatcher {
             type = Dispatcher
             executor = "fork-join-executor"
@@ -84,7 +84,6 @@ pekko.persistence {
                 parallelism-max = 8
             }
         }
-        # Default dispatcher for streaming snapshot IO
         default-stream-dispatcher {
             type = Dispatcher
             executor = "fork-join-executor"
@@ -106,10 +105,10 @@ pekko.persistence {
       class = ""
 
       # Dispatcher for the plugin actor.
-      plugin-dispatcher = "pekko.persistence.dispatchers.default-plugin-dispatcher"
+      plugin-dispatcher = "pekko.actor.default-dispatcher"
 
       # Dispatcher for message replay.
-      replay-dispatcher = "pekko.persistence.dispatchers.default-replay-dispatcher"
+      replay-dispatcher = "pekko.actor.default-dispatcher"
 
       # Removed: used to be the Maximum size of a persistent message batch written to the journal.
       # Now this setting is without function, PersistentActor will write as many messages
@@ -181,7 +180,7 @@ pekko.persistence {
       class = ""
 
       # Dispatcher for the plugin actor.
-      plugin-dispatcher = "pekko.persistence.dispatchers.default-plugin-dispatcher"
+      plugin-dispatcher = "pekko.actor.default-dispatcher"
 
       circuit-breaker {
         max-failures = 5


### PR DESCRIPTION
new attempt at #2434 

https://github.com/akka/akka-core/pull/31598 is now available under Apache License, Version 2.0 because Akka 2.7.0 was released over 3 years ago.