### PR TITLE
Add dependabot support for GitHub Actions on branch 1.5.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "1.5.x"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
we're getting build failures for 1.5.x branch because the action versions are out of date 