### PR TITLE
Unpin jackson-annotations

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -13,7 +13,6 @@ updates.pin = [
 updates.ignore = [
   // these will get updated along with jackson-core, so no need to update them
   // separately
-  { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-annotations" }
   { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-databind" }
   { groupId = "com.fasterxml.jackson.module" }
   { groupId = "com.fasterxml.jackson.dataformat" }


### PR DESCRIPTION
Jackson-annotations is unmoored from jackson-core from version 2.20, see https://github.com/FasterXML/jackson-annotations?tab=readme-ov-file#release-notes.