### PR TITLE
docs: replace ACM link with authors' site

### DIFF
--- a/docs/src/main/paradox/general/remoting.md
+++ b/docs/src/main/paradox/general/remoting.md
@@ -13,7 +13,7 @@ asynchronous. This effort has been undertaken to ensure that all functions are
 available equally when running within a single JVM or on a cluster of hundreds
 of machines. The key for enabling this is to go from remote to local by way of
 optimization instead of trying to go from local to remote by way of
-generalization. See [this classic paper](https://dl.acm.org/doi/pdf/10.5555/974938)
+generalization. See [this classic paper](https://waldo.scholars.harvard.edu/publications/note-distributed-computing)
 for a detailed discussion on why the second approach is bound to fail.
 
 ## Ways in which Transparency is Broken


### PR DESCRIPTION
While ACM seems to be one of the less-awful publishers, still nice to link to the 'actual source'. And is fixes the link checker as ACM seems to 403 when accessed from it.