### PR TITLE
fix: Reduce Java 25 nightly stream test flakiness

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -148,12 +148,18 @@ jobs:
 
       - name: Compile and Test
         # note that this is not running any multi-jvm tests because multi-in-test=false
+        # JDK 25 ForkJoinPool scheduling changes need a higher timefactor (see #2573)
         run: |-
+          if [ "${{ matrix.javaVersion }}" -ge 25 ]; then
+            TIMEFACTOR=3
+          else
+            TIMEFACTOR=2
+          fi
           sbt \
             -Dpekko.cluster.assert=on \
             -Dpekko.log.timestamps=true \
-            -Dpekko.test.timefactor=2 \
-            -Dpekko.actor.testkit.typed.timefactor=2 \
+            -Dpekko.test.timefactor=$TIMEFACTOR \
+            -Dpekko.actor.testkit.typed.timefactor=$TIMEFACTOR \
             -Dpekko.test.tags.exclude=gh-exclude,timing \
             -Dpekko.test.multi-in-test=false \
             -Dio.netty.leakDetection.level=PARANOID \

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/AggregateWithBoundarySpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/AggregateWithBoundarySpec.scala
@@ -41,7 +41,7 @@ class AggregateWithBoundarySpec extends StreamSpec {
         }, harvest = buffer => buffer.toSeq, emitOnTimer = None)
       .runWith(Sink.collection)
 
-    Await.result(result, 10.seconds) should be(stream.grouped(groupSize).toSeq)
+    Await.result(result, 30.seconds) should be(stream.grouped(groupSize).toSeq)
 
   }
 
@@ -58,7 +58,7 @@ class AggregateWithBoundarySpec extends StreamSpec {
         emitOnTimer = None)
       .runWith(Sink.collection)
 
-    Await.result(result, 10.seconds) should be(stream.grouped(groupSize).toSeq.map(seq => seq :+ -1))
+    Await.result(result, 30.seconds) should be(stream.grouped(groupSize).toSeq.map(seq => seq :+ -1))
 
   }
 
@@ -73,7 +73,7 @@ class AggregateWithBoundarySpec extends StreamSpec {
         }, harvest = buffer => buffer.toSeq, emitOnTimer = None)
       .runWith(Sink.collection)
 
-    Await.result(result, 10.seconds) should be(Seq(Seq(1, 2, 3, 4), Seq(5, 6), Seq(7)))
+    Await.result(result, 30.seconds) should be(Seq(Seq(1, 2, 3, 4), Seq(5, 6), Seq(7)))
   }
 
 }
@@ -186,7 +186,7 @@ class AggregateWithTimeBoundaryAndSimulatedTimeSpec extends AnyWordSpecLike with
     p.sendNext(7)
     p.sendComplete()
 
-    Await.result(result, 10.seconds) should be(Seq(Seq(1, 2), Seq(3, 4), Seq(5, 6, 7)))
+    Await.result(result, 30.seconds) should be(Seq(Seq(1, 2), Seq(3, 4), Seq(5, 6, 7)))
 
   }
 
@@ -227,7 +227,7 @@ class AggregateWithTimeBoundaryAndSimulatedTimeSpec extends AnyWordSpecLike with
     p.sendNext(7)
     p.sendComplete()
 
-    Await.result(result, 10.seconds) should be(Seq(Seq(1, 2, 3, 4), Seq(5, 6, 7)))
+    Await.result(result, 30.seconds) should be(Seq(Seq(1, 2, 3, 4), Seq(5, 6, 7)))
 
   }
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowFlatMapConcatParallelismSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowFlatMapConcatParallelismSpec.scala
@@ -33,9 +33,17 @@ import pekko.stream._
 import pekko.stream.testkit.{ ScriptedTest, StreamSpec }
 import pekko.stream.testkit.scaladsl.TestSink
 
+import org.scalatest.time.{ Seconds, Span }
+
 class FlowFlatMapConcatParallelismSpec extends StreamSpec("""
     pekko.stream.materializer.initial-input-buffer-size = 2
   """) with ScriptedTest with FutureTimeoutSupport {
+
+  // 100K-element tests need extra headroom, especially on JDK 25+ where
+  // ForkJoinPool scheduling changes slow down highly-parallel workloads (#2573)
+  override implicit val patience: PatienceConfig =
+    PatienceConfig(timeout = Span(30, Seconds), interval = Span(1, Seconds))
+
   val toSeq = Flow[Int].grouped(1000).toMat(Sink.head)(Keep.right)
 
   class BoomException extends RuntimeException("BOOM~~") with NoStackTrace

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
@@ -30,8 +30,15 @@ import pekko.stream.testkit.scaladsl.TestSink
 import pekko.stream.testkit.scaladsl.TestSource
 import pekko.testkit.EventFilter
 
+import org.scalatest.time.{ Seconds, Span }
+
 class HubSpec extends StreamSpec {
   implicit val ec: ExecutionContext = system.dispatcher
+
+  // Long-stream tests (20K elements) need extra headroom on JDK 25+
+  // where ForkJoinPool scheduling changes cause slower throughput (#2573)
+  override implicit val patience: PatienceConfig =
+    PatienceConfig(timeout = Span(30, Seconds), interval = Span(1, Seconds))
 
   "MergeHub" must {
 

--- a/stream-typed-tests/src/test/scala/org/apache/pekko/stream/MapAsyncPartitionedSpec.scala
+++ b/stream-typed-tests/src/test/scala/org/apache/pekko/stream/MapAsyncPartitionedSpec.scala
@@ -107,8 +107,10 @@ class MapAsyncPartitionedSpec
 
   import MapAsyncPartitionedSpec.TestData._
 
+  // Property-based tests with blocking operations need extra headroom,
+  // especially on JDK 25+ with ForkJoinPool scheduling changes (#2573)
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(
-    timeout = 5.seconds,
+    timeout = 15.seconds,
     interval = 100.millis)
 
   private implicit val system: ActorSystem[_] = ActorSystem(Behaviors.empty, "test-system")


### PR DESCRIPTION
## Motivation

JDK 25 introduced changes to `ForkJoinPool` scheduling behavior that cause ~100+ stream test failures per nightly CI run. The most affected tests are high-throughput stream tests (`FlowFlatMapConcatParallelismSpec`, `HubSpec`, `MapAsyncPartitionedSpec`, `AggregateWithBoundarySpec`) that have timing-sensitive assertions.

## Modification

1. **Nightly CI (`.github/workflows/nightly-builds.yml`)**: Added `timefactor=3` for JDK 25+ builds, scaling all `dilated` timeouts across the entire test suite
2. **`FlowFlatMapConcatParallelismSpec`**: Added explicit `PatienceConfig(30.seconds)` for high-element-count tests (100K elements)
3. **`HubSpec`**: Added explicit `PatienceConfig(30.seconds)` for 20K+ element throughput tests
4. **`MapAsyncPartitionedSpec`**: Increased patience from 5s to 15s (3x, matching timefactor)
5. **`AggregateWithBoundarySpec`**: Increased `Await.result` timeouts from 10s to 30s (3x)

## Result

- All modified tests pass locally
- The `timefactor=3` in nightly CI provides a safety net for tests without explicit overrides
- Explicit timeout increases target the highest-failure tests identified from nightly CI logs

## References

- Fixes https://github.com/apache/pekko/issues/2573