### PR TITLE
Fix formatting of a URL in link-validator.conf

### DIFF
--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -56,7 +56,7 @@ site-link-validator {
     "https://www.scala-lang.org/api/2.13.17/scala/runtime/AbstractFunction3.html"
     "https://www.scala-lang.org/api/2.13.17/scala/runtime/AbstractPartialFunction.html"
     ## Bug, see https://github.com/scala/bug/issues/12807 and https://github.com/lampepfl/dotty/issues/17973
-    "https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/file/StandardOpenOption$.html "
+    "https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/file/StandardOpenOption$.html"
   ]
 
   non-https-whitelist = [


### PR DESCRIPTION
this link is failing in link validator CI job and the whitespace may be why it is not ignored

https://github.com/apache/pekko/actions/runs/19385491553