### PR TITLE
handle build issue in OSGi build code

### DIFF
--- a/project/OSGi.scala
+++ b/project/OSGi.scala
@@ -137,6 +137,8 @@ object OSGi {
       "!scala.util.parsing.*",
       scalaImport(scalaVersion))
   def pekkoImport(version: String, packageName: String = "org.apache.pekko.*") = {
+    // see https://github.com/apache/pekko/issues/2509 for background
+    // on why the version that is input might not be in the expected format
     val versionComponents = version.split('.')
     if (versionComponents.length < 2) {
       useDefaultImportRange(version, packageName)


### PR DESCRIPTION
fixes #2509 

Not having a semver version and having sbt-dynver derive versions like HEAD+20251117-1039 when the code is not under git control leads to other problems with the build but this issue breaks the build.

Other issues that we get with HEAD+20251117-1039 style versions include:
```
[error] bnd: Invalid value for Bundle-Version, HEAD+20251117-1039 does not match \d{1,9}(\.\d{1,9}(\.\d{1,9}(\.[-\w]+)?)?)?
```