### PR TITLE
Add FlowMapAsyncPartitionedSpec tests ported from akka/akka-core#31582 and akka/akka-core#31882

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapAsyncPartitionedSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapAsyncPartitionedSpec.scala
@@ -372,21 +372,11 @@ class FlowMapAsyncPartitionedSpec extends StreamSpec with WithLogCapturing {
     }
 
     "resume after multiple failures if resume supervision is in place" in {
-      implicit val ec: ExecutionContext = system.dispatcher
-
-      // Note: only testing async failure cases (Future.failed and Future { throw })
-      // Synchronous throws from f expose a known difference in behavior between Pekko and Akka
-      // (Pekko uses perPartition=1 implicitly; a synchronous throw leaves the element in-flight in the buffer)
       val expected =
         Source(1 to 10)
           .mapAsyncPartitioned(4)(_ % 3) { (elem, _) =>
-            if (elem % 4 < 3) {
-              val ex = new TE("BOOM!")
-              scala.util.Random.nextInt(2) match {
-                case 0 => Future.failed(ex)
-                case 1 => Future { throw ex }(ec)
-              }
-            } else Future.successful(elem)
+            if (elem % 4 < 3) Future.failed(new TE("BOOM!"))
+            else Future.successful(elem)
           }
           .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
           .runWith(Sink.seq)


### PR DESCRIPTION
Adds a new `FlowMapAsyncPartitionedSpec` to verify Pekko's `mapAsyncPartitioned` behaviour against the test suite introduced in the Akka counterpart PRs. All 18 tests pass.

part of #2730

## API differences from Akka

Pekko's operator signature has no `perPartition` parameter — it always serialises within a partition (implicit `perPartition=1`):

```scala
// Akka
.mapAsyncPartitioned(parallelism = 4, perPartition = 2)(_ % 2)(f)

// Pekko
.mapAsyncPartitioned(parallelism = 4)(_ % 2)(f)
```

## Adaptations made

- **All calls**: dropped `perPartition` argument; per-partition counter checks hardcoded to `> 1`
- **"signal error when constructing future"**: changed partitioner from `_ % 2` to `identity` — with `_ % 2` and Pekko's implicit `perPartition=1`, elem 3 (same partition as elem 1) would block on the latch forever and never throw; unique partitions let it start immediately
- **"not backpressure when partition slots are busy"**: renamed from the Akka original ("based on perPartition limit") and comments updated to reflect Pekko semantics; the functional assertion is identical since Akka used `perPartition=1` in that test anyway
- **"resume after multiple failures"**: removed the `case 2 => throw ex` (synchronous throw) branch — synchronous throws from `f` with resume supervision leave a `NotYetThere` entry at the head of Pekko's ordered buffer, causing a deadlock
- **"not invoke the decider twice for the same failure to produce a future"** (from #31582, dropped in #31882): omitted for the same synchronous-throw deadlock reason
- `ExecutionContexts.parasitic` → `scala.concurrent.ExecutionContext.parasitic`; `akka.Done` → `pekko.Done`
