### PR TITLE
add jspecify to persistence libs (javadsl/japi packages only)

### DIFF
--- a/persistence-query/src/main/java/org/apache/pekko/persistence/query/javadsl/package-info.java
+++ b/persistence-query/src/main/java/org/apache/pekko/persistence/query/javadsl/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Java API for Pekko Persistence Query.
+ *
+ * <p>This package contains the Java DSL for Pekko Persistence Query. For the Scala DSL see
+ * [[org.apache.pekko.persistence.query.scaladsl]].
+ */
+@org.jspecify.annotations.NullMarked
+package org.apache.pekko.persistence.query.javadsl;

--- a/persistence-testkit/src/main/java/org/apache/pekko/persistence/testkit/javadsl/package-info.java
+++ b/persistence-testkit/src/main/java/org/apache/pekko/persistence/testkit/javadsl/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Java API for Pekko Persistence TestKit.
+ *
+ * <p>This package contains the Java DSL for Pekko Persistence TestKit. For the Scala DSL see
+ * [[org.apache.pekko.persistence.testkit.scaladsl]].
+ */
+@org.jspecify.annotations.NullMarked
+package org.apache.pekko.persistence.testkit.javadsl;

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/javadsl/PersistenceProbeBehavior.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/javadsl/PersistenceProbeBehavior.scala
@@ -22,6 +22,7 @@ import pekko.actor.testkit.typed.javadsl.BehaviorTestKit
 import pekko.actor.typed.Behavior
 import pekko.annotation.DoNotInherit
 import pekko.persistence.testkit.internal.PersistenceProbeImpl
+import org.jspecify.annotations.Nullable
 
 /**
  * Factory methods to create PersistenceProbeBehavior instances for testing.
@@ -46,7 +47,7 @@ object PersistenceProbeBehavior {
    */
   def fromEventSourced[Command, Event, State](
       behavior: Behavior[Command],
-      initialState: State,
+      @Nullable initialState: State,
       initialSequenceNr: Long): PersistenceProbeBehavior[Command, Event, State] = {
     require(initialSequenceNr >= 0, "initialSequenceNr must be at least zero")
 

--- a/persistence-typed/src/main/java/org/apache/pekko/persistence/typed/javadsl/package-info.java
+++ b/persistence-typed/src/main/java/org/apache/pekko/persistence/typed/javadsl/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Java API for Pekko Persistence Typed.
+ *
+ * <p>This package contains the Java DSL for Pekko Persistence Typed. For the Scala DSL see
+ * [[org.apache.pekko.persistence.typed.scaladsl]].
+ */
+@org.jspecify.annotations.NullMarked
+package org.apache.pekko.persistence.typed.javadsl;

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/EventSourcedBehavior.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/EventSourcedBehavior.scala
@@ -31,6 +31,7 @@ import pekko.persistence.typed.EventAdapter
 import pekko.persistence.typed.internal._
 
 import com.typesafe.config.Config
+import org.jspecify.annotations.Nullable
 
 abstract class EventSourcedBehavior[Command, Event, State] private[pekko] (
     val persistenceId: PersistenceId,
@@ -52,7 +53,7 @@ abstract class EventSourcedBehavior[Command, Event, State] private[pekko] (
    * @param persistenceId stable unique identifier for the event sourced behavior
    * @param onPersistFailure BackoffSupervisionStrategy for persist failures
    */
-  def this(persistenceId: PersistenceId, onPersistFailure: BackoffSupervisorStrategy) = {
+  def this(persistenceId: PersistenceId, @Nullable onPersistFailure: BackoffSupervisorStrategy) = {
     this(persistenceId, Optional.ofNullable(onPersistFailure))
   }
 
@@ -280,7 +281,7 @@ abstract class EventSourcedBehaviorWithEnforcedReplies[Command, Event, State](
     this(persistenceId, Optional.empty[BackoffSupervisorStrategy])
   }
 
-  def this(persistenceId: PersistenceId, backoffSupervisorStrategy: BackoffSupervisorStrategy) = {
+  def this(persistenceId: PersistenceId, @Nullable backoffSupervisorStrategy: BackoffSupervisorStrategy) = {
     this(persistenceId, Optional.ofNullable(backoffSupervisorStrategy))
   }
 

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/javadsl/DurableStateBehavior.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/javadsl/DurableStateBehavior.scala
@@ -28,6 +28,7 @@ import pekko.persistence.typed.SnapshotAdapter
 import pekko.persistence.typed.state.internal
 import pekko.persistence.typed.state.internal._
 import pekko.persistence.typed.state.scaladsl
+import org.jspecify.annotations.Nullable
 
 /**
  * A `Behavior` for a persistent actor with durable storage of its state.
@@ -55,7 +56,7 @@ abstract class DurableStateBehavior[Command, State] private[pekko] (
    * @param persistenceId stable unique identifier for the `DurableStateBehavior`
    * @param onPersistFailure BackoffSupervisionStrategy for persist failures
    */
-  def this(persistenceId: PersistenceId, onPersistFailure: BackoffSupervisorStrategy) = {
+  def this(persistenceId: PersistenceId, @Nullable onPersistFailure: BackoffSupervisorStrategy) = {
     this(persistenceId, Optional.ofNullable(onPersistFailure))
   }
 
@@ -175,7 +176,7 @@ abstract class DurableStateBehaviorWithEnforcedReplies[Command, State](
     this(persistenceId, Optional.empty[BackoffSupervisorStrategy])
   }
 
-  def this(persistenceId: PersistenceId, backoffSupervisorStrategy: BackoffSupervisorStrategy) = {
+  def this(persistenceId: PersistenceId, @Nullable backoffSupervisorStrategy: BackoffSupervisorStrategy) = {
     this(persistenceId, Optional.ofNullable(backoffSupervisorStrategy))
   }
 

--- a/persistence/src/main/java/org/apache/pekko/persistence/journal/japi/package-info.java
+++ b/persistence/src/main/java/org/apache/pekko/persistence/journal/japi/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Java API for Pekko Persistence Journal.
+ *
+ * <p>This package contains the Java DSL for Pekko Persistence Journal. For the Scala DSL see
+ * [[org.apache.pekko.persistence.journal]].
+ */
+@org.jspecify.annotations.NullMarked
+package org.apache.pekko.persistence.journal.japi;

--- a/persistence/src/main/java/org/apache/pekko/persistence/snapshot/japi/package-info.java
+++ b/persistence/src/main/java/org/apache/pekko/persistence/snapshot/japi/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Java API for Pekko Persistence Snapshot Store.
+ *
+ * <p>This package contains the Java DSL for Pekko Persistence Snapshot Store. For the Scala DSL see
+ * [[org.apache.pekko.persistence.snapshot]].
+ */
+@org.jspecify.annotations.NullMarked
+package org.apache.pekko.persistence.snapshot.japi;

--- a/persistence/src/main/java/org/apache/pekko/persistence/state/javadsl/package-info.java
+++ b/persistence/src/main/java/org/apache/pekko/persistence/state/javadsl/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Java API for Pekko Persistence Durable State.
+ *
+ * <p>This package contains the Java DSL for Pekko Persistence Durable State. For the Scala DSL see
+ * [[org.apache.pekko.persistence.state.scaladsl]].
+ */
+@org.jspecify.annotations.NullMarked
+package org.apache.pekko.persistence.state.javadsl;

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -289,6 +289,7 @@ object Dependencies {
   lazy val slf4j = l ++= Seq(slf4jApi, TestDependencies.logback)
 
   lazy val persistence = l ++= Seq(
+    jspecify,
     Provided.levelDB,
     Provided.levelDBNative,
     TestDependencies.scalatest,
@@ -298,6 +299,7 @@ object Dependencies {
     TestDependencies.commonsCodec)
 
   lazy val persistenceQuery = l ++= Seq(
+    jspecify,
     TestDependencies.scalatest,
     TestDependencies.junit,
     TestDependencies.commonsIo,
@@ -310,11 +312,18 @@ object Dependencies {
     Provided.levelDB,
     Provided.levelDBNative)
 
-  lazy val persistenceTestKit = l ++= Seq(TestDependencies.scalatest, TestDependencies.logback)
+  lazy val persistenceTestKit = l ++= Seq(
+    jspecify,
+    TestDependencies.scalatest,
+    TestDependencies.logback)
 
   lazy val persistenceTypedTests = l ++= Seq(TestDependencies.scalatest, TestDependencies.logback)
 
-  lazy val persistenceShared = l ++= Seq(Provided.levelDB, Provided.levelDBNative, TestDependencies.logback)
+  lazy val persistenceShared = l ++= Seq(
+    jspecify,
+    Provided.levelDB,
+    Provided.levelDBNative,
+    TestDependencies.logback)
 
   lazy val jackson = l ++= Seq(
     jacksonCore,


### PR DESCRIPTION
follow up to #2617 

* couldn't find much that explicitly support nulls
* could be more but in the end of the day, this is best effort
* if users report more cases where nulls are supported, we can update the annotations