### PR TITLE
add test for groupBy not throwing tooManySubstreamsOpenException on closed substream

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowGroupBySpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowGroupBySpec.scala
@@ -707,6 +707,23 @@ class FlowGroupBySpec extends StreamSpec("""
         .expectComplete()
     }
 
+    "not throw tooManySubstreamsOpenException for element on closed substream" in {
+      val publisher = TestPublisher.Probe[(Int, Boolean)]()
+      val outProbe =
+        Source.fromPublisher(publisher).groupBy(2, _._1).takeWhile(_._2 != false).mergeSubstreams.runWith(TestSink())
+      outProbe.request(4)
+      publisher.sendNext((1, true))
+      outProbe.expectNext((1, true))
+      publisher.sendNext((2, true))
+      outProbe.expectNext((2, true))
+      publisher.sendNext((2, false)) // substream 2 completed
+      publisher.sendNext((2, false)) // should be dropped, not crash the stream
+      publisher.sendNext((1, true))
+      outProbe.expectNext((1, true))
+
+      outProbe.cancel()
+    }
+
   }
 
 }


### PR DESCRIPTION
We already have our own fix for https://github.com/akka/akka-core/pull/31872 but it is useful to add the Akka test.

part of #2730  