### PR TITLE
Unpin sbt-java-formatter

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -24,8 +24,6 @@ updates.ignore = [
   { groupId = "tools.jackson.dataformat" }
   { groupId = "tools.jackson.datatype" }
   { groupId = "tools.jackson.jaxrs" }
-  # other ignored updates
-  { groupId = "com.lightbend.sbt", artifactId = "sbt-java-formatter" }
   # lmdbjava 0.9.2 causes issues - https://github.com/apache/pekko/issues/2484
   { groupId = "org.lmdbjava" }
 ]


### PR DESCRIPTION
We're already using a newer version with a different groupId since https://github.com/apache/pekko/pull/2081.