### PR TITLE
Update OnMessageIntroTest.java

### DIFF
--- a/actor-typed-tests/src/test/java/jdocs/org/apache/pekko/typed/OnMessageIntroTest.java
+++ b/actor-typed-tests/src/test/java/jdocs/org/apache/pekko/typed/OnMessageIntroTest.java
@@ -137,7 +137,7 @@ public interface OnMessageIntroTest {
          *     return onPublishSessionMessage(psm);
          *   }
          *
-         * Java 21 onward: JEP 441 (https://openjdk.org/jeps/441 =>
+         * Java 21 onward: JEP 441 (https://openjdk.org/jeps/441) =>
          // #chatroom-behavior
         // uses Java 21-onward features
         switch(msg) {


### PR DESCRIPTION
* copies over some of the changes from #2491 
* we still need to compile in Java 8 in 1.3.x but this brings some of the comments and commented out code examples up to date