### PR TITLE
Revert recent changes to recoverWith

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
@@ -36,16 +36,9 @@ import pekko.stream.Attributes.{ InputBuffer, LogLevels }
 import pekko.stream.Attributes.SourceLocation
 import pekko.stream.OverflowStrategies._
 import pekko.stream.Supervision.Decider
-import pekko.stream.impl.{
-  Buffer => BufferImpl,
-  ContextPropagation,
-  FailedSource,
-  JavaStreamSource,
-  ReactiveStreamsCompliance,
-  TraversalBuilder
-}
+import pekko.stream.impl.{ Buffer => BufferImpl, ContextPropagation, ReactiveStreamsCompliance, TraversalBuilder }
 import pekko.stream.impl.Stages.DefaultAttributes
-import pekko.stream.impl.fusing.GraphStages.{ FutureSource, SimpleLinearGraphStage, SingleSource }
+import pekko.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
 import pekko.stream.scaladsl.{
   DelayStrategy,
   Source,
@@ -2173,7 +2166,7 @@ private[pekko] object TakeWithin {
         import Collect.NotApplied
         if (maximumRetries < 0 || attempt < maximumRetries) {
           pf.applyOrElse(ex, NotApplied) match {
-            case _: NotApplied.type => failStage(ex)
+            case _: NotApplied.type                                                                               => failStage(ex)
             case source: Graph[SourceShape[T] @unchecked, M @unchecked] if TraversalBuilder.isEmptySource(source) =>
               completeStage()
             case other: Graph[SourceShape[T] @unchecked, M @unchecked] =>


### PR DESCRIPTION
see #2620 and https://github.com/apache/pekko-http/issues/954

This keeps tests and doc changes but reverts the Ops.scala changes from #1775 and #2631