### PR TITLE
test pekko 1.3 with java 25

### DIFF
--- a/.github/workflows/nightly-1.3-builds.yml
+++ b/.github/workflows/nightly-1.3-builds.yml
@@ -127,7 +127,10 @@ jobs:
         # binary version is required and Pekko build will set the right
         # full version from it.
         scalaVersion: ["2.12.x", "2.13.x", "3.3.x"]
-        javaVersion: [8, 11, 17, 21]
+        javaVersion: [8, 11, 17, 21, 25]
+        exclude:
+          - scalaVersion: "2.12.x"
+            javaVersion: 25
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
scala 2.12.20 does not support java 25 (thus the exclude)