### PR TITLE
Add close on ActorSystem

### DIFF
--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/ActorSystemStub.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/ActorSystemStub.scala
@@ -113,6 +113,10 @@ import com.typesafe.config.{ Config, ConfigFactory }
   override def terminate(): Unit = terminationPromise.trySuccess(Done)
   override def whenTerminated: Future[Done] = terminationPromise.future
   override def getWhenTerminated: CompletionStage[Done] = whenTerminated.asJava
+  override def close(): Unit = {
+    terminate()
+    Await.result(whenTerminated, scala.concurrent.duration.Duration.Inf)
+  }
   override val startTime: Long = System.currentTimeMillis()
   override def uptime: Long = System.currentTimeMillis() - startTime
   override def threadFactory: java.util.concurrent.ThreadFactory = new ThreadFactory {

--- a/actor-tests/src/test/java/org/apache/pekko/actor/ActorSystemTest.java
+++ b/actor-tests/src/test/java/org/apache/pekko/actor/ActorSystemTest.java
@@ -15,6 +15,7 @@ package org.apache.pekko.actor;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.CompletionStage;
 import org.apache.pekko.testkit.PekkoJUnitActorSystemResource;
@@ -46,5 +47,15 @@ public class ActorSystemTest extends JUnitSuite {
   @Test
   public void testGetWhenTerminatedWithoutTermination() {
     assertFalse(system.getWhenTerminated().toCompletableFuture().isDone());
+  }
+
+  @Test
+  public void testTryWithResources() throws Exception {
+    ActorSystem system = null;
+    try (ActorSystem actorSystem = ActorSystem.create()) {
+      system = actorSystem;
+    }
+    final CompletionStage<Terminated> cs = system.getWhenTerminated();
+    assertTrue(cs.toCompletableFuture().isDone());
   }
 }

--- a/actor-tests/src/test/scala/org/apache/pekko/dispatch/DispatcherShutdownSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/dispatch/DispatcherShutdownSpec.scala
@@ -45,7 +45,7 @@ class DispatcherShutdownSpec extends AnyWordSpec with Matchers {
       val system = ActorSystem("DispatcherShutdownSpec")
       threadCount should be > 0
 
-      Await.ready(system.terminate(), 1.second)
+      system.close()
       Await.ready(Future(pekko.Done)(system.dispatcher), 1.second)
 
       TestKit.awaitCond(threadCount == 0, 3.second)

--- a/actor-typed-tests/src/test/java/org/apache/pekko/actor/typed/ActorSystemTest.java
+++ b/actor-typed-tests/src/test/java/org/apache/pekko/actor/typed/ActorSystemTest.java
@@ -15,6 +15,7 @@ package org.apache.pekko.actor.typed;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.CompletionStage;
 import org.apache.pekko.Done;
@@ -38,5 +39,16 @@ public class ActorSystemTest extends JUnitSuite {
     final ActorSystem<Void> system =
         ActorSystem.create(Behaviors.empty(), "GetWhenTerminatedWithoutTermination");
     assertFalse(system.getWhenTerminated().toCompletableFuture().isDone());
+  }
+
+  @Test
+  public void testTryWithResources() throws Exception {
+    ActorSystem<Void> system = null;
+    try (ActorSystem<Void> actorSystem =
+        ActorSystem.create(Behaviors.empty(), "TryWithResourcesSystem")) {
+      system = actorSystem;
+    }
+    final CompletionStage<Done> cs = system.getWhenTerminated();
+    assertTrue(cs.toCompletableFuture().isDone());
   }
 }

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/ActorSystemSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/ActorSystemSpec.scala
@@ -18,6 +18,7 @@
 package org.apache.pekko.actor.typed
 
 import scala.annotation.nowarn
+import scala.util.Using
 
 import org.apache.pekko
 import pekko.actor.typed.scaladsl.Behaviors
@@ -44,6 +45,20 @@ class ActorSystemSpec extends PekkoSpec {
       } finally {
         system.terminate()
       }
+    }
+
+    "close method terminates ActorSystem" in {
+      val system = ActorSystem(Behaviors.empty[String], "close-terminates-system")
+      system.close()
+      system.whenTerminated.isCompleted should ===(true)
+    }
+
+    "Scala's Using automatically terminates ActorSystem" in {
+      var currentSystem: ActorSystem[Nothing] = null
+      Using(ActorSystem(Behaviors.empty[String], "using-terminates-system")) { system =>
+        currentSystem = system
+      }
+      currentSystem.whenTerminated.isCompleted should ===(true)
     }
   }
 }

--- a/actor-typed/src/main/mima-filters/1.3.x.backwards.excludes/actorsystem-close.excludes
+++ b/actor-typed/src/main/mima-filters/1.3.x.backwards.excludes/actorsystem-close.excludes
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Add close to ActorSystem
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.actor.typed.ActorSystem.close")
+ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("org.apache.pekko.actor.typed.ActorSystem.close")

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/adapter/ActorSystemAdapter.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/adapter/ActorSystemAdapter.scala
@@ -122,6 +122,8 @@ import org.slf4j.{ Logger, LoggerFactory }
   override lazy val getWhenTerminated: CompletionStage[pekko.Done] =
     whenTerminated.asJava
 
+  override def close(): Unit = system.close()
+
   override def systemActorOf[U](behavior: Behavior[U], name: String, props: Props): ActorRef[U] = {
     val ref = system.systemActorOf(
       PropsAdapter(

--- a/actor/src/main/mima-filters/1.3.x.backwards.excludes/actorsystem-close.excludes
+++ b/actor/src/main/mima-filters/1.3.x.backwards.excludes/actorsystem-close.excludes
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Add close to ActorSystem
+ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("org.apache.pekko.actor.ActorSystem.close")
+ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("org.apache.pekko.actor.ExtendedActorSystem.close")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.actor.ActorSystem.close")

--- a/actor/src/main/resources/reference.conf
+++ b/actor/src/main/resources/reference.conf
@@ -1244,6 +1244,12 @@ pekko {
     # Terminate the ActorSystem in the last phase actor-system-terminate.
     terminate-actor-system = on
 
+    # The timeout that will be used when calling .close on an ActorSystem.
+    # This timeout will also be used when ActorSystem's are automatically
+    # terminated by using Java's try-with-resources or Scala's
+    # scala.util.Using
+    close-actor-system-timeout = 60 s
+
     # Exit the JVM (System.exit(0)) in the last phase actor-system-terminate
     # if this is set to 'on'. It is done after termination of the
     # ActorSystem if terminate-actor-system=on, otherwise it is done

--- a/bench-jmh/src/main/scala/org/apache/pekko/actor/ActorBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/actor/ActorBenchmark.scala
@@ -15,9 +15,6 @@ package org.apache.pekko.actor
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
-
 import BenchmarkActors._
 import org.openjdk.jmh.annotations._
 
@@ -100,10 +97,8 @@ class ActorBenchmark {
   }
 
   @TearDown(Level.Trial)
-  def shutdown(): Unit = {
-    system.terminate()
-    Await.ready(system.whenTerminated, 15.seconds)
-  }
+  def shutdown(): Unit =
+    system.close()
 
   @Benchmark
   @OperationsPerInvocation(totalMessages)

--- a/bench-jmh/src/main/scala/org/apache/pekko/actor/ActorCreationBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/actor/ActorCreationBenchmark.scala
@@ -15,9 +15,6 @@ package org.apache.pekko.actor
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
-
 import org.openjdk.jmh.annotations._
 
 /*
@@ -46,10 +43,8 @@ class ActorCreationBenchmark {
   }
 
   @TearDown(Level.Trial)
-  def shutdown(): Unit = {
-    system.terminate()
-    Await.ready(system.whenTerminated, 15.seconds)
-  }
+  def shutdown(): Unit =
+    system.close()
 
   @Benchmark
   @OutputTimeUnit(TimeUnit.MICROSECONDS)

--- a/bench-jmh/src/main/scala/org/apache/pekko/actor/ForkJoinActorBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/actor/ForkJoinActorBenchmark.scala
@@ -16,8 +16,6 @@ package org.apache.pekko.actor
 import java.util.concurrent.TimeUnit
 
 import scala.annotation.tailrec
-import scala.concurrent.Await
-import scala.concurrent.duration._
 
 import BenchmarkActors._
 import org.openjdk.jmh.annotations._
@@ -78,10 +76,8 @@ class ForkJoinActorBenchmark {
   }
 
   @TearDown(Level.Trial)
-  def shutdown(): Unit = {
-    system.terminate()
-    Await.ready(system.whenTerminated, 15.seconds)
-  }
+  def shutdown(): Unit =
+    system.close()
 
   //  @Benchmark
   //  @OperationsPerInvocation(totalMessagesTwoActors)

--- a/bench-jmh/src/main/scala/org/apache/pekko/actor/RouterPoolCreationBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/actor/RouterPoolCreationBenchmark.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.actor
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import org.openjdk.jmh.annotations._
@@ -40,10 +39,8 @@ class RouterPoolCreationBenchmark {
   var size = 0
 
   @TearDown(Level.Trial)
-  def shutdown(): Unit = {
-    system.terminate()
-    Await.ready(system.whenTerminated, 15.seconds)
-  }
+  def shutdown(): Unit =
+    system.close()
 
   @Benchmark
   @OutputTimeUnit(TimeUnit.MICROSECONDS)

--- a/bench-jmh/src/main/scala/org/apache/pekko/actor/ScheduleBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/actor/ScheduleBenchmark.scala
@@ -52,10 +52,8 @@ class ScheduleBenchmark {
   }
 
   @TearDown
-  def shutdown(): Unit = {
-    system.terminate()
-    Await.ready(system.whenTerminated, 15.seconds)
-  }
+  def shutdown(): Unit =
+    system.close()
 
   def op(idx: Int) = if (idx == winner) promise.trySuccess(idx) else idx
 

--- a/bench-jmh/src/main/scala/org/apache/pekko/actor/StashCreationBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/actor/StashCreationBenchmark.scala
@@ -15,9 +15,6 @@ package org.apache.pekko.actor
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
-
 import org.openjdk.jmh.annotations._
 
 import org.apache.pekko.testkit.TestProbe
@@ -49,10 +46,8 @@ class StashCreationBenchmark {
   val probe = TestProbe()
 
   @TearDown(Level.Trial)
-  def shutdown(): Unit = {
-    system.terminate()
-    Await.ready(system.whenTerminated, 15.seconds)
-  }
+  def shutdown(): Unit =
+    system.close()
 
   @Benchmark
   @OutputTimeUnit(TimeUnit.MICROSECONDS)

--- a/bench-jmh/src/main/scala/org/apache/pekko/actor/TellOnlyBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/actor/TellOnlyBenchmark.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.actor
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import org.openjdk.jmh.annotations._
@@ -65,10 +64,8 @@ class TellOnlyBenchmark {
   }
 
   @TearDown(Level.Trial)
-  def shutdown(): Unit = {
-    system.terminate()
-    Await.ready(system.whenTerminated, 15.seconds)
-  }
+  def shutdown(): Unit =
+    system.close()
 
   var actor: ActorRef = _
   var probe: TestProbe = _

--- a/bench-jmh/src/main/scala/org/apache/pekko/actor/typed/TypedActorBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/actor/typed/TypedActorBenchmark.scala
@@ -100,10 +100,8 @@ class TypedActorBenchmark {
   }
 
   @TearDown(Level.Trial)
-  def shutdown(): Unit = {
-    system.terminate()
-    Await.ready(system.whenTerminated, 15.seconds)
-  }
+  def shutdown(): Unit =
+    system.close()
 
   @Benchmark
   @OperationsPerInvocation(totalMessages)

--- a/bench-jmh/src/main/scala/org/apache/pekko/actor/typed/TypedForkJoinActorBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/actor/typed/TypedForkJoinActorBenchmark.scala
@@ -117,10 +117,8 @@ class TypedForkJoinActorBenchmark {
   }
 
   @TearDown(Level.Trial)
-  def shutdown(): Unit = {
-    system.terminate()
-    Await.ready(system.whenTerminated, 15.seconds)
-  }
+  def shutdown(): Unit =
+    system.close()
 }
 
 object TypedForkJoinActorBenchmark {

--- a/bench-jmh/src/main/scala/org/apache/pekko/actor/typed/delivery/ReliableDeliveryBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/actor/typed/delivery/ReliableDeliveryBenchmark.scala
@@ -237,10 +237,8 @@ class ReliableDeliveryBenchmark {
   }
 
   @TearDown(Level.Trial)
-  def shutdown(): Unit = {
-    system.terminate()
-    Await.ready(system.whenTerminated, 15.seconds)
-  }
+  def shutdown(): Unit =
+    system.close()
 
   @Benchmark
   @OperationsPerInvocation(messagesPerOperation)

--- a/bench-jmh/src/main/scala/org/apache/pekko/persistence/LevelDbBatchingBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/persistence/LevelDbBatchingBenchmark.scala
@@ -17,8 +17,6 @@ import java.io.File
 import java.util.concurrent.TimeUnit
 
 import scala.annotation.nowarn
-import scala.concurrent.Await
-import scala.concurrent.duration._
 
 import org.apache.commons.io.FileUtils
 import org.openjdk.jmh.annotations._
@@ -75,8 +73,7 @@ class LevelDbBatchingBenchmark {
     store ! PoisonPill
     Thread.sleep(500)
 
-    sys.terminate()
-    Await.ready(sys.whenTerminated, 10.seconds)
+    sys.close()
   }
 
   @Benchmark

--- a/bench-jmh/src/main/scala/org/apache/pekko/persistence/PersistenceActorDeferBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/persistence/PersistenceActorDeferBenchmark.scala
@@ -15,9 +15,6 @@ package org.apache.pekko.persistence
 
 import java.io.File
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
-
 import org.apache.commons.io.FileUtils
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.annotations.Scope
@@ -71,8 +68,7 @@ class PersistentActorDeferBenchmark {
 
   @TearDown
   def shutdown(): Unit = {
-    system.terminate()
-    Await.ready(system.whenTerminated, 15.seconds)
+    system.close()
 
     storageLocations.foreach(FileUtils.deleteDirectory)
   }

--- a/bench-jmh/src/main/scala/org/apache/pekko/persistence/PersistentActorBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/persistence/PersistentActorBenchmark.scala
@@ -15,9 +15,6 @@ package org.apache.pekko.persistence
 
 import java.io.File
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
-
 import org.apache.commons.io.FileUtils
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.annotations.Scope
@@ -69,8 +66,7 @@ class PersistentActorThroughputBenchmark {
 
   @TearDown
   def shutdown(): Unit = {
-    system.terminate()
-    Await.ready(system.whenTerminated, 15.seconds)
+    system.close()
 
     storageLocations.foreach(FileUtils.deleteDirectory)
   }

--- a/bench-jmh/src/main/scala/org/apache/pekko/persistence/PersistentActorWithAtLeastOnceDeliveryBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/persistence/PersistentActorWithAtLeastOnceDeliveryBenchmark.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.persistence
 
 import java.io.File
 
-import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import org.apache.commons.io.FileUtils
@@ -72,8 +71,7 @@ class PersistentActorWithAtLeastOnceDeliveryBenchmark {
 
   @TearDown
   def shutdown(): Unit = {
-    system.terminate()
-    Await.ready(system.whenTerminated, 15.seconds)
+    system.close()
 
     storageLocations.foreach(FileUtils.deleteDirectory)
   }

--- a/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/PersistentShardingMigrationSpec.scala
+++ b/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/PersistentShardingMigrationSpec.scala
@@ -12,9 +12,9 @@
  */
 
 package org.apache.pekko.cluster.sharding
+
 import java.util.UUID
 
-import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import org.apache.pekko
@@ -184,7 +184,7 @@ class PersistentShardingMigrationSpec extends PekkoSpec(PersistentShardingMigrat
           extractShardId(rememberedEntitiesProbe.ref))
         f(system, region, rememberedEntitiesProbe)
       } finally {
-        Await.ready(system.terminate(), 20.seconds)
+        system.close()
       }
     }
 

--- a/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/RememberEntitiesShardIdExtractorChangeSpec.scala
+++ b/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/RememberEntitiesShardIdExtractorChangeSpec.scala
@@ -15,9 +15,6 @@ package org.apache.pekko.cluster.sharding
 
 import java.util.UUID
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
-
 import org.apache.pekko
 import pekko.actor.ActorRef
 import pekko.actor.ActorSystem
@@ -145,7 +142,7 @@ class RememberEntitiesShardIdExtractorChangeSpec
         val region = ClusterSharding(system).start(TypeName, Props(new PA()), extractEntityId, extractShardId)
         f(system, region)
       } finally {
-        Await.ready(system.terminate(), 20.seconds)
+        system.close()
       }
     }
 

--- a/cluster-tools/src/multi-jvm/scala/org/apache/pekko/cluster/client/ClusterClientStopSpec.scala
+++ b/cluster-tools/src/multi-jvm/scala/org/apache/pekko/cluster/client/ClusterClientStopSpec.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.cluster.client
 
 import scala.annotation.nowarn
-import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import org.apache.pekko
@@ -117,7 +116,7 @@ class ClusterClientStopSpec extends MultiNodeSpec(ClusterClientStopSpec) with ST
 
       runOn(first, second) {
         enterBarrier("was-in-contact")
-        Await.ready(system.terminate(), 10.seconds)
+        system.close()
 
       }
 

--- a/cluster-typed/src/test/scala/org/apache/pekko/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
+++ b/cluster-typed/src/test/scala/org/apache/pekko/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
@@ -205,8 +205,7 @@ class ClusterReceptionistSpec extends AnyWordSpec with Matchers with LogCapturin
 
         if (down) {
           // abrupt termination
-          system2.terminate()
-          Await.ready(system2.whenTerminated, 10.seconds)
+          system2.close()
           clusterNode1.manager ! Down(clusterNode2.selfMember.address)
         } else {
           clusterNode1.manager ! Leave(clusterNode2.selfMember.address)
@@ -368,8 +367,7 @@ class ClusterReceptionistSpec extends AnyWordSpec with Matchers with LogCapturin
 
         // abrupt termination but then a node with the same host:port comes online quickly
         system1.log.debug("Terminating system2: [{}]", clusterNode2.selfMember.uniqueAddress)
-        system2.terminate()
-        Await.ready(system2.whenTerminated, 10.seconds)
+        system2.close()
 
         val testKit3 = ActorTestKit(
           system1.name,

--- a/distributed-data/src/multi-jvm/scala/org/apache/pekko/cluster/ddata/DurableDataSpec.scala
+++ b/distributed-data/src/multi-jvm/scala/org/apache/pekko/cluster/ddata/DurableDataSpec.scala
@@ -290,7 +290,7 @@ abstract class DurableDataSpec(multiNodeConfig: DurableDataSpecConfig)
           expectTerminated(r)
         }
       } finally {
-        Await.ready(sys1.terminate(), 10.seconds)
+        sys1.close()
       }
 
       val sys2 = ActorSystem(

--- a/distributed-data/src/multi-jvm/scala/org/apache/pekko/cluster/ddata/DurablePruningSpec.scala
+++ b/distributed-data/src/multi-jvm/scala/org/apache/pekko/cluster/ddata/DurablePruningSpec.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.cluster.ddata
 
-import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import org.apache.pekko
@@ -147,7 +146,7 @@ class DurablePruningSpec extends MultiNodeSpec(DurablePruningSpec) with STMultiN
       }
       enterBarrier("removed")
       runOn(first) {
-        Await.ready(sys2.terminate(), 5.seconds)
+        sys2.close()
       }
 
       within(15.seconds) {

--- a/docs/src/test/scala/docs/io/ReadBackPressure.scala
+++ b/docs/src/test/scala/docs/io/ReadBackPressure.scala
@@ -90,6 +90,6 @@ class PullReadingSpec extends PekkoSpec with ImplicitSender {
     client.send(connection, ResumeReading)
     client.expectMsg(Received(ByteString("hello")))
 
-    Await.ready(system.terminate(), Duration.Inf)
+    system.close()
   }
 }

--- a/persistence-query/src/test/scala/org/apache/pekko/persistence/query/PersistenceQuerySpec.scala
+++ b/persistence-query/src/test/scala/org/apache/pekko/persistence/query/PersistenceQuerySpec.scala
@@ -15,9 +15,6 @@ package org.apache.pekko.persistence.query
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
-
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.persistence.journal.{ EventSeq, ReadEventAdapter }
@@ -102,7 +99,7 @@ class PersistenceQuerySpec extends AnyWordSpecLike with Matchers with BeforeAndA
 
     val sys = ActorSystem(s"sys-${systemCounter.incrementAndGet()}", config)
     try block(sys)
-    finally Await.ready(sys.terminate(), 10.seconds)
+    finally sys.close()
   }
 }
 

--- a/persistence-shared/src/test/scala/org/apache/pekko/persistence/serialization/SerializerSpec.scala
+++ b/persistence-shared/src/test/scala/org/apache/pekko/persistence/serialization/SerializerSpec.scala
@@ -16,9 +16,6 @@ package org.apache.pekko.persistence.serialization
 import java.io.NotSerializableException
 import java.util.UUID
 
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
-
 import org.apache.commons.codec.binary.Hex.{ decodeHex, encodeHex }
 
 import org.apache.pekko
@@ -348,9 +345,8 @@ class MessageSerializerRemotingSpec extends PekkoSpec(remote.withFallback(custom
     remoteSystem.actorOf(Props[RemoteActor](), "remote")
   }
 
-  override def afterTermination(): Unit = {
-    Await.ready(remoteSystem.terminate(), Duration.Inf)
-  }
+  override def afterTermination(): Unit =
+    remoteSystem.close()
 
   "A message serializer" must {
     "custom-serialize PersistentRepr messages during remoting" in {

--- a/persistence/src/test/scala/org/apache/pekko/persistence/EndToEndEventAdapterSpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/EndToEndEventAdapterSpec.scala
@@ -16,8 +16,6 @@ package org.apache.pekko.persistence
 import java.io.File
 
 import scala.annotation.nowarn
-import scala.concurrent.Await
-import scala.concurrent.duration._
 
 import org.apache.commons.io.FileUtils
 
@@ -187,7 +185,7 @@ class EndToEndEventAdapterSpec extends AnyWordSpecLike with Matchers with Before
   def withActorSystem[T](name: String, config: Config)(block: ActorSystem => T): T = {
     val system = ActorSystem(name, journalConfig.withFallback(config))
     try block(system)
-    finally Await.ready(system.terminate(), 3.seconds)
+    finally system.close()
   }
 
   "EventAdapters in end-to-end scenarios" must {

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/SystemMessageDeliverySpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/SystemMessageDeliverySpec.scala
@@ -184,7 +184,7 @@ class SystemMessageDeliverySpec extends AbstractSystemMessageDeliverySpec(System
         watch(remoteRef)
         remoteRef ! "hello"
         expectMsg("hello")
-        Await.ready(systemC.terminate(), 10.seconds)
+        systemC.close()
         system.log.debug("systemC terminated")
         // DeathWatchNotification is sent from systemC, failure detection takes longer than 3 seconds
         expectTerminated(remoteRef, 10.seconds)


### PR DESCRIPTION
Adds the `close` method on `ActorSystem` (classic and typed) as well as implementing the `AutoCloseable` interface, work taken from https://github.com/apache/pekko/pull/2479. Regardless of what happens with https://github.com/apache/pekko/issues/2093, the changes in this PR are always valid (`close` is blocking and returns `Unit`/`Void` so its valid for both `javadsl` and `scaladsl`).

The PR also cleans up test code by removing the `Await.result(system.close,...)` pattern that is used everywhere.

An overloaded `close(duration: Duration)` method can be added in Pekko 2.0.0 if https://github.com/apache/pekko/pull/2479 works out, as the `scaladsl` will use the Scala `Duration` and the `javadsl` will use the Java `Duration`.