### PR TITLE
docs: use different reference for deserialization security

### DIFF
--- a/docs/src/main/paradox/remoting-artery.md
+++ b/docs/src/main/paradox/remoting-artery.md
@@ -270,7 +270,7 @@ compromising any node with certificates issued by the same internal PKI tree.
 
 By default, @ref[Java serialization](serialization.md#java-serialization) is disabled in Pekko.
 That is also security best-practice because of its multiple
-[known attack surfaces](https://community.microfocus.com/cyberres/fortify/f/fortify-discussions/317555/the-perils-of-java-deserialization).
+[known attack surfaces](https://docs.oracle.com/en/java/javase/25/core/addressing-serialization-vulnerabilities.html).
 
 <a id="remote-tls"></a>
 ### Configuring SSL/TLS for Pekko Remoting

--- a/docs/src/main/paradox/remoting.md
+++ b/docs/src/main/paradox/remoting.md
@@ -434,7 +434,7 @@ compromising any node with certificates issued by the same internal PKI tree.
 
 By default, @ref[Java serialization](serialization.md#java-serialization) is disabled in Pekko.
 That is also security best-practice because of its multiple
-[known attack surfaces](https://community.microfocus.com/cyberres/fortify/f/fortify-discussions/317555/the-perils-of-java-deserialization).
+[known attack surfaces](https://docs.oracle.com/en/java/javase/25/core/addressing-serialization-vulnerabilities.html).
 
 <a id="remote-tls"></a>
 ### Configuring SSL/TLS for Pekko Remoting

--- a/docs/src/main/paradox/serialization.md
+++ b/docs/src/main/paradox/serialization.md
@@ -218,7 +218,7 @@ Applications should use standard Protobuf dependency and not `pekko-protobuf-v3`
 
 ## Java serialization
 
-Java serialization is known to be slow and [prone to attacks](https://community.microfocus.com/cyberres/fortify/f/fortify-discussions/317555/the-perils-of-java-deserialization)
+Java serialization is known to be slow and [prone to attacks](https://docs.oracle.com/en/java/javase/25/core/addressing-serialization-vulnerabilities.html")
 of various kinds - it never was designed for high throughput messaging after all.
 One may think that network bandwidth and latency limit the performance of remote messaging, but serialization is a more typical bottleneck.
 


### PR DESCRIPTION
Since our previous link has a certificate configuration error now, and did not respond when we notified them of that.

Fixes https://github.com/apache/pekko/issues/2651.

This seems like a more 'authorative' reference anyway.