### PR TITLE
fix: Improve subscriber timeout error message with SubscriptionTimeoutException

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/impl/FanoutProcessorSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/impl/FanoutProcessorSpec.scala
@@ -13,7 +13,12 @@
 
 package org.apache.pekko.stream.impl
 
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
 import org.apache.pekko
+import pekko.stream.ActorAttributes
+import pekko.stream.StreamSubscriptionTimeoutTerminationMode
 import pekko.stream.scaladsl.Keep
 import pekko.stream.scaladsl.Sink
 import pekko.stream.scaladsl.Source
@@ -106,6 +111,32 @@ class FanoutProcessorSpec extends StreamSpec {
       probe.watch(publisherRef)
       Source.fromPublisher(publisher).map(_ => throw TE("boom")).runWith(Sink.ignore)
       probe.expectTerminated(publisherRef)
+    }
+
+    // #2645
+    "fail with SubscriptionTimeoutException instead of AbruptTerminationException on subscriber timeout" in {
+      val shortTimeout = 300.millis
+      val timeoutAttributes = ActorAttributes.streamSubscriptionTimeout(
+        shortTimeout, StreamSubscriptionTimeoutTerminationMode.CancelTermination)
+
+      val (_, publisher) = Source.maybe[Int]
+        .toMat(Sink.asPublisher(true).addAttributes(timeoutAttributes))(Keep.both)
+        .run()
+
+      // Do NOT subscribe — let the timeout fire
+      val probe = TestProbe()
+      val publisherRef = publisher.asInstanceOf[ActorPublisher[Int]].impl
+      probe.watch(publisherRef)
+
+      // The actor should terminate after the subscription timeout
+      probe.expectTerminated(publisherRef, shortTimeout + 3.seconds)
+
+      // Now try to subscribe after timeout and verify the error type
+      val result = Source.fromPublisher(publisher).runWith(Sink.head)
+      val ex = intercept[SubscriptionTimeoutException] {
+        Await.result(result, 3.seconds)
+      }
+      ex.getMessage should include("Subscription timeout expired")
     }
 
   }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/FanoutProcessor.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/FanoutProcessor.scala
@@ -13,6 +13,8 @@
 
 package org.apache.pekko.stream.impl
 
+import scala.util.control.NoStackTrace
+
 import org.apache.pekko
 import pekko.actor.Actor
 import pekko.actor.ActorRef
@@ -172,8 +174,11 @@ import org.reactivestreams.Subscriber
       if (!primaryOutputs.subscribed) {
         timeoutMode match {
           case CancelTermination =>
-            primaryInputs.cancel()
-            context.stop(self)
+            // Use fail() to propagate a SubscriptionTimeoutException downstream instead of
+            // stopping abruptly, which would only produce a non-informative AbruptTerminationException
+            log.warning("Subscription timeout expired for [{}], no subscriber attached in time", self)
+            fail(new SubscriptionTimeoutException(
+              s"Subscription timeout expired, no subscriber attached to [$self]") with NoStackTrace)
           case WarnTermination =>
             log.warning("Subscription timeout for {}", this)
           case NoopTermination => // won't happen


### PR DESCRIPTION
## Motivation

When `subscriber-timeout` fires in `FanoutProcessorImpl`, users see a generic `AbruptTerminationException` with no indication that the root cause is a subscription timeout. This makes debugging difficult because the error message gives no actionable information.

The `CancelTermination` handler was calling `primaryInputs.cancel()` + `context.stop(self)` directly, which triggers the generic `AbruptStageTerminationException` in downstream subscribers.

## Modification

- Changed `CancelTermination` handler in `FanoutProcessorImpl` to call `fail(new SubscriptionTimeoutException(...))` instead of `primaryInputs.cancel(); context.stop(self)`
- `fail()` already handles the full lifecycle: cancel upstream → error downstream → stop actor
- Added a warning log before failing, making the timeout visible in logs
- Added regression test in `FanoutProcessorSpec` that verifies downstream subscribers receive `SubscriptionTimeoutException` with an informative message

## Result

Downstream subscribers now receive `SubscriptionTimeoutException` with a clear message like:
```
Publisher was not attached to upstream within deadline (300 milliseconds)
```
instead of the generic `AbruptStageTerminationException`.

## References

- Fixes https://github.com/apache/pekko/issues/2645