### PR TITLE
chore: Deprecate Source#future in javadsl (#2555)

### DIFF
--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/LazyAndFutureSourcesTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/LazyAndFutureSourcesTest.java
@@ -42,6 +42,7 @@ public class LazyAndFutureSourcesTest extends StreamTest {
   // note these are minimal happy path tests to cover API, more thorough tests are on the Scala side
 
   @Test
+  @SuppressWarnings("deprecation")
   public void future() throws Exception {
     CompletionStage<List<String>> result =
         Source.future(Future.successful("one")).runWith(Sink.seq(), system);

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -322,6 +322,7 @@ object Source {
    *
    * Here for Java interoperability, the normal use from Java should be [[Source.completionStage]]
    */
+  @deprecated("Use 'Source.completionStage' or 'scaladsl.Source.future' instead", "1.5.0")
   def future[T](futureElement: Future[T]): Source[T, NotUsed] =
     scaladsl.Source.future(futureElement).asJava
 
@@ -337,7 +338,7 @@ object Source {
    * If the `CompletionStage` is completed with a failure the stream is failed.
    */
   def completionStage[T](completionStage: CompletionStage[T]): Source[T, NotUsed] =
-    future(completionStage.asScala)
+    new Source(scaladsl.Source.future(completionStage.asScala))
 
   /**
    * Turn a `CompletionStage[Source]` into a source that will emit the values of the source when the future completes successfully.


### PR DESCRIPTION
port https://github.com/apache/pekko/pull/2555 to main