### PR TITLE
chore: safer EventEnvelope.toString

### DIFF
--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/EventEnvelope.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/EventEnvelope.scala
@@ -85,8 +85,13 @@ final class EventEnvelope(
     case _ => false
   }
 
-  override def toString: String =
-    s"EventEnvelope($offset,$persistenceId,$sequenceNr,$event,$timestamp,$eventMetadata)"
+  override def toString: String = {
+    val metaStr = eventMetadata match {
+      case Some(meta) => meta.getClass.getName
+      case None       => ""
+    }
+    s"EventEnvelope($offset,$persistenceId,$sequenceNr,${event.getClass.getName},$timestamp,$metaStr)"
+  }
 
   // for binary compatibility (used to be a case class)
   def copy(

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/typed/EventEnvelope.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/typed/EventEnvelope.scala
@@ -121,6 +121,15 @@ final class EventEnvelope[Event](
     case _ => false
   }
 
-  override def toString: String =
-    s"EventEnvelope($offset,$persistenceId,$sequenceNr,$eventOption,$timestamp,$eventMetadata,$entityType,$slice)"
+  override def toString: String = {
+    val eventStr = eventOption match {
+      case Some(evt) => evt.getClass.getName
+      case None      => ""
+    }
+    val metaStr = eventMetadata match {
+      case Some(meta) => meta.getClass.getName
+      case None       => ""
+    }
+    s"EventEnvelope($offset,$persistenceId,$sequenceNr,$eventStr,$timestamp,$metaStr,$entityType,$slice)"
+  }
 }


### PR DESCRIPTION
Port of [akka/akka-core#31804](https://github.com/akka/akka-core/pull/31804). `EventEnvelope.toString` included full object representations of event and metadata, risking verbose or sensitive data exposure in logs.

part of #2730 

## Changes

- **`typed/EventEnvelope`**: Replace `$eventOption` and `$eventMetadata` interpolation with class name lookups (`evt.getClass.getName` / `meta.getClass.getName`), using `""` for absent values.
- **`EventEnvelope`** (non-typed): Same treatment for `$event` and `$eventMetadata`.

**Before:**
```
EventEnvelope(offset,my-id,1,Some(MyEvent(field1=..., field2=...)),1672000000,Some(MyMeta(...)),MyEntity,0)
```

**After:**
```
EventEnvelope(offset,my-id,1,com.example.MyEvent,1672000000,com.example.MyMeta,MyEntity,0)
```
