### PR TITLE
dependabot: update GitHub Actions only weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
To reduce race conditions with https://github.com/apache/infrastructure-action