### PR TITLE
VarHandle multi-byte reads for ByteString lastIndexOf

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -405,6 +405,56 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       ByteString1.fromString("0123456789").take(3).drop(1) should ===(ByteString("12"))
       ByteString1.fromString("0123456789").take(10).take(8).drop(3).take(5) should ===(ByteString("34567"))
     }
+    "lastIndexOf (specialized)" in {
+      ByteString.empty.lastIndexOf(5.toByte, -1) should ===(-1)
+      ByteString.empty.lastIndexOf(5.toByte, 0) should ===(-1)
+      ByteString.empty.lastIndexOf(5.toByte, 1) should ===(-1)
+      ByteString.empty.lastIndexOf(5.toByte) should ===(-1)
+      val byteString1 = ByteString1.fromString("abb")
+      byteString1.lastIndexOf('d'.toByte) should ===(-1)
+      byteString1.lastIndexOf('d'.toByte, -1) should ===(-1)
+      byteString1.lastIndexOf('d'.toByte, 4) should ===(-1)
+      byteString1.lastIndexOf('d'.toByte, 1) should ===(-1)
+      byteString1.lastIndexOf('d'.toByte, 0) should ===(-1)
+      byteString1.lastIndexOf('a'.toByte, -1) should ===(-1)
+      byteString1.lastIndexOf('a'.toByte) should ===(0)
+      byteString1.lastIndexOf('a'.toByte, 0) should ===(0)
+      byteString1.lastIndexOf('a'.toByte, 1) should ===(0)
+      byteString1.lastIndexOf('b'.toByte) should ===(2)
+      byteString1.lastIndexOf('b'.toByte, 2) should ===(2)
+      byteString1.lastIndexOf('b'.toByte, 1) should ===(1)
+      byteString1.lastIndexOf('b'.toByte, 0) should ===(-1)
+
+      val byteStrings = ByteStrings(ByteString1.fromString("abb"), ByteString1.fromString("efg"))
+      byteStrings.lastIndexOf('e'.toByte) should ===(3)
+      byteStrings.lastIndexOf('e'.toByte, 6) should ===(3)
+      byteStrings.lastIndexOf('e'.toByte, 4) should ===(3)
+      byteStrings.lastIndexOf('e'.toByte, 1) should ===(-1)
+      byteStrings.lastIndexOf('e'.toByte, 0) should ===(-1)
+      byteStrings.lastIndexOf('e'.toByte, -1) should ===(-1)
+
+      byteStrings.lastIndexOf('b'.toByte) should ===(2)
+      byteStrings.lastIndexOf('b'.toByte, 6) should ===(2)
+      byteStrings.lastIndexOf('b'.toByte, 4) should ===(2)
+      byteStrings.lastIndexOf('b'.toByte, 1) should ===(1)
+      byteStrings.lastIndexOf('b'.toByte, 0) should ===(-1)
+      byteStrings.lastIndexOf('b'.toByte, -1) should ===(-1)
+
+      val compact = byteStrings.compact
+      compact.lastIndexOf('e'.toByte) should ===(3)
+      compact.lastIndexOf('e'.toByte, 6) should ===(3)
+      compact.lastIndexOf('e'.toByte, 4) should ===(3)
+      compact.lastIndexOf('e'.toByte, 1) should ===(-1)
+      compact.lastIndexOf('e'.toByte, 0) should ===(-1)
+      compact.lastIndexOf('e'.toByte, -1) should ===(-1)
+
+      compact.lastIndexOf('b'.toByte) should ===(2)
+      compact.lastIndexOf('b'.toByte, 6) should ===(2)
+      compact.lastIndexOf('b'.toByte, 4) should ===(2)
+      compact.lastIndexOf('b'.toByte, 1) should ===(1)
+      compact.lastIndexOf('b'.toByte, 0) should ===(-1)
+      compact.lastIndexOf('b'.toByte, -1) should ===(-1)
+    }
     "copyToArray" in {
       val byteString = ByteString1(Array[Byte](1, 2, 3, 4, 5), startIndex = 1, length = 3)
       def verify(f: Array[Byte] => Unit)(expected: Byte*): Unit = {

--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -888,6 +888,12 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       zeros.lastIndexOf(0.toByte) should ===(2)
       val neg = ByteString(Array[Byte](-1, 0, -1))
       neg.lastIndexOf((-1).toByte) should ===(2)
+
+      val concat0 = makeMultiByteStringsSample()
+      concat0.lastIndexOf(0xFF.toByte) should ===(18)
+      concat0.lastIndexOf(0xFF.toByte, 18) should ===(18)
+      concat0.lastIndexOf(0xFF.toByte, 17) should ===(0)
+      concat0.lastIndexOf(0xFE.toByte) should ===(-1)
     }
     "indexOf (specialized)" in {
       ByteString.empty.indexOf(5.toByte) should ===(-1)
@@ -920,6 +926,11 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       compact.indexOf('e'.toByte) should ===(3)
       compact.indexOf('f'.toByte) should ===(4)
       compact.indexOf('g'.toByte) should ===(5)
+
+      val concat0 = makeMultiByteStringsSample()
+      concat0.indexOf(0xFF.toByte) should ===(0)
+      concat0.indexOf(16.toByte) should ===(17)
+      concat0.indexOf(0xFE.toByte) should ===(-1)
     }
     "indexOf (specialized) from offset" in {
       ByteString.empty.indexOf(5.toByte, -1) should ===(-1)
@@ -986,6 +997,11 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       byteStringLong.indexOf('m', 2) should ===(12)
       byteStringLong.indexOf('z', 2) should ===(25)
       byteStringLong.indexOf('a', 2) should ===(-1)
+
+      val concat0 = makeMultiByteStringsSample()
+      concat0.indexOf(0xFF.toByte, 0) should ===(0)
+      concat0.indexOf(0xFF.toByte, 17) should ===(18)
+      concat0.indexOf(0xFE.toByte, 17) should ===(-1)
     }
     "contains" in {
       ByteString.empty.contains(5) should ===(false)
@@ -1999,5 +2015,18 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
         }
       }
     }
+  }
+
+  private def makeMultiByteStringsSample(): ByteString = {
+    val byteStrings = Vector(
+      ByteString1(Array[Byte](0xFF.toByte)),
+      ByteString1(Array[Byte](0, 1, 2, 3)),
+      ByteString1(Array[Byte](4, 5)),
+      ByteString1(Array[Byte](6, 7, 8, 9)),
+      ByteString1(Array[Byte](10)),
+      ByteString1(Array[Byte](11, 12, 13, 14, 15, 16)),
+      ByteString1(Array[Byte](0xFF.toByte))
+    )
+    ByteStrings(byteStrings)
   }
 }

--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -405,56 +405,6 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       ByteString1.fromString("0123456789").take(3).drop(1) should ===(ByteString("12"))
       ByteString1.fromString("0123456789").take(10).take(8).drop(3).take(5) should ===(ByteString("34567"))
     }
-    "lastIndexOf (specialized)" in {
-      ByteString.empty.lastIndexOf(5.toByte, -1) should ===(-1)
-      ByteString.empty.lastIndexOf(5.toByte, 0) should ===(-1)
-      ByteString.empty.lastIndexOf(5.toByte, 1) should ===(-1)
-      ByteString.empty.lastIndexOf(5.toByte) should ===(-1)
-      val byteString1 = ByteString1.fromString("abb")
-      byteString1.lastIndexOf('d'.toByte) should ===(-1)
-      byteString1.lastIndexOf('d'.toByte, -1) should ===(-1)
-      byteString1.lastIndexOf('d'.toByte, 4) should ===(-1)
-      byteString1.lastIndexOf('d'.toByte, 1) should ===(-1)
-      byteString1.lastIndexOf('d'.toByte, 0) should ===(-1)
-      byteString1.lastIndexOf('a'.toByte, -1) should ===(-1)
-      byteString1.lastIndexOf('a'.toByte) should ===(0)
-      byteString1.lastIndexOf('a'.toByte, 0) should ===(0)
-      byteString1.lastIndexOf('a'.toByte, 1) should ===(0)
-      byteString1.lastIndexOf('b'.toByte) should ===(2)
-      byteString1.lastIndexOf('b'.toByte, 2) should ===(2)
-      byteString1.lastIndexOf('b'.toByte, 1) should ===(1)
-      byteString1.lastIndexOf('b'.toByte, 0) should ===(-1)
-
-      val byteStrings = ByteStrings(ByteString1.fromString("abb"), ByteString1.fromString("efg"))
-      byteStrings.lastIndexOf('e'.toByte) should ===(3)
-      byteStrings.lastIndexOf('e'.toByte, 6) should ===(3)
-      byteStrings.lastIndexOf('e'.toByte, 4) should ===(3)
-      byteStrings.lastIndexOf('e'.toByte, 1) should ===(-1)
-      byteStrings.lastIndexOf('e'.toByte, 0) should ===(-1)
-      byteStrings.lastIndexOf('e'.toByte, -1) should ===(-1)
-
-      byteStrings.lastIndexOf('b'.toByte) should ===(2)
-      byteStrings.lastIndexOf('b'.toByte, 6) should ===(2)
-      byteStrings.lastIndexOf('b'.toByte, 4) should ===(2)
-      byteStrings.lastIndexOf('b'.toByte, 1) should ===(1)
-      byteStrings.lastIndexOf('b'.toByte, 0) should ===(-1)
-      byteStrings.lastIndexOf('b'.toByte, -1) should ===(-1)
-
-      val compact = byteStrings.compact
-      compact.lastIndexOf('e'.toByte) should ===(3)
-      compact.lastIndexOf('e'.toByte, 6) should ===(3)
-      compact.lastIndexOf('e'.toByte, 4) should ===(3)
-      compact.lastIndexOf('e'.toByte, 1) should ===(-1)
-      compact.lastIndexOf('e'.toByte, 0) should ===(-1)
-      compact.lastIndexOf('e'.toByte, -1) should ===(-1)
-
-      compact.lastIndexOf('b'.toByte) should ===(2)
-      compact.lastIndexOf('b'.toByte, 6) should ===(2)
-      compact.lastIndexOf('b'.toByte, 4) should ===(2)
-      compact.lastIndexOf('b'.toByte, 1) should ===(1)
-      compact.lastIndexOf('b'.toByte, 0) should ===(-1)
-      compact.lastIndexOf('b'.toByte, -1) should ===(-1)
-    }
     "copyToArray" in {
       val byteString = ByteString1(Array[Byte](1, 2, 3, 4, 5), startIndex = 1, length = 3)
       def verify(f: Array[Byte] => Unit)(expected: Byte*): Unit = {
@@ -871,6 +821,56 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       compact.lastIndexOf('b', 0) should ===(-1)
       compact.lastIndexOf('b', -1) should ===(-1)
     }
+    "lastIndexOf (specialized)" in {
+      ByteString.empty.lastIndexOf(5.toByte, -1) should ===(-1)
+      ByteString.empty.lastIndexOf(5.toByte, 0) should ===(-1)
+      ByteString.empty.lastIndexOf(5.toByte, 1) should ===(-1)
+      ByteString.empty.lastIndexOf(5.toByte) should ===(-1)
+      val byteString1 = ByteString1.fromString("abb")
+      byteString1.lastIndexOf('d'.toByte) should ===(-1)
+      byteString1.lastIndexOf('d'.toByte, -1) should ===(-1)
+      byteString1.lastIndexOf('d'.toByte, 4) should ===(-1)
+      byteString1.lastIndexOf('d'.toByte, 1) should ===(-1)
+      byteString1.lastIndexOf('d'.toByte, 0) should ===(-1)
+      byteString1.lastIndexOf('a'.toByte, -1) should ===(-1)
+      byteString1.lastIndexOf('a'.toByte) should ===(0)
+      byteString1.lastIndexOf('a'.toByte, 0) should ===(0)
+      byteString1.lastIndexOf('a'.toByte, 1) should ===(0)
+      byteString1.lastIndexOf('b'.toByte) should ===(2)
+      byteString1.lastIndexOf('b'.toByte, 2) should ===(2)
+      byteString1.lastIndexOf('b'.toByte, 1) should ===(1)
+      byteString1.lastIndexOf('b'.toByte, 0) should ===(-1)
+
+      val byteStrings = ByteStrings(ByteString1.fromString("abb"), ByteString1.fromString("efg"))
+      byteStrings.lastIndexOf('e'.toByte) should ===(3)
+      byteStrings.lastIndexOf('e'.toByte, 6) should ===(3)
+      byteStrings.lastIndexOf('e'.toByte, 4) should ===(3)
+      byteStrings.lastIndexOf('e'.toByte, 1) should ===(-1)
+      byteStrings.lastIndexOf('e'.toByte, 0) should ===(-1)
+      byteStrings.lastIndexOf('e'.toByte, -1) should ===(-1)
+
+      byteStrings.lastIndexOf('b'.toByte) should ===(2)
+      byteStrings.lastIndexOf('b'.toByte, 6) should ===(2)
+      byteStrings.lastIndexOf('b'.toByte, 4) should ===(2)
+      byteStrings.lastIndexOf('b'.toByte, 1) should ===(1)
+      byteStrings.lastIndexOf('b'.toByte, 0) should ===(-1)
+      byteStrings.lastIndexOf('b'.toByte, -1) should ===(-1)
+
+      val compact = byteStrings.compact
+      compact.lastIndexOf('e'.toByte) should ===(3)
+      compact.lastIndexOf('e'.toByte, 6) should ===(3)
+      compact.lastIndexOf('e'.toByte, 4) should ===(3)
+      compact.lastIndexOf('e'.toByte, 1) should ===(-1)
+      compact.lastIndexOf('e'.toByte, 0) should ===(-1)
+      compact.lastIndexOf('e'.toByte, -1) should ===(-1)
+
+      compact.lastIndexOf('b'.toByte) should ===(2)
+      compact.lastIndexOf('b'.toByte, 6) should ===(2)
+      compact.lastIndexOf('b'.toByte, 4) should ===(2)
+      compact.lastIndexOf('b'.toByte, 1) should ===(1)
+      compact.lastIndexOf('b'.toByte, 0) should ===(-1)
+      compact.lastIndexOf('b'.toByte, -1) should ===(-1)
+    }
     "indexOf (specialized)" in {
       ByteString.empty.indexOf(5.toByte) should ===(-1)
       val byteString1 = ByteString1.fromString("abc")
@@ -902,7 +902,6 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       compact.indexOf('e'.toByte) should ===(3)
       compact.indexOf('f'.toByte) should ===(4)
       compact.indexOf('g'.toByte) should ===(5)
-
     }
     "indexOf (specialized) from offset" in {
       ByteString.empty.indexOf(5.toByte, -1) should ===(-1)

--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -699,6 +699,12 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       byteStringLong.lastIndexOf('m') should ===(12)
       byteStringLong.lastIndexOf('z') should ===(25)
       byteStringLong.lastIndexOf('a') should ===(0)
+
+      val long1 = ByteString1.fromString("abcdefghijklmnop") // 16 bytes
+      long1.lastIndexOf('a'.toByte) should ===(0)
+      long1.lastIndexOf('p'.toByte) should ===(15)
+      long1.lastIndexOf('h'.toByte, 7) should ===(7)
+      long1.lastIndexOf('h'.toByte, 6) should ===(-1)
     }
     "indexOf from offset" in {
       ByteString.empty.indexOf(5, -1) should ===(-1)
@@ -820,6 +826,10 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       compact.lastIndexOf('b', 1) should ===(1)
       compact.lastIndexOf('b', 0) should ===(-1)
       compact.lastIndexOf('b', -1) should ===(-1)
+
+      val concat0 = ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("dd"))
+      concat0.lastIndexOf('d'.toByte, 2) should ===(2)
+      concat0.lastIndexOf('d'.toByte, 3) should ===(3)
     }
     "lastIndexOf (specialized)" in {
       ByteString.empty.lastIndexOf(5.toByte, -1) should ===(-1)
@@ -870,6 +880,14 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       compact.lastIndexOf('b'.toByte, 1) should ===(1)
       compact.lastIndexOf('b'.toByte, 0) should ===(-1)
       compact.lastIndexOf('b'.toByte, -1) should ===(-1)
+
+      val sliced = ByteString1.fromString("xxabcdefghijk").drop(2)
+      sliced.lastIndexOf('k'.toByte) should ===(10)
+
+      val zeros = ByteString(Array[Byte](0, 1, 0, 1))
+      zeros.lastIndexOf(0.toByte) should ===(2)
+      val neg = ByteString(Array[Byte](-1, 0, -1))
+      neg.lastIndexOf((-1).toByte) should ===(2)
     }
     "indexOf (specialized)" in {
       ByteString.empty.indexOf(5.toByte) should ===(-1)

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -259,7 +259,7 @@ object ByteString {
         if (offset == length) return -1
       }
       val longCount = searchLength >>> 3
-      val pattern = SWARUtil.compilePattern(elem)
+      val pattern = if (longCount > 0) SWARUtil.compilePattern(elem) else 0L
       var i = 0
       while (i < longCount) {
         val word = SWARUtil.getLong(bytes, offset, ByteOrder.BIG_ENDIAN)
@@ -285,7 +285,7 @@ object ByteString {
         if (offset == length) return -1
       }
       val longCount = searchLength >>> 3
-      val pattern = SWARUtil.compilePattern(elem)
+      val pattern = if (longCount > 0) SWARUtil.compilePattern(elem) else 0L
       var i = 0
       while (i < longCount) {
         val word = SWARUtil.getLong(bytes, offset, ByteOrder.BIG_ENDIAN)
@@ -318,7 +318,6 @@ object ByteString {
       val endIdx = math.min(end, length - 1)
       if (endIdx < 0) return -1
       val searchLength = endIdx + 1
-      val pattern = SWARUtil.compilePattern(elem)
       // Check the rightmost partial chunk first (bytes not fitting in a full 8-byte block)
       val tailBytes = searchLength & 7
       if (tailBytes > 0) {
@@ -329,6 +328,7 @@ object ByteString {
       }
       // Scan full 8-byte chunks from right to left
       var chunkStart = searchLength - tailBytes - 8
+      val pattern = if (chunkStart >= 0) SWARUtil.compilePattern(elem) else 0L
       while (chunkStart >= 0) {
         val word = SWARUtil.getLong(bytes, chunkStart, ByteOrder.BIG_ENDIAN)
         val result = SWARUtil.applyPattern(word, pattern)
@@ -585,7 +585,7 @@ object ByteString {
         if (offset == length) return -1
       }
       val longCount = searchLength >>> 3
-      val pattern = SWARUtil.compilePattern(elem)
+      val pattern = if (longCount > 0) SWARUtil.compilePattern(elem) else 0L
       var i = 0
       while (i < longCount) {
         val word = SWARUtil.getLong(bytes, startIndex + offset, ByteOrder.BIG_ENDIAN)
@@ -611,7 +611,7 @@ object ByteString {
         if (offset == length) return -1
       }
       val longCount = searchLength >>> 3
-      val pattern = SWARUtil.compilePattern(elem)
+      val pattern = if (longCount > 0) SWARUtil.compilePattern(elem) else 0L
       var i = 0
       while (i < longCount) {
         val word = SWARUtil.getLong(bytes, startIndex + offset, ByteOrder.BIG_ENDIAN)
@@ -645,7 +645,6 @@ object ByteString {
       val endIdx = math.min(end, length - 1)
       if (endIdx < 0) return -1
       val searchLength = endIdx + 1
-      val pattern = SWARUtil.compilePattern(elem)
       // Check the rightmost partial chunk first (bytes not fitting in a full 8-byte block)
       val tailBytes = searchLength & 7
       if (tailBytes > 0) {
@@ -656,6 +655,7 @@ object ByteString {
       }
       // Scan full 8-byte chunks from right to left
       var chunkStart = searchLength - tailBytes - 8
+      val pattern = if (chunkStart >= 0) SWARUtil.compilePattern(elem) else 0L
       while (chunkStart >= 0) {
         val word = SWARUtil.getLong(bytes, startIndex + chunkStart, ByteOrder.BIG_ENDIAN)
         val result = SWARUtil.applyPattern(word, pattern)

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -297,6 +297,60 @@ object ByteString {
       -1
     }
 
+    override def lastIndexOf[B >: Byte](elem: B, end: Int): Int = {
+      elem match {
+        case byte: Byte => lastIndexOf(byte, end)
+        case _          =>
+          if (end < 0) -1
+          else {
+            var found = -1
+            var i = math.min(end, length - 1)
+            while (i >= 0 && found == -1) {
+              if (bytes(i) == elem) found = i
+              i -= 1
+            }
+            found
+          }
+      }
+    }
+
+    override def lastIndexOf(elem: Byte, end: Int): Int = {
+      val endIdx = math.min(end, length - 1)
+      if (endIdx < 0) return -1
+      val searchLength = endIdx + 1
+      val pattern = SWARUtil.compilePattern(elem)
+      // Check the rightmost partial chunk first (bytes not fitting in a full 8-byte block)
+      val tailBytes = searchLength & 7
+      if (tailBytes > 0) {
+        val tailStart = searchLength - tailBytes
+        val index = unrolledLastIndexOf(tailStart, tailBytes, elem)
+        if (index != -1) return index
+        if (tailStart == 0) return -1
+      }
+      // Scan full 8-byte chunks from right to left
+      var chunkStart = searchLength - tailBytes - 8
+      while (chunkStart >= 0) {
+        val word = SWARUtil.getLong(bytes, chunkStart, ByteOrder.BIG_ENDIAN)
+        val result = SWARUtil.applyPattern(word, pattern)
+        if (result != 0) return chunkStart + SWARUtil.getLastIndex(result)
+        chunkStart -= 8
+      }
+      -1
+    }
+
+    // Searches byteCount bytes (1-7) starting at fromIndex from highest to lowest index,
+    // returning the rightmost (last) match, or -1 if not found.
+    private def unrolledLastIndexOf(fromIndex: Int, byteCount: Int, value: Byte): Int = {
+      if (byteCount >= 7 && bytes(fromIndex + 6) == value) fromIndex + 6
+      else if (byteCount >= 6 && bytes(fromIndex + 5) == value) fromIndex + 5
+      else if (byteCount >= 5 && bytes(fromIndex + 4) == value) fromIndex + 4
+      else if (byteCount >= 4 && bytes(fromIndex + 3) == value) fromIndex + 3
+      else if (byteCount >= 3 && bytes(fromIndex + 2) == value) fromIndex + 2
+      else if (byteCount >= 2 && bytes(fromIndex + 1) == value) fromIndex + 1
+      else if (bytes(fromIndex) == value) fromIndex
+      else -1
+    }
+
     private def unrolledFirstIndexOf(fromIndex: Int, byteCount: Int, value: Byte): Int = {
       if (bytes(fromIndex) == value) fromIndex
       else if (byteCount == 1) -1
@@ -570,6 +624,47 @@ object ByteString {
 
     }
 
+    override def lastIndexOf[B >: Byte](elem: B, end: Int): Int = {
+      elem match {
+        case byte: Byte => lastIndexOf(byte, end)
+        case _          =>
+          if (end < 0) -1
+          else {
+            var found = -1
+            var i = math.min(end, length - 1)
+            while (i >= 0 && found == -1) {
+              if (bytes(startIndex + i) == elem) found = i
+              i -= 1
+            }
+            found
+          }
+      }
+    }
+
+    override def lastIndexOf(elem: Byte, end: Int): Int = {
+      val endIdx = math.min(end, length - 1)
+      if (endIdx < 0) return -1
+      val searchLength = endIdx + 1
+      val pattern = SWARUtil.compilePattern(elem)
+      // Check the rightmost partial chunk first (bytes not fitting in a full 8-byte block)
+      val tailBytes = searchLength & 7
+      if (tailBytes > 0) {
+        val tailStart = searchLength - tailBytes
+        val index = unrolledLastIndexOf(startIndex + tailStart, tailBytes, elem)
+        if (index != -1) return index - startIndex
+        if (tailStart == 0) return -1
+      }
+      // Scan full 8-byte chunks from right to left
+      var chunkStart = searchLength - tailBytes - 8
+      while (chunkStart >= 0) {
+        val word = SWARUtil.getLong(bytes, startIndex + chunkStart, ByteOrder.BIG_ENDIAN)
+        val result = SWARUtil.applyPattern(word, pattern)
+        if (result != 0) return chunkStart + SWARUtil.getLastIndex(result)
+        chunkStart -= 8
+      }
+      -1
+    }
+
     // the calling code already adds the startIndex so this method does not need to
     private def unrolledFirstIndexOf(fromIndex: Int, byteCount: Int, value: Byte): Int = {
       if (bytes(fromIndex) == value) fromIndex
@@ -585,6 +680,20 @@ object ByteString {
       else if (bytes(fromIndex + 5) == value) fromIndex + 5
       else if (byteCount == 6) -1
       else if (bytes(fromIndex + 6) == value) fromIndex + 6
+      else -1
+    }
+
+    // the calling code already adds the startIndex so this method does not need to.
+    // Searches byteCount bytes (1-7) starting at fromIndex from highest to lowest index,
+    // returning the rightmost (last) match, or -1 if not found.
+    private def unrolledLastIndexOf(fromIndex: Int, byteCount: Int, value: Byte): Int = {
+      if (byteCount >= 7 && bytes(fromIndex + 6) == value) fromIndex + 6
+      else if (byteCount >= 6 && bytes(fromIndex + 5) == value) fromIndex + 5
+      else if (byteCount >= 5 && bytes(fromIndex + 4) == value) fromIndex + 4
+      else if (byteCount >= 4 && bytes(fromIndex + 3) == value) fromIndex + 3
+      else if (byteCount >= 3 && bytes(fromIndex + 2) == value) fromIndex + 2
+      else if (byteCount >= 2 && bytes(fromIndex + 1) == value) fromIndex + 1
+      else if (bytes(fromIndex) == value) fromIndex
       else -1
     }
 
@@ -921,6 +1030,67 @@ object ByteString {
       }
     }
 
+    override def lastIndexOf[B >: Byte](elem: B, end: Int): Int = {
+      if (end < 0) -1
+      else {
+        val byteStringsLast = bytestrings.size - 1
+
+        @tailrec
+        def find(bsIdx: Int, relativeIndex: Int, len: Int): Int = {
+          if (bsIdx < 0) -1
+          else {
+            val bs = bytestrings(bsIdx)
+            val bsStartIndex = len - bs.length
+
+            if (relativeIndex < bsStartIndex || bs.isEmpty) {
+              if (bsIdx == 0) -1
+              else find(bsIdx - 1, relativeIndex, bsStartIndex)
+            } else {
+              val subIndexOf = bs.lastIndexOf(elem, relativeIndex)
+              if (subIndexOf < 0) {
+                if (bsIdx == 0) -1
+                else find(bsIdx - 1, relativeIndex, bsStartIndex)
+              } else subIndexOf + bsStartIndex
+            }
+          }
+        }
+
+        find(byteStringsLast, math.min(end, length), length)
+      }
+    }
+
+    override def lastIndexOf(elem: Byte, end: Int): Int = {
+      if (end < 0) -1
+      else {
+        if (end < 0) -1
+        else {
+          val byteStringsLast = bytestrings.size - 1
+
+          @tailrec
+          def find(bsIdx: Int, relativeIndex: Int, len: Int): Int = {
+            if (bsIdx < 0) -1
+            else {
+              val bs = bytestrings(bsIdx)
+              val bsStartIndex = len - bs.length
+
+              if (relativeIndex < bsStartIndex || bs.isEmpty) {
+                if (bsIdx == 0) -1
+                else find(bsIdx - 1, relativeIndex, bsStartIndex)
+              } else {
+                val subIndexOf = bs.lastIndexOf(elem, relativeIndex)
+                if (subIndexOf < 0) {
+                  if (bsIdx == 0) -1
+                  else find(bsIdx - 1, relativeIndex, bsStartIndex)
+                } else subIndexOf + bsStartIndex
+              }
+            }
+          }
+
+          find(byteStringsLast, math.min(end, length), length)
+        }
+      }
+    }
+
     override def copyToArray[B >: Byte](dest: Array[B], start: Int, len: Int): Int = {
       if (bytestrings.size == 1) bytestrings.head.copyToArray(dest, start, len)
       else {
@@ -995,10 +1165,10 @@ sealed abstract class ByteString
   // of ByteString which changed for Scala 2.12, see https://github.com/akka/akka/issues/21774
   override final def className: String = "ByteString"
 
+  override def isEmpty: Boolean = length == 0
+
   // Cache the hash code since ByteString is immutable
   override lazy val hashCode: Int = super.hashCode()
-
-  override def isEmpty: Boolean = length == 0
 
   // override protected[this] def newBuilder: ByteStringBuilder = ByteString.newBuilder
 
@@ -1084,6 +1254,31 @@ sealed abstract class ByteString
    *  @since 1.1.0
    */
   def indexOf(elem: Byte): Int = indexOf(elem, 0)
+
+  /**
+   * Finds index of last occurrence of some byte in this ByteString before or at some end index.
+   *
+   * Similar to lastIndexOf, but it avoids boxing if the value is already a byte.
+   *
+   *  @param   elem   the element value to search for.
+   *  @param   end    the end index
+   *  @return  the index `<= end` of the last element of this ByteString that is equal (as determined by `==`)
+   *           to `elem`, or `-1`, if none exists.
+   *  @since 2.0.0
+   */
+  def lastIndexOf(elem: Byte, end: Int): Int = lastIndexOf[Byte](elem, end)
+
+  /**
+   * Finds index of last occurrence of some byte in this ByteString.
+   *
+   * Similar to lastIndexOf, but it avoids boxing if the value is already a byte.
+   *
+   *  @param   elem   the element value to search for.
+   *  @return  the index of the last element of this ByteString that is equal (as determined by `==`)
+   *           to `elem`, or `-1`, if none exists.
+   *  @since 2.0.0
+   */
+  def lastIndexOf(elem: Byte): Int = lastIndexOf(elem, length - 1)
 
   override def indexOfSlice[B >: Byte](slice: scala.collection.Seq[B], from: Int): Int = {
     // this is only called if the first byte matches, so we can skip that check

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -1046,7 +1046,7 @@ object ByteString {
               if (bsIdx == 0) -1
               else find(bsIdx - 1, relativeIndex, bsStartIndex)
             } else {
-              val subIndexOf = bs.lastIndexOf(elem, relativeIndex)
+              val subIndexOf = bs.lastIndexOf(elem, relativeIndex - bsStartIndex)
               if (subIndexOf < 0) {
                 if (bsIdx == 0) -1
                 else find(bsIdx - 1, relativeIndex, bsStartIndex)
@@ -1055,39 +1055,36 @@ object ByteString {
           }
         }
 
-        find(byteStringsLast, math.min(end, length), length)
+        find(byteStringsLast, math.min(end, length - 1), length)
       }
     }
 
     override def lastIndexOf(elem: Byte, end: Int): Int = {
       if (end < 0) -1
       else {
-        {
-        else {
-          val byteStringsLast = bytestrings.size - 1
+        val byteStringsLast = bytestrings.size - 1
 
-          @tailrec
-          def find(bsIdx: Int, relativeIndex: Int, len: Int): Int = {
-            if (bsIdx < 0) -1
-            else {
-              val bs = bytestrings(bsIdx)
-              val bsStartIndex = len - bs.length
+        @tailrec
+        def find(bsIdx: Int, relativeIndex: Int, len: Int): Int = {
+          if (bsIdx < 0) -1
+          else {
+            val bs = bytestrings(bsIdx)
+            val bsStartIndex = len - bs.length
 
-              if (relativeIndex < bsStartIndex || bs.isEmpty) {
+            if (relativeIndex < bsStartIndex || bs.isEmpty) {
+              if (bsIdx == 0) -1
+              else find(bsIdx - 1, relativeIndex, bsStartIndex)
+            } else {
+              val subIndexOf = bs.lastIndexOf(elem, relativeIndex - bsStartIndex)
+              if (subIndexOf < 0) {
                 if (bsIdx == 0) -1
                 else find(bsIdx - 1, relativeIndex, bsStartIndex)
-              } else {
-                val subIndexOf = bs.lastIndexOf(elem, relativeIndex - bsStartIndex)
-                if (subIndexOf < 0) {
-                  if (bsIdx == 0) -1
-                  else find(bsIdx - 1, relativeIndex, bsStartIndex)
-                } else subIndexOf + bsStartIndex
-              }
+              } else subIndexOf + bsStartIndex
             }
           }
-
-          find(byteStringsLast, math.min(end, length), length)
         }
+
+        find(byteStringsLast, math.min(end, length - 1), length)
       }
     }
 

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -1062,7 +1062,7 @@ object ByteString {
     override def lastIndexOf(elem: Byte, end: Int): Int = {
       if (end < 0) -1
       else {
-        if (end < 0) -1
+        {
         else {
           val byteStringsLast = bytestrings.size - 1
 
@@ -1077,7 +1077,7 @@ object ByteString {
                 if (bsIdx == 0) -1
                 else find(bsIdx - 1, relativeIndex, bsStartIndex)
               } else {
-                val subIndexOf = bs.lastIndexOf(elem, relativeIndex)
+                val subIndexOf = bs.lastIndexOf(elem, relativeIndex - bsStartIndex)
                 if (subIndexOf < 0) {
                   if (bsIdx == 0) -1
                   else find(bsIdx - 1, relativeIndex, bsStartIndex)

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -328,12 +328,14 @@ object ByteString {
       }
       // Scan full 8-byte chunks from right to left
       var chunkStart = searchLength - tailBytes - 8
-      val pattern = if (chunkStart >= 0) SWARUtil.compilePattern(elem) else 0L
-      while (chunkStart >= 0) {
-        val word = SWARUtil.getLong(bytes, chunkStart, ByteOrder.BIG_ENDIAN)
-        val result = SWARUtil.applyPattern(word, pattern)
-        if (result != 0) return chunkStart + SWARUtil.getLastIndex(result)
-        chunkStart -= 8
+      if (chunkStart >= 0) {
+        val pattern = SWARUtil.compilePattern(elem)
+        while (chunkStart >= 0) {
+          val word = SWARUtil.getLong(bytes, chunkStart, ByteOrder.BIG_ENDIAN)
+          val result = SWARUtil.applyPattern(word, pattern)
+          if (result != 0) return chunkStart + SWARUtil.getLastIndex(result)
+          chunkStart -= 8
+        }
       }
       -1
     }
@@ -655,12 +657,14 @@ object ByteString {
       }
       // Scan full 8-byte chunks from right to left
       var chunkStart = searchLength - tailBytes - 8
-      val pattern = if (chunkStart >= 0) SWARUtil.compilePattern(elem) else 0L
-      while (chunkStart >= 0) {
-        val word = SWARUtil.getLong(bytes, startIndex + chunkStart, ByteOrder.BIG_ENDIAN)
-        val result = SWARUtil.applyPattern(word, pattern)
-        if (result != 0) return chunkStart + SWARUtil.getLastIndex(result)
-        chunkStart -= 8
+      if (chunkStart >= 0) {
+        val pattern = SWARUtil.compilePattern(elem)
+        while (chunkStart >= 0) {
+          val word = SWARUtil.getLong(bytes, startIndex + chunkStart, ByteOrder.BIG_ENDIAN)
+          val result = SWARUtil.applyPattern(word, pattern)
+          if (result != 0) return chunkStart + SWARUtil.getLastIndex(result)
+          chunkStart -= 8
+        }
       }
       -1
     }

--- a/actor/src/main/scala/org/apache/pekko/util/SWARUtil.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/SWARUtil.scala
@@ -148,13 +148,14 @@ private[pekko] object SWARUtil {
 
   /**
    * Returns the index of the last occurrence of a byte specified in the pattern within a word.
-   * If no pattern is found, the result is undefined (caller must check result != 0 first).
-   * Currently only supports big endian.
+   * If no pattern is found, the result is -1. Currently only supports big endian.
    *
    * @param word the return value of [[applyPattern]]
    * @return the index of the last occurrence of the specified pattern in the specified word.
    */
-  def getLastIndex(word: Long): Int = (java.lang.Long.SIZE - 1 - java.lang.Long.numberOfTrailingZeros(word)) >>> 3
+  def getLastIndex(word: Long): Int =
+    if (word == 0) -1
+    else (java.lang.Long.SIZE - 1 - java.lang.Long.numberOfTrailingZeros(word)) >>> 3
 
   /**
    * Returns the long value at the specified index in the given byte array.

--- a/actor/src/main/scala/org/apache/pekko/util/SWARUtil.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/SWARUtil.scala
@@ -147,6 +147,16 @@ private[pekko] object SWARUtil {
     java.lang.Long.numberOfLeadingZeros(word) >>> 3
 
   /**
+   * Returns the index of the last occurrence of a byte specified in the pattern within a word.
+   * If no pattern is found, the result is undefined (caller must check result != 0 first).
+   * Currently only supports big endian.
+   *
+   * @param word the return value of [[applyPattern]]
+   * @return the index of the last occurrence of the specified pattern in the specified word.
+   */
+  def getLastIndex(word: Long): Int = (java.lang.Long.SIZE - 1 - java.lang.Long.numberOfTrailingZeros(word)) >>> 3
+
+  /**
    * Returns the long value at the specified index in the given byte array.
    * Uses big-endian byte order. Uses a VarHandle byte array view if supported.
    * Does not range check - assumes caller has checked bounds.


### PR DESCRIPTION
* Relates to #2150 (there is non SWAR PR too that may work out better)

## SWARUtil — extended VarHandle infrastructure
- Use `byteArrayViewVarHandle` instances for `short` (BE+LE), `int` (BE+LE), `long` (LE)
- Added `getLastIndex(word)` — finds rightmost byte match in SWAR result using `numberOfTrailingZeros`

## ByteString
- Use SWARUtil for multi byte processing

Significant improvement in benchmark.
```
With Changes
[info] Benchmark                                                              Mode  Cnt          Score           Error  Units
[info] ByteString_lastIndexOf_Benchmark.bs1_lastIndexOf                      thrpt    3  107880125.372 ± 247014962.175  ops/s
[info] ByteString_lastIndexOf_Benchmark.bs1_lastIndexOf_byte                 thrpt    3   88478677.724 ± 181685386.699  ops/s
[info] ByteString_lastIndexOf_Benchmark.bss_lastIndexOf_best_case            thrpt    3   58313896.505 ± 806477112.611  ops/s
[info] ByteString_lastIndexOf_Benchmark.bss_lastIndexOf_far_index_case       thrpt    3   17472854.418 ±  94251978.262  ops/s
[info] ByteString_lastIndexOf_Benchmark.bss_lastIndexOf_far_index_case_byte  thrpt    3   19332603.332 ±   2245521.678  ops/s
[info] ByteString_lastIndexOf_Benchmark.bss_lastIndexOf_worst_case           thrpt    3   20053173.893 ±   2385070.269  ops/s

Without Changes
[info] Benchmark                                                              Mode  Cnt          Score          Error  Units
[info] ByteString_lastIndexOf_Benchmark.bs1_lastIndexOf                      thrpt    3   33298670.109 ± 63631788.200  ops/s
[info] ByteString_lastIndexOf_Benchmark.bs1_lastIndexOf_byte                 thrpt    3   27021365.677 ±  5557597.483  ops/s
[info] ByteString_lastIndexOf_Benchmark.bss_lastIndexOf_best_case            thrpt    3   34686168.040 ±  7080975.674  ops/s
[info] ByteString_lastIndexOf_Benchmark.bss_lastIndexOf_far_index_case       thrpt    3     635863.919 ±    69057.413  ops/s
[info] ByteString_lastIndexOf_Benchmark.bss_lastIndexOf_far_index_case_byte  thrpt    3     597510.828 ±    29481.618  ops/s
[info] ByteString_lastIndexOf_Benchmark.bss_lastIndexOf_worst_case           thrpt    3    2125744.038 ±   196176.723  ops/s
```