### PR TITLE
Remove 1.5.x branch entry in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    target-branch: "1.5.x"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
* 1.6.x is now the top branch for 1.x
* We either need to change the yml to 1.6.x or remove the entry altogether
* We had an issue where one action (setup-sbt) stopped working because it was very out of date but it is very noisy getting so many dependabot PRs - there is an argument that when we get 1.x CI issues that we can do one off fixes for 1.x
* I favour removing it but can be outvoted, if the consensus is to keep the top 1.x branch up to date, I can rework this PR
