### PR TITLE
switch some tests over to using junit-jupiter naming

### DIFF
--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/JUnit5IntegrationExampleTest.java
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/JUnit5IntegrationExampleTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(TestKitJUnitJupiterExtension.class)
 class JUnit5IntegrationExampleTest {
 
-  @JUnitJupiterTestKit public ActorTestKit testKit = new JUnitJupiterTestKit().build();
+  @JUnitJupiterTestKit public ActorTestKit testKit = new JUnitJupiterTestKitBuilder().build();
 
   @Test
   void junit5Test() {

--- a/actor-testkit-typed/src/test/java/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKitJUnit5Test.java
+++ b/actor-testkit-typed/src/test/java/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKitJUnit5Test.java
@@ -29,7 +29,7 @@ import org.scalatestplus.junit.JUnitSuite;
 @ExtendWith(LogCapturingExtension.class)
 class ActorTestKitJUnit5Test extends JUnitSuite {
 
-  @JUnitJupiterTestKit public ActorTestKit testKit = new JUnitJupiterTestKit().build();
+  @JUnitJupiterTestKit public ActorTestKit testKit = new JUnitJupiterTestKitBuilder().build();
 
   @Test
   void systemNameShouldComeFromTestClassViaJunitResource() {


### PR DESCRIPTION
We now use junit jupiter v6 so using junit5 naming seems outdated.

We already have some classes named as JunitJupiter to facilitate this switch