### PR TITLE
Port akka-core#31753: Run DurableStateBehavior delete effect asynchronously like persist

### DIFF
--- a/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/state/scaladsl/DurableStateBehaviorReplySpec.scala
+++ b/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/state/scaladsl/DurableStateBehaviorReplySpec.scala
@@ -92,7 +92,7 @@ class DurableStateBehaviorReplySpec
   val pidCounter = new AtomicInteger(0)
   private def nextPid(): PersistenceId = PersistenceId.ofUniqueId(s"c${pidCounter.incrementAndGet()}")
 
-  "A typed persistent actor with commands that are expecting replies" must {
+  "A DurableStateBehavior actor with commands that are expecting replies" must {
 
     "persist state thenReply" in {
       val c = spawn(counter(nextPid()))
@@ -136,6 +136,29 @@ class DurableStateBehaviorReplySpec
       val queryProbe = TestProbe[State]()
       c ! GetValue(queryProbe.ref)
       queryProbe.expectMessage(State(0))
+    }
+
+    "handle commands sequentially" in {
+      val c = spawn(counter(nextPid()))
+      val probe = TestProbe[Any]()
+
+      c ! IncrementWithConfirmation(probe.ref)
+      c ! IncrementWithConfirmation(probe.ref)
+      c ! IncrementWithConfirmation(probe.ref)
+      c ! GetValue(probe.ref)
+      probe.expectMessage(Done)
+      probe.expectMessage(Done)
+      probe.expectMessage(Done)
+      probe.expectMessage(State(3))
+
+      c ! IncrementWithConfirmation(probe.ref)
+      c ! IncrementWithConfirmation(probe.ref)
+      c ! DeleteWithConfirmation(probe.ref)
+      c ! GetValue(probe.ref)
+      probe.expectMessage(Done)
+      probe.expectMessage(Done)
+      probe.expectMessage(Done)
+      probe.expectMessage(State(0))
     }
   }
 }

--- a/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/state/scaladsl/DurableStateBehaviorSpec.scala
+++ b/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/state/scaladsl/DurableStateBehaviorSpec.scala
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2021-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package org.apache.pekko.persistence.typed.state.scaladsl
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.apache.pekko
+import pekko.Done
+import pekko.actor.testkit.typed.TestKitSettings
+import pekko.actor.testkit.typed.scaladsl._
+import pekko.actor.typed.ActorRef
+import pekko.persistence.testkit.PersistenceTestKitDurableStateStorePlugin
+import pekko.persistence.typed.PersistenceId
+import pekko.serialization.jackson.CborSerializable
+
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+
+object DurableStateBehaviorSpec {
+
+  def conf: Config = PersistenceTestKitDurableStateStorePlugin.config.withFallback(ConfigFactory.parseString(s"""
+    pekko.loglevel = INFO
+    """))
+
+  sealed trait Command extends CborSerializable
+  final case class IncrementWithConfirmation(replyTo: ActorRef[Done]) extends Command
+  final case class GetValue(replyTo: ActorRef[State]) extends Command
+  final case class DeleteWithConfirmation(replyTo: ActorRef[Done]) extends Command
+  case class IncrementBy(by: Int) extends Command
+
+  final case class State(value: Int) extends CborSerializable
+
+  def counter(persistenceId: PersistenceId): DurableStateBehavior[Command, State] = {
+    DurableStateBehavior(
+      persistenceId,
+      emptyState = State(0),
+      commandHandler = (state, command) =>
+        command match {
+
+          case IncrementBy(by) =>
+            Effect.persist(state.copy(value = state.value + by))
+
+          case IncrementWithConfirmation(replyTo) =>
+            Effect.persist(state.copy(value = state.value + 1)).thenRun(_ => replyTo ! Done)
+
+          case GetValue(replyTo) =>
+            replyTo ! state
+            Effect.none
+
+          case DeleteWithConfirmation(replyTo) =>
+            Effect.delete[State]().thenRun(_ => replyTo ! Done)
+        })
+  }
+}
+
+class DurableStateBehaviorSpec
+    extends ScalaTestWithActorTestKit(DurableStateBehaviorSpec.conf)
+    with AnyWordSpecLike
+    with LogCapturing {
+  import DurableStateBehaviorSpec._
+
+  implicit val testSettings: TestKitSettings = TestKitSettings(system)
+
+  val pidCounter = new AtomicInteger(0)
+  private def nextPid(): PersistenceId = PersistenceId.ofUniqueId(s"c${pidCounter.incrementAndGet()}")
+
+  "A DurableStateBehavior actor" must {
+    "persist and update state" in {
+      val c = spawn(counter(nextPid()))
+      val updateProbe = TestProbe[Done]()
+      val queryProbe = TestProbe[State]()
+
+      c ! IncrementWithConfirmation(updateProbe.ref)
+      updateProbe.expectMessage(Done)
+
+      c ! GetValue(queryProbe.ref)
+      queryProbe.expectMessage(State(1))
+
+      c ! IncrementBy(5)
+      c ! IncrementWithConfirmation(updateProbe.ref)
+      updateProbe.expectMessage(Done)
+
+      c ! GetValue(queryProbe.ref)
+      queryProbe.expectMessage(State(7))
+    }
+
+    "delete state" in {
+      val c = spawn(counter(nextPid()))
+      val updateProbe = TestProbe[Done]()
+      c ! IncrementWithConfirmation(updateProbe.ref)
+      updateProbe.expectMessage(Done)
+
+      val deleteProbe = TestProbe[Done]()
+      c ! DeleteWithConfirmation(deleteProbe.ref)
+      deleteProbe.expectMessage(Done)
+
+      val queryProbe = TestProbe[State]()
+      c ! GetValue(queryProbe.ref)
+      queryProbe.expectMessage(State(0))
+    }
+
+    "handle commands sequentially" in {
+      val c = spawn(counter(nextPid()))
+      val probe = TestProbe[Any]()
+
+      c ! IncrementWithConfirmation(probe.ref)
+      c ! IncrementWithConfirmation(probe.ref)
+      c ! IncrementWithConfirmation(probe.ref)
+      c ! GetValue(probe.ref)
+      probe.expectMessage(Done)
+      probe.expectMessage(Done)
+      probe.expectMessage(Done)
+      probe.expectMessage(State(3))
+
+      c ! DeleteWithConfirmation(probe.ref)
+      c ! GetValue(probe.ref)
+      probe.expectMessage(Done)
+      probe.expectMessage(State(0))
+    }
+  }
+}

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/internal/DurableStateStoreInteractions.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/internal/DurableStateStoreInteractions.scala
@@ -68,13 +68,13 @@ private[pekko] trait DurableStateStoreInteractions[C, S] {
 
   protected def internalDelete(
       ctx: ActorContext[InternalProtocol],
-      cmd: Any,
+      @nowarn("msg=never used") cmd: Any,
       state: Running.RunningState[S, C]): Running.RunningState[S, C] = {
 
     val newRunningState: Running.RunningState[S, C] = state.nextRevision().copy(state = setup.emptyState)
     val persistenceId = setup.persistenceId.id
 
-    onDeleteInitiated(ctx, cmd)
+    // TODO Might need to call hook method for Telemetry
 
     ctx.pipeToSelf[Done](setup.durableStateStore.deleteObject(persistenceId, newRunningState.revision)) {
       case Success(_)     => InternalProtocol.DeleteSuccess
@@ -84,12 +84,9 @@ private[pekko] trait DurableStateStoreInteractions[C, S] {
     newRunningState
   }
 
-  // FIXME These hook methods are for Telemetry. What more parameters are needed? persistenceId?
+  // TODO These hook methods are for Telemetry. What more parameters are needed? persistenceId?
   @InternalStableApi
   private[pekko] def onWriteInitiated(@nowarn("msg=never used") ctx: ActorContext[_],
-      @nowarn("msg=never used") cmd: Any): Unit = ()
-
-  private[pekko] def onDeleteInitiated(@nowarn("msg=never used") ctx: ActorContext[_],
       @nowarn("msg=never used") cmd: Any): Unit = ()
 
   protected def requestRecoveryPermit(): Unit = {

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/internal/Running.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/internal/Running.scala
@@ -195,6 +195,16 @@ private[pekko] object Running {
       (persistingState(newState2, state, sideEffects), false)
     }
 
+    private def handleDelete(
+        cmd: Any,
+        sideEffects: immutable.Seq[SideEffect[S]]): (Behavior[InternalProtocol], Boolean) = {
+      _currentRevision = state.revision + 1
+
+      val nextState = internalDelete(setup.context, cmd, state)
+
+      (persistingState(nextState, state, sideEffects), false)
+    }
+
     @tailrec def applyEffects(
         msg: Any,
         state: RunningState[S, C],
@@ -219,8 +229,7 @@ private[pekko] object Running {
           (applySideEffects(sideEffects, state), true)
 
         case _: Delete[_] =>
-          val nextState = internalDelete(setup.context, msg, state)
-          (applySideEffects(sideEffects, nextState), true)
+          handleDelete(msg, sideEffects)
 
         case _: Unhandled.type =>
           import pekko.actor.typed.scaladsl.adapter._
@@ -271,12 +280,12 @@ private[pekko] object Running {
         case UpsertFailure(exc)                => onUpsertFailed(exc)
         case in: IncomingCommand[C @unchecked] => onCommand(in)
         case get: GetState[S @unchecked]       => stashInternal(get)
+        case DeleteSuccess                     => onDeleteSuccess()
+        case DeleteFailure(exc)                => onDeleteFailed(exc)
         case RecoveryTimeout                   => Behaviors.unhandled
         case RecoveryPermitGranted             => Behaviors.unhandled
         case _: GetSuccess[_]                  => Behaviors.unhandled
         case _: GetFailure                     => Behaviors.unhandled
-        case DeleteSuccess                     => Behaviors.unhandled
-        case DeleteFailure(_)                  => Behaviors.unhandled
       }
     }
 
@@ -305,6 +314,24 @@ private[pekko] object Running {
 
     final def onUpsertFailed(cause: Throwable): Behavior[InternalProtocol] = {
       onWriteFailed(setup.context, cause)
+      throw new DurableStateStoreException(setup.persistenceId, currentRevision, cause)
+    }
+
+    final def onDeleteSuccess(): Behavior[InternalProtocol] = {
+      if (setup.internalLogger.isDebugEnabled) {
+        setup.internalLogger
+          .debug("Received DeleteSuccess response after: {} nanos", System.nanoTime() - persistStartTime)
+      }
+
+      // TODO Might need to call hook method for Telemetry
+
+      visibleState = state
+      val newState = applySideEffects(sideEffects, state)
+      tryUnstashOne(newState)
+    }
+
+    final def onDeleteFailed(cause: Throwable): Behavior[InternalProtocol] = {
+      // TODO Might need to call hook method for Telemetry
       throw new DurableStateStoreException(setup.persistenceId, currentRevision, cause)
     }
 


### PR DESCRIPTION
`Delete` effects in `DurableStateBehavior` were applied synchronously — side effects (`thenRun`, `thenReply`) fired immediately without waiting for the store to confirm the delete. This broke command ordering: commands queued after a delete could be processed before the delete completed.

https://github.com/akka/akka-core/pull/31753

part of #2730

## Changes

- **`Running.scala`**: Added `handleDelete` in `HandlingCommands` that transitions to `PersistingState` (mirroring `handlePersist`). Added `onDeleteSuccess`/`onDeleteFailed` handlers to `PersistingState`. `DeleteSuccess`/`DeleteFailure` messages were previously `Behaviors.unhandled`.
- **`DurableStateStoreInteractions.scala`**: Removed `onDeleteInitiated` hook (unused telemetry stub). Annotated `cmd` parameter as `@nowarn` unused.
- **`DurableStateBehaviorReplySpec.scala`**: Renamed test suite; added `"handle commands sequentially"` test covering mixed increment + delete ordering.
- **`DurableStateBehaviorSpec.scala`** _(new)_: Basic tests for persist, delete, and sequential command handling on `DurableStateBehavior`.

```scala
c ! IncrementWithConfirmation(probe.ref)
c ! IncrementWithConfirmation(probe.ref)
c ! DeleteWithConfirmation(probe.ref)
c ! GetValue(probe.ref)
// Previously: GetValue could resolve before DeleteWithConfirmation completed
// Now: guaranteed ordering — Done, Done, Done, State(0)
probe.expectMessage(Done)
probe.expectMessage(Done)
probe.expectMessage(Done)
probe.expectMessage(State(0))
```
