### PR TITLE
Update Scala and Java API URLs in link validator

### DIFF
--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -51,12 +51,12 @@ site-link-validator {
   ignore-prefixes = [
     ## GitHub will block with "429 Too Many Requests"
     "https://github.com/"
-    "https://www.scala-lang.org/api/2.13.16/scala/runtime/AbstractFunction1.html"
-    "https://www.scala-lang.org/api/2.13.16/scala/runtime/AbstractFunction2.html"
-    "https://www.scala-lang.org/api/2.13.16/scala/runtime/AbstractFunction3.html"
-    "https://www.scala-lang.org/api/2.13.16/scala/runtime/AbstractPartialFunction.html"
+    "https://www.scala-lang.org/api/2.13.17/scala/runtime/AbstractFunction1.html"
+    "https://www.scala-lang.org/api/2.13.17/scala/runtime/AbstractFunction2.html"
+    "https://www.scala-lang.org/api/2.13.17/scala/runtime/AbstractFunction3.html"
+    "https://www.scala-lang.org/api/2.13.17/scala/runtime/AbstractPartialFunction.html"
     ## Bug, see https://github.com/scala/bug/issues/12807 and https://github.com/lampepfl/dotty/issues/17973
-    "https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/StandardOpenOption$.html"
+    "https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/file/StandardOpenOption$.html "
   ]
 
   non-https-whitelist = [


### PR DESCRIPTION
* fix link validator exclusions for Scala and Java
* https://github.com/apache/pekko/actions/runs/19288087737/job/55152785710
* there is also an issue with a link to microservices.com - I will do a separate PR for that - removing that link
