### PR TITLE
chore: Rename Junit5 to JunitJupiter

### DIFF
--- a/actor-testkit-typed/src/main/java/org/apache/pekko/actor/testkit/typed/annotations/JUnit5TestKit.java
+++ b/actor-testkit-typed/src/main/java/org/apache/pekko/actor/testkit/typed/annotations/JUnit5TestKit.java
@@ -22,4 +22,4 @@ import java.lang.annotation.*;
 @Documented
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface JUnit5TestKit {}
+public @interface JunitJupiterTestKit {}

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/JUnit5TestKitBuilder.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/JUnit5TestKitBuilder.scala
@@ -24,25 +24,25 @@ import pekko.actor.typed.ActorSystem
 
 import com.typesafe.config.Config
 
-final class JUnit5TestKitBuilder() {
+final class JunitJupiterTestKitBuilder() {
 
   var system: Option[ActorSystem[_]] = None
 
   var customConfig: Config = ApplicationTestConfig
 
-  var name: String = TestKitUtils.testNameFromCallStack(classOf[JUnit5TestKitBuilder])
+  var name: String = TestKitUtils.testNameFromCallStack(classOf[JunitJupiterTestKitBuilder])
 
-  def withSystem(system: ActorSystem[_]): JUnit5TestKitBuilder = {
+  def withSystem(system: ActorSystem[_]): JunitJupiterTestKitBuilder = {
     this.system = Some(system)
     this
   }
 
-  def withCustomConfig(customConfig: Config): JUnit5TestKitBuilder = {
+  def withCustomConfig(customConfig: Config): JunitJupiterTestKitBuilder = {
     this.customConfig = customConfig
     this
   }
 
-  def withName(name: String): JUnit5TestKitBuilder = {
+  def withName(name: String): JunitJupiterTestKitBuilder = {
     this.name = name
     this
   }

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJUnit5Extension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJUnit5Extension.scala
@@ -20,22 +20,22 @@ package org.apache.pekko.actor.testkit.typed.javadsl
 import org.junit.jupiter.api.extension.{ AfterAllCallback, BeforeTestExecutionCallback, ExtensionContext }
 import org.junit.platform.commons.support.AnnotationSupport
 
-import org.apache.pekko.actor.testkit.typed.annotations.JUnit5TestKit
+import org.apache.pekko.actor.testkit.typed.annotations.JunitJupiterTestKit
 
-final class TestKitJUnit5Extension() extends AfterAllCallback with BeforeTestExecutionCallback {
+final class TestKitJunitJupiterExtension() extends AfterAllCallback with BeforeTestExecutionCallback {
 
   var testKit: Option[ActorTestKit] = None
 
   /**
-   * Get a reference to the field annotated with `@JUnit5Testkit` [[JUnit5TestKit]]
+   * Get a reference to the field annotated with `@JunitJupiterTestkit` [[JunitJupiterTestKit]]
    */
   override def beforeTestExecution(context: ExtensionContext): Unit = {
     val testInstance: Option[AnyRef] =
       if (context.getTestInstance.isPresent) Some(context.getTestInstance.get()) else None
     testInstance.map(instance => {
-      val annotations = AnnotationSupport.findAnnotatedFieldValues(instance, classOf[JUnit5TestKit])
+      val annotations = AnnotationSupport.findAnnotatedFieldValues(instance, classOf[JunitJupiterTestKit])
       val fieldValue = annotations.stream().findFirst().orElseThrow(() =>
-        throw new IllegalArgumentException("Could not find field annotated with @JUnit5TestKit"))
+        throw new IllegalArgumentException("Could not find field annotated with @JunitJupiterTestKit"))
       testKit = Some(fieldValue.asInstanceOf[ActorTestKit])
     })
   }

--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/JUnit5IntegrationExampleTest.java
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/JUnit5IntegrationExampleTest.java
@@ -20,15 +20,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-// #junit5-integration
-@DisplayName("JUnit5")
+// #JunitJupiter-integration
+@DisplayName("JunitJupiter")
 @ExtendWith(TestKitJUnitJupiterExtension.class)
-class JUnit5IntegrationExampleTest {
+class JunitJupiterIntegrationExampleTest {
 
   @JUnitJupiterTestKit public ActorTestKit testKit = new JUnitJupiterTestKitBuilder().build();
 
   @Test
-  void junit5Test() {
+  void JunitJupiterTest() {
     Address address = testKit.system().address();
     assertNotNull(address);
   }
@@ -56,4 +56,4 @@ class JUnit5IntegrationExampleTest {
     assertEquals("hello", pong.message);
   }
 }
-// #junit5-integration
+// #JunitJupiter-integration

--- a/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/JUnit5TestKitBuilderSpec.scala
+++ b/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/JUnit5TestKitBuilderSpec.scala
@@ -18,50 +18,50 @@
 package org.apache.pekko.actor.testkit.typed.scaladsl
 
 import org.apache.pekko
-import org.apache.pekko.actor.testkit.typed.javadsl.JUnit5TestKitBuilder
+import org.apache.pekko.actor.testkit.typed.javadsl.JunitJupiterTestKitBuilder
 import pekko.actor.typed.ActorSystem
 
 import org.scalatest.wordspec.AnyWordSpec
 
 import com.typesafe.config.ConfigFactory
 
-class JUnit5TestKitBuilderSpec extends AnyWordSpec {
+class JunitJupiterTestKitBuilderSpec extends AnyWordSpec {
 
-  "the JUnit5TestKitBuilder" should {
+  "the JunitJupiterTestKitBuilder" should {
     "create a Testkit with name hello" in {
-      val actualTestKit = new JUnit5TestKitBuilder().withName("hello").build()
+      val actualTestKit = new JunitJupiterTestKitBuilder().withName("hello").build()
 
       assertResult("hello")(actualTestKit.system.name)
     }
   }
 
-  "the JUnit5TestKitBuilder" should {
+  "the JunitJupiterTestKitBuilder" should {
     "create a Testkit with the classname as name" in {
-      val actualTestKit = new JUnit5TestKitBuilder()
+      val actualTestKit = new JunitJupiterTestKitBuilder()
         .build()
 
-      assertResult("JUnit5TestKitBuilderSpec")(actualTestKit.system.name)
+      assertResult("JunitJupiterTestKitBuilderSpec")(actualTestKit.system.name)
     }
   }
 
-  "the JUnit5TestKitBuilder" should {
+  "the JunitJupiterTestKitBuilder" should {
     "create a Testkit with a custom config" in {
 
       val conf = ConfigFactory.load("application.conf")
-      val actualTestKit = new JUnit5TestKitBuilder()
+      val actualTestKit = new JunitJupiterTestKitBuilder()
         .withCustomConfig(conf)
         .build()
       assertResult("someValue")(actualTestKit.system.settings.config.getString("test.value"))
-      assertResult("JUnit5TestKitBuilderSpec")(actualTestKit.system.name)
+      assertResult("JunitJupiterTestKitBuilderSpec")(actualTestKit.system.name)
 
     }
   }
 
-  "the JUnit5TestKitBuilder" should {
+  "the JunitJupiterTestKitBuilder" should {
     "create a Testkit with a custom config and name" in {
 
       val conf = ConfigFactory.load("application.conf")
-      val actualTestKit = new JUnit5TestKitBuilder()
+      val actualTestKit = new JunitJupiterTestKitBuilder()
         .withCustomConfig(conf)
         .withName("hello")
         .build()
@@ -71,12 +71,12 @@ class JUnit5TestKitBuilderSpec extends AnyWordSpec {
     }
   }
 
-  "the JUnit5TestKitBuilder" should {
+  "the JunitJupiterTestKitBuilder" should {
     "create a Testkit with a custom system" in {
 
       val system: ActorSystem[GreeterMain.SayHello] = ActorSystem(GreeterMain(), "PekkoQuickStart")
 
-      val actualTestKit = new JUnit5TestKitBuilder()
+      val actualTestKit = new JunitJupiterTestKitBuilder()
         .withSystem(system)
         .build()
       assertResult("PekkoQuickStart")(actualTestKit.system.name)

--- a/docs/src/main/paradox/release-notes/releases-1.1.md
+++ b/docs/src/main/paradox/release-notes/releases-1.1.md
@@ -150,7 +150,7 @@ The Stream Testkit Java DSL has some extra functions.
 * Support Jackson StreamReadConstraints and StreamWriteConstraints ([PR564](https://github.com/apache/pekko/pull/564))
 * Support configuration for Jackson Recycler Pool ([PR1192](https://github.com/apache/pekko/pull/1192))
 * pekko-multi-node-testkit was changed to use Netty 4 instead of Netty 3 ([PR539](https://github.com/apache/pekko/pull/539))
-* add junit5 support to pekko-testkit-typed ([PR751](https://github.com/apache/pekko/pull/751))
+* add JunitJupiter support to pekko-testkit-typed ([PR751](https://github.com/apache/pekko/pull/751))
 * Fix maybe throw for MinimalStage (Stream Unfold). ([PR822](https://github.com/apache/pekko/pull/822))
 * Add dedicated stream timeout exceptions for timeout related operators ([PR861](https://github.com/apache/pekko/pull/861))
 * Reimplement MapConcat operator without statefulMapConcat ([PR902](https://github.com/apache/pekko/pull/902))


### PR DESCRIPTION
Will deprecate this in 1.5.x @pjfanning 