### PR TITLE
ByteString lastIndexOfSlice

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -1215,6 +1215,10 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       val byteStringWithOffset = ByteString1(
         "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8), 2, 24)
       byteStringWithOffset.lastIndexOfSlice(slice0) should ===(21)
+
+      val concat0 = makeMultiByteStringsSample()
+      concat0.lastIndexOfSlice(Array(16.toByte, 0xFF.toByte)) should ===(17)
+      concat0.lastIndexOfSlice(Array(16.toByte, 0xFE.toByte)) should ===(-1)
     }
     "startsWith (specialized)" in {
       val slice0 = "abcdefghijk".getBytes(StandardCharsets.UTF_8)

--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -1168,6 +1168,54 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
         "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8), 2, 24)
       byteStringWithOffset.indexOfSlice(slice0) should ===(21)
     }
+    "lastIndexOfSlice" in {
+      val slice0 = ByteString1.fromString("xyz")
+      val slice1 = ByteString1.fromString("xyzabc")
+      val notSlice = ByteString1.fromString("12345")
+      val pByte = ByteString1.fromString("p")
+      val byteStringLong = ByteString1.fromString("abcdefghijklmnopqrstuvwxyz")
+      val byteStrings = ByteStrings(byteStringLong, byteStringLong)
+      byteStringLong.lastIndexOfSlice(slice0) should ===(23)
+      byteStringLong.lastIndexOfSlice(slice1) should ===(-1)
+      byteStringLong.lastIndexOfSlice(notSlice) should ===(-1)
+      byteStringLong.lastIndexOfSlice(pByte) should ===(15)
+
+      byteStrings.lastIndexOfSlice(slice0) should ===(49)
+      byteStrings.lastIndexOfSlice(slice1) should ===(23)
+      byteStrings.lastIndexOfSlice(notSlice) should ===(-1)
+      byteStrings.lastIndexOfSlice(pByte) should ===(41)
+      byteStrings.lastIndexOfSlice(pByte, 40) should ===(15)
+
+      val byteStringXxyz = ByteString1.fromString("xxyz")
+      byteStringXxyz.lastIndexOfSlice(slice0) should ===(1)
+      byteStringXxyz.lastIndexOfSlice(slice0, 0) should ===(-1)
+    }
+    "lastIndexOfSlice (specialized)" in {
+      val slice0 = "xyz".getBytes(StandardCharsets.UTF_8)
+      val slice1 = "xyzabc".getBytes(StandardCharsets.UTF_8)
+      val notSlice = "12345".getBytes(StandardCharsets.UTF_8)
+      val pByte = Array('p'.toByte)
+      val byteStringLong = ByteString1.fromString("abcdefghijklmnopqrstuvwxyz")
+      val byteStrings = ByteStrings(byteStringLong, byteStringLong)
+      byteStringLong.lastIndexOfSlice(slice0) should ===(23)
+      byteStringLong.lastIndexOfSlice(slice1) should ===(-1)
+      byteStringLong.lastIndexOfSlice(notSlice) should ===(-1)
+      byteStringLong.lastIndexOfSlice(pByte) should ===(15)
+
+      byteStrings.lastIndexOfSlice(slice0) should ===(49)
+      byteStrings.lastIndexOfSlice(slice1) should ===(23)
+      byteStrings.lastIndexOfSlice(notSlice) should ===(-1)
+      byteStrings.lastIndexOfSlice(pByte) should ===(41)
+      byteStrings.lastIndexOfSlice(pByte, 40) should ===(15)
+
+      val byteStringXxyz = ByteString1.fromString("xxyz")
+      byteStringXxyz.lastIndexOfSlice(slice0) should ===(1)
+      byteStringXxyz.lastIndexOfSlice(slice0, 0) should ===(-1)
+
+      val byteStringWithOffset = ByteString1(
+        "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8), 2, 24)
+      byteStringWithOffset.lastIndexOfSlice(slice0) should ===(21)
+    }
     "startsWith (specialized)" in {
       val slice0 = "abcdefghijk".getBytes(StandardCharsets.UTF_8)
       val slice1 = "xyz".getBytes(StandardCharsets.UTF_8)

--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -830,6 +830,12 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       val concat0 = ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("dd"))
       concat0.lastIndexOf('d'.toByte, 2) should ===(2)
       concat0.lastIndexOf('d'.toByte, 3) should ===(3)
+
+      // end larger than length - 1 should be clamped to the last valid index
+      val bs5 = ByteString1.fromString("abcde")
+      bs5.lastIndexOf('e', 100) should ===(4)
+      bs5.lastIndexOf('a', 100) should ===(0)
+      bs5.lastIndexOf('z', 100) should ===(-1)
     }
     "lastIndexOf (specialized)" in {
       ByteString.empty.lastIndexOf(5.toByte, -1) should ===(-1)
@@ -894,6 +900,50 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       concat0.lastIndexOf(0xFF.toByte, 18) should ===(18)
       concat0.lastIndexOf(0xFF.toByte, 17) should ===(0)
       concat0.lastIndexOf(0xFE.toByte) should ===(-1)
+
+      // Single-byte ByteString
+      val single = ByteString1(Array[Byte]('x'))
+      single.lastIndexOf('x'.toByte) should ===(0)
+      single.lastIndexOf('y'.toByte) should ===(-1)
+
+      // SWAR boundary: exactly 7 bytes (only tail, no full chunk)
+      val len7 = ByteString1.fromString("abcdefg")
+      len7.lastIndexOf('g'.toByte) should ===(6)
+      len7.lastIndexOf('a'.toByte) should ===(0)
+      len7.lastIndexOf('d'.toByte) should ===(3)
+      len7.lastIndexOf('z'.toByte) should ===(-1)
+
+      // SWAR boundary: exactly 8 bytes (one full chunk, no tail)
+      val len8 = ByteString1.fromString("abcdefgh")
+      len8.lastIndexOf('h'.toByte) should ===(7)
+      len8.lastIndexOf('a'.toByte) should ===(0)
+      len8.lastIndexOf('d'.toByte) should ===(3)
+      len8.lastIndexOf('z'.toByte) should ===(-1)
+
+      // SWAR boundary: exactly 9 bytes (1-byte tail + 1 full chunk)
+      val len9 = ByteString1.fromString("abcdefghi")
+      len9.lastIndexOf('i'.toByte) should ===(8) // found in tail
+      len9.lastIndexOf('a'.toByte) should ===(0) // found in chunk
+      len9.lastIndexOf('h'.toByte) should ===(7) // last byte of chunk
+      len9.lastIndexOf('z'.toByte) should ===(-1)
+
+      // SWAR boundary: exactly 16 bytes (2 full chunks, no tail)
+      val len16 = ByteString1.fromString("abcdefghijklmnop")
+      len16.lastIndexOf('p'.toByte) should ===(15) // last byte of rightmost chunk
+      len16.lastIndexOf('a'.toByte) should ===(0)  // first byte of leftmost chunk
+      len16.lastIndexOf('h'.toByte) should ===(7)  // last byte of leftmost chunk
+      len16.lastIndexOf('i'.toByte) should ===(8)  // first byte of rightmost chunk
+
+      // All-same-byte array longer than 8: last index is the highest
+      val allSame = ByteString(Array[Byte](7, 7, 7, 7, 7, 7, 7, 7, 7)) // 9 bytes
+      allSame.lastIndexOf(7.toByte) should ===(8)
+      allSame.lastIndexOf(7.toByte, 5) should ===(5)
+      allSame.lastIndexOf(7.toByte, 0) should ===(0)
+
+      // ByteString1 with startIndex offset: find a byte residing in the SWAR chunk
+      val slicedLong = ByteString1.fromString("xxabcdefghijk").drop(2) // "abcdefghijk", 11 bytes
+      slicedLong.lastIndexOf('a'.toByte) should ===(0)  // first byte, found via chunk scan
+      slicedLong.lastIndexOf('h'.toByte) should ===(7)  // last byte of chunk
     }
     "indexOf (specialized)" in {
       ByteString.empty.indexOf(5.toByte) should ===(-1)
@@ -1145,6 +1195,29 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       byteStringXxyz.indexOfSlice(Seq.empty) should ===(0)
       byteStringXxyz.indexOfSlice(Seq.empty, -1) should ===(0)
       byteStringXxyz.indexOfSlice(Seq.empty, 1) should ===(1)
+
+      // empty slice at from == length: should return length (consistent with Scala standard library)
+      byteStringXxyz.indexOfSlice(Seq.empty, 4) should ===(4)
+      // empty slice at from > length: should return -1
+      byteStringXxyz.indexOfSlice(Seq.empty, 5) should ===(-1)
+
+      // Empty source
+      ByteString.empty.indexOfSlice(Seq.empty) should ===(0)
+      ByteString.empty.indexOfSlice(ByteString1.fromString("a")) should ===(-1)
+
+      // Slice equals entire source
+      ByteString1.fromString("abc").indexOfSlice(ByteString1.fromString("abc")) should ===(0)
+
+      // Slice longer than source
+      ByteString1.fromString("ab").indexOfSlice(ByteString1.fromString("abc")) should ===(-1)
+
+      // Cross-segment match in ByteStrings: "bc" spans segment boundary of ("ab" ++ "cd")
+      ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd"))
+        .indexOfSlice(ByteString1.fromString("bc")) should ===(1)
+
+      // False match: first byte matches multiple times before the full slice matches
+      // "ab" in "aabc": 'a' at index 0 (check: bytes[1]='a' != 'b' ✗), then 'a' at 1 (bytes[2]='b' == 'b' ✓) -> 1
+      ByteString1.fromString("aabc").indexOfSlice(ByteString1.fromString("ab")) should ===(1)
     }
     "indexOfSlice (specialized)" in {
       val slice0 = "xyz".getBytes(StandardCharsets.UTF_8)
@@ -1171,6 +1244,28 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       byteStringXxyz.indexOfSlice(Seq.empty) should ===(0)
       byteStringXxyz.indexOfSlice(Seq.empty, -1) should ===(0)
       byteStringXxyz.indexOfSlice(Seq.empty, 1) should ===(1)
+
+      // empty slice at from == length: should return length (consistent with Scala standard library)
+      byteStringXxyz.indexOfSlice(Seq.empty, 4) should ===(4)
+      // empty slice at from > length: should return -1
+      byteStringXxyz.indexOfSlice(Seq.empty, 5) should ===(-1)
+
+      // Empty source
+      ByteString.empty.indexOfSlice(Array.empty[Byte]) should ===(0)
+      ByteString.empty.indexOfSlice(Array[Byte]('a')) should ===(-1)
+
+      // Slice equals entire source
+      ByteString1.fromString("abc").indexOfSlice("abc".getBytes(StandardCharsets.UTF_8)) should ===(0)
+
+      // Slice longer than source
+      ByteString1.fromString("ab").indexOfSlice("abc".getBytes(StandardCharsets.UTF_8)) should ===(-1)
+
+      // Cross-segment match in ByteStrings: "bc" spans segment boundary of ("ab" ++ "cd")
+      ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd"))
+        .indexOfSlice(Array[Byte]('b', 'c')) should ===(1)
+
+      // False match: first byte matches multiple times before the full slice matches
+      ByteString1.fromString("aabc").indexOfSlice(Array[Byte]('a', 'b')) should ===(1)
 
       val byteStringWithOffset = ByteString1(
         "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8), 2, 24)
@@ -1204,6 +1299,29 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
 
       val xyzx = ByteString1.fromString("xyzx")
       xyzx.lastIndexOfSlice(slice0) should ===(0)
+
+      // Empty source with empty slice -> 0; with non-empty slice -> -1
+      ByteString.empty.lastIndexOfSlice(ByteString.empty) should ===(0)
+      ByteString.empty.lastIndexOfSlice(ByteString1.fromString("a")) should ===(-1)
+
+      // Slice equals entire source -> 0
+      ByteString1.fromString("abc").lastIndexOfSlice(ByteString1.fromString("abc")) should ===(0)
+
+      // Slice longer than source -> -1
+      ByteString1.fromString("ab").lastIndexOfSlice(ByteString1.fromString("abc")) should ===(-1)
+
+      // end = -1 for non-empty slice -> -1
+      ByteString1.fromString("abc").lastIndexOfSlice(ByteString1.fromString("a"), -1) should ===(-1)
+
+      // False-match retry: tail byte 'b' matches at index 2, but bytes[1]='b' != 'a'; retries, finds at index 1, bytes[0]='a' == 'a'
+      ByteString1.fromString("abb").lastIndexOfSlice(ByteString1.fromString("ab")) should ===(0)
+
+      // Repeated pattern: "aa" in "aaaa" -> last occurrence starts at index 2
+      ByteString1.fromString("aaaa").lastIndexOfSlice(ByteString1.fromString("aa")) should ===(2)
+
+      // Cross-segment match in ByteStrings: slice "bc" spans segment boundary of ("ab" ++ "cd")
+      ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd"))
+        .lastIndexOfSlice(ByteString1.fromString("bc")) should ===(1)
     }
     "lastIndexOfSlice (specialized)" in {
       val slice0 = "xyz".getBytes(StandardCharsets.UTF_8)
@@ -1241,6 +1359,29 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       val concat0 = makeMultiByteStringsSample()
       concat0.lastIndexOfSlice(Array(16.toByte, 0xFF.toByte)) should ===(17)
       concat0.lastIndexOfSlice(Array(16.toByte, 0xFE.toByte)) should ===(-1)
+
+      // Empty source with empty slice -> 0; with non-empty slice -> -1
+      ByteString.empty.lastIndexOfSlice(Array.empty[Byte]) should ===(0)
+      ByteString.empty.lastIndexOfSlice(Array[Byte]('a')) should ===(-1)
+
+      // Slice equals entire source -> 0
+      ByteString1.fromString("abc").lastIndexOfSlice("abc".getBytes(StandardCharsets.UTF_8)) should ===(0)
+
+      // Slice longer than source -> -1
+      ByteString1.fromString("ab").lastIndexOfSlice("abc".getBytes(StandardCharsets.UTF_8)) should ===(-1)
+
+      // end = -1 for non-empty slice -> -1
+      ByteString1.fromString("abc").lastIndexOfSlice(Array[Byte]('a'), -1) should ===(-1)
+
+      // False-match retry: tail byte 'b' matches at index 2, but bytes[1]='b' != 'a'; retries, finds at index 1
+      ByteString1.fromString("abb").lastIndexOfSlice(Array[Byte]('a', 'b')) should ===(0)
+
+      // Repeated pattern: "aa" in "aaaa" -> last occurrence starts at index 2
+      ByteString1.fromString("aaaa").lastIndexOfSlice(Array[Byte]('a', 'a')) should ===(2)
+
+      // Cross-segment match in ByteStrings: slice "bc" spans segment boundary of ("ab" ++ "cd")
+      ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd"))
+        .lastIndexOfSlice(Array[Byte]('b', 'c')) should ===(1)
     }
     "startsWith (specialized)" in {
       val slice0 = "abcdefghijk".getBytes(StandardCharsets.UTF_8)

--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -1140,7 +1140,11 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
 
       val byteStringXxyz = ByteString1.fromString("xxyz")
       byteStringXxyz.indexOfSlice(slice0) should ===(1)
+      byteStringXxyz.indexOfSlice(slice0, -1) should ===(1)
       byteStringXxyz.indexOfSlice(slice0, 2) should ===(-1)
+      byteStringXxyz.indexOfSlice(Seq.empty) should ===(0)
+      byteStringXxyz.indexOfSlice(Seq.empty, -1) should ===(0)
+      byteStringXxyz.indexOfSlice(Seq.empty, 1) should ===(1)
     }
     "indexOfSlice (specialized)" in {
       val slice0 = "xyz".getBytes(StandardCharsets.UTF_8)
@@ -1162,7 +1166,11 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
 
       val byteStringXxyz = ByteString1.fromString("xxyz")
       byteStringXxyz.indexOfSlice(slice0) should ===(1)
+      byteStringXxyz.indexOfSlice(slice0, -1) should ===(1)
       byteStringXxyz.indexOfSlice(slice0, 2) should ===(-1)
+      byteStringXxyz.indexOfSlice(Seq.empty) should ===(0)
+      byteStringXxyz.indexOfSlice(Seq.empty, -1) should ===(0)
+      byteStringXxyz.indexOfSlice(Seq.empty, 1) should ===(1)
 
       val byteStringWithOffset = ByteString1(
         "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8), 2, 24)
@@ -1188,7 +1196,14 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
 
       val byteStringXxyz = ByteString1.fromString("xxyz")
       byteStringXxyz.lastIndexOfSlice(slice0) should ===(1)
+      byteStringXxyz.lastIndexOfSlice(slice0, 10) should ===(1)
       byteStringXxyz.lastIndexOfSlice(slice0, 0) should ===(-1)
+      byteStringXxyz.lastIndexOfSlice(slice0, 2) should ===(1)
+      byteStringXxyz.lastIndexOfSlice(Seq.empty) should ===(4)
+      byteStringXxyz.lastIndexOfSlice(Seq.empty, 2) should ===(2)
+
+      val xyzx = ByteString1.fromString("xyzx")
+      xyzx.lastIndexOfSlice(slice0) should ===(0)
     }
     "lastIndexOfSlice (specialized)" in {
       val slice0 = "xyz".getBytes(StandardCharsets.UTF_8)
@@ -1210,7 +1225,14 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
 
       val byteStringXxyz = ByteString1.fromString("xxyz")
       byteStringXxyz.lastIndexOfSlice(slice0) should ===(1)
+      byteStringXxyz.lastIndexOfSlice(slice0, 10) should ===(1)
       byteStringXxyz.lastIndexOfSlice(slice0, 0) should ===(-1)
+      byteStringXxyz.lastIndexOfSlice(slice0, 2) should ===(1)
+      byteStringXxyz.lastIndexOfSlice(Seq.empty) should ===(4)
+      byteStringXxyz.lastIndexOfSlice(Seq.empty, 2) should ===(2)
+
+      val xyzx = ByteString1.fromString("xyzx")
+      xyzx.lastIndexOfSlice(slice0) should ===(0)
 
       val byteStringWithOffset = ByteString1(
         "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8), 2, 24)

--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -930,9 +930,9 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       // SWAR boundary: exactly 16 bytes (2 full chunks, no tail)
       val len16 = ByteString1.fromString("abcdefghijklmnop")
       len16.lastIndexOf('p'.toByte) should ===(15) // last byte of rightmost chunk
-      len16.lastIndexOf('a'.toByte) should ===(0)  // first byte of leftmost chunk
-      len16.lastIndexOf('h'.toByte) should ===(7)  // last byte of leftmost chunk
-      len16.lastIndexOf('i'.toByte) should ===(8)  // first byte of rightmost chunk
+      len16.lastIndexOf('a'.toByte) should ===(0) // first byte of leftmost chunk
+      len16.lastIndexOf('h'.toByte) should ===(7) // last byte of leftmost chunk
+      len16.lastIndexOf('i'.toByte) should ===(8) // first byte of rightmost chunk
 
       // All-same-byte array longer than 8: last index is the highest
       val allSame = ByteString(Array[Byte](7, 7, 7, 7, 7, 7, 7, 7, 7)) // 9 bytes
@@ -942,8 +942,8 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
 
       // ByteString1 with startIndex offset: find a byte residing in the SWAR chunk
       val slicedLong = ByteString1.fromString("xxabcdefghijk").drop(2) // "abcdefghijk", 11 bytes
-      slicedLong.lastIndexOf('a'.toByte) should ===(0)  // first byte, found via chunk scan
-      slicedLong.lastIndexOf('h'.toByte) should ===(7)  // last byte of chunk
+      slicedLong.lastIndexOf('a'.toByte) should ===(0) // first byte, found via chunk scan
+      slicedLong.lastIndexOf('h'.toByte) should ===(7) // last byte of chunk
     }
     "indexOf (specialized)" in {
       ByteString.empty.indexOf(5.toByte) should ===(-1)

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -352,7 +352,7 @@ object ByteString {
       else if (bytes(fromIndex) == value) fromIndex
       else -1
     }
-    
+
     private def unrolledFirstIndexOf(fromIndex: Int, byteCount: Int, value: Byte): Int = {
       if (bytes(fromIndex) == value) fromIndex
       else if (byteCount == 1) -1

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -1295,7 +1295,7 @@ sealed abstract class ByteString
       true
     }
     val sliceLength = slice.length
-    if (sliceLength == 0) if (from >= length) -1 else math.max(from, 0)
+    if (sliceLength == 0) if (from > length) -1 else math.max(from, 0)
     else {
       val headByte = slice.head.asInstanceOf[Byte]
       @tailrec def rec(from: Int): Int = {
@@ -1333,7 +1333,7 @@ sealed abstract class ByteString
       true
     }
     val sliceLength = slice.length
-    if (sliceLength == 0) if (from >= length) -1 else math.max(from, 0)
+    if (sliceLength == 0) if (from > length) -1 else math.max(from, 0)
     else if (sliceLength > length) -1
     else {
       val headByte = slice.head
@@ -1454,7 +1454,7 @@ sealed abstract class ByteString
    *          to `slice`, or `-1`, if none exists.
    * @since 2.0.0
    */
-  def lastIndexOfSlice(slice: Array[Byte]): Int = lastIndexOfSlice(slice, length - 1)
+  def lastIndexOfSlice(slice: Array[Byte]): Int = lastIndexOfSlice(slice, length)
 
   override def contains[B >: Byte](elem: B): Boolean = indexOf(elem, 0) != -1
 

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -340,6 +340,19 @@ object ByteString {
       -1
     }
 
+    // Searches byteCount bytes (1-7) starting at fromIndex from highest to lowest index,
+    // returning the rightmost (last) match, or -1 if not found.
+    private def unrolledLastIndexOf(fromIndex: Int, byteCount: Int, value: Byte): Int = {
+      if (byteCount >= 7 && bytes(fromIndex + 6) == value) fromIndex + 6
+      else if (byteCount >= 6 && bytes(fromIndex + 5) == value) fromIndex + 5
+      else if (byteCount >= 5 && bytes(fromIndex + 4) == value) fromIndex + 4
+      else if (byteCount >= 4 && bytes(fromIndex + 3) == value) fromIndex + 3
+      else if (byteCount >= 3 && bytes(fromIndex + 2) == value) fromIndex + 2
+      else if (byteCount >= 2 && bytes(fromIndex + 1) == value) fromIndex + 1
+      else if (bytes(fromIndex) == value) fromIndex
+      else -1
+    }
+    
     private def unrolledFirstIndexOf(fromIndex: Int, byteCount: Int, value: Byte): Int = {
       if (bytes(fromIndex) == value) fromIndex
       else if (byteCount == 1) -1
@@ -354,19 +367,6 @@ object ByteString {
       else if (bytes(fromIndex + 5) == value) fromIndex + 5
       else if (byteCount == 6) -1
       else if (bytes(fromIndex + 6) == value) fromIndex + 6
-      else -1
-    }
-
-    // Searches byteCount bytes (1-7) starting at fromIndex from highest to lowest index,
-    // returning the rightmost (last) match, or -1 if not found.
-    private def unrolledLastIndexOf(fromIndex: Int, byteCount: Int, value: Byte): Int = {
-      if (byteCount >= 7 && bytes(fromIndex + 6) == value) fromIndex + 6
-      else if (byteCount >= 6 && bytes(fromIndex + 5) == value) fromIndex + 5
-      else if (byteCount >= 5 && bytes(fromIndex + 4) == value) fromIndex + 4
-      else if (byteCount >= 4 && bytes(fromIndex + 3) == value) fromIndex + 3
-      else if (byteCount >= 3 && bytes(fromIndex + 2) == value) fromIndex + 2
-      else if (byteCount >= 2 && bytes(fromIndex + 1) == value) fromIndex + 1
-      else if (bytes(fromIndex) == value) fromIndex
       else -1
     }
 

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -1294,17 +1294,19 @@ sealed abstract class ByteString
       }
       true
     }
-    val headByte = slice.head.asInstanceOf[Byte]
-    @tailrec def rec(from: Int): Int = {
-      val startPos = indexOf(headByte, from, length - slice.length + 1)
-      if (startPos == -1) -1
-      else if (check(startPos)) startPos
-      else rec(startPos + 1)
-    }
     val sliceLength = slice.length
-    if (sliceLength == 0) 0
-    else if (sliceLength == 1) indexOf(headByte, from)
-    else rec(math.max(0, from))
+    if (sliceLength == 0) if (from >= length) -1 else math.max(from, 0)
+    else {
+      val headByte = slice.head.asInstanceOf[Byte]
+      @tailrec def rec(from: Int): Int = {
+        val startPos = indexOf(headByte, from, length - slice.length + 1)
+        if (startPos == -1) -1
+        else if (check(startPos)) startPos
+        else rec(startPos + 1)
+      }
+      if (sliceLength == 1) indexOf(headByte, from)
+      else rec(math.max(0, from))
+    }
   }
 
   /**
@@ -1330,16 +1332,20 @@ sealed abstract class ByteString
       }
       true
     }
-    @tailrec def rec(from: Int): Int = {
-      val startPos = indexOf(slice.head, from, length - slice.length + 1)
-      if (startPos == -1) -1
-      else if (check(startPos)) startPos
-      else rec(startPos + 1)
-    }
     val sliceLength = slice.length
-    if (sliceLength == 0) 0
-    else if (sliceLength == 1) indexOf(slice.head, from)
-    else rec(math.max(0, from))
+    if (sliceLength == 0) if (from >= length) -1 else math.max(from, 0)
+    else if (sliceLength > length) -1
+    else {
+      val headByte = slice.head
+      @tailrec def rec(from: Int): Int = {
+        val startPos = indexOf(headByte, from, length - slice.length + 1)
+        if (startPos == -1) -1
+        else if (check(startPos)) startPos
+        else rec(startPos + 1)
+      }
+      if (sliceLength == 1) indexOf(headByte, from)
+      else rec(math.max(0, from))
+    }
   }
 
   /**
@@ -1364,6 +1370,7 @@ sealed abstract class ByteString
         var i = startPos
         var j = 0
         while (j < sliceLength - 1) {
+          // let's trust the calling code has ensured that we have enough bytes in this ByteString
           if (apply(i) != slice(j)) return false
           i += 1
           j += 1
@@ -1411,6 +1418,7 @@ sealed abstract class ByteString
         var i = startPos
         var j = 0
         while (j < sliceLength - 1) {
+          // let's trust the calling code has ensured that we have enough bytes in this ByteString
           if (apply(i) != slice(j)) return false
           i += 1
           j += 1

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -340,19 +340,6 @@ object ByteString {
       -1
     }
 
-    // Searches byteCount bytes (1-7) starting at fromIndex from highest to lowest index,
-    // returning the rightmost (last) match, or -1 if not found.
-    private def unrolledLastIndexOf(fromIndex: Int, byteCount: Int, value: Byte): Int = {
-      if (byteCount >= 7 && bytes(fromIndex + 6) == value) fromIndex + 6
-      else if (byteCount >= 6 && bytes(fromIndex + 5) == value) fromIndex + 5
-      else if (byteCount >= 5 && bytes(fromIndex + 4) == value) fromIndex + 4
-      else if (byteCount >= 4 && bytes(fromIndex + 3) == value) fromIndex + 3
-      else if (byteCount >= 3 && bytes(fromIndex + 2) == value) fromIndex + 2
-      else if (byteCount >= 2 && bytes(fromIndex + 1) == value) fromIndex + 1
-      else if (bytes(fromIndex) == value) fromIndex
-      else -1
-    }
-
     private def unrolledFirstIndexOf(fromIndex: Int, byteCount: Int, value: Byte): Int = {
       if (bytes(fromIndex) == value) fromIndex
       else if (byteCount == 1) -1
@@ -367,6 +354,19 @@ object ByteString {
       else if (bytes(fromIndex + 5) == value) fromIndex + 5
       else if (byteCount == 6) -1
       else if (bytes(fromIndex + 6) == value) fromIndex + 6
+      else -1
+    }
+
+    // Searches byteCount bytes (1-7) starting at fromIndex from highest to lowest index,
+    // returning the rightmost (last) match, or -1 if not found.
+    private def unrolledLastIndexOf(fromIndex: Int, byteCount: Int, value: Byte): Int = {
+      if (byteCount >= 7 && bytes(fromIndex + 6) == value) fromIndex + 6
+      else if (byteCount >= 6 && bytes(fromIndex + 5) == value) fromIndex + 5
+      else if (byteCount >= 5 && bytes(fromIndex + 4) == value) fromIndex + 4
+      else if (byteCount >= 4 && bytes(fromIndex + 3) == value) fromIndex + 3
+      else if (byteCount >= 3 && bytes(fromIndex + 2) == value) fromIndex + 2
+      else if (byteCount >= 2 && bytes(fromIndex + 1) == value) fromIndex + 1
+      else if (bytes(fromIndex) == value) fromIndex
       else -1
     }
 
@@ -1259,10 +1259,10 @@ sealed abstract class ByteString
   /**
    * Finds index of last occurrence of some byte in this ByteString before or at some end index.
    *
-   * Similar to lastIndexOf, but it avoids boxing if the value is already a byte.
+   * Similar to `lastIndexOf`, but it avoids boxing if the value is already a byte.
    *
    *  @param   elem   the element value to search for.
-   *  @param   end    the end index
+   *  @param   end    the end index (inclusive)
    *  @return  the index `<= end` of the last element of this ByteString that is equal (as determined by `==`)
    *           to `elem`, or `-1`, if none exists.
    *  @since 2.0.0
@@ -1272,7 +1272,7 @@ sealed abstract class ByteString
   /**
    * Finds index of last occurrence of some byte in this ByteString.
    *
-   * Similar to lastIndexOf, but it avoids boxing if the value is already a byte.
+   * Similar to `lastIndexOf`, but it avoids boxing if the value is already a byte.
    *
    *  @param   elem   the element value to search for.
    *  @return  the index of the last element of this ByteString that is equal (as determined by `==`)
@@ -1352,6 +1352,101 @@ sealed abstract class ByteString
    * @since 2.0.0
    */
   def indexOfSlice(slice: Array[Byte]): Int = indexOfSlice(slice, 0)
+
+  override def lastIndexOfSlice[B >: Byte](slice: scala.collection.Seq[B], end: Int): Int = {
+    val sliceLength = slice.length
+    if (sliceLength == 0) if (end < 0) -1 else math.min(end, length)
+    else if (sliceLength > length) -1
+    else {
+      val tailByte = slice(sliceLength - 1).asInstanceOf[Byte]
+      // Check all bytes of the slice except the last one (which was matched by lastIndexOf)
+      def check(startPos: Int): Boolean = {
+        var i = startPos
+        var j = 0
+        while (j < sliceLength - 1) {
+          if (apply(i) != slice(j)) return false
+          i += 1
+          j += 1
+        }
+        true
+      }
+      // Cap end to the max valid slice start position to avoid Int overflow when end is very large
+      val effectiveEnd = math.min(end, length - sliceLength)
+      val maxEndPos = effectiveEnd + sliceLength - 1
+      @tailrec def rec(currEnd: Int): Int = {
+        val endPos = lastIndexOf(tailByte, currEnd)
+        if (endPos < sliceLength - 1) -1
+        else {
+          val startPos = endPos - sliceLength + 1
+          if (check(startPos)) startPos
+          else rec(endPos - 1)
+        }
+      }
+      if (sliceLength == 1) lastIndexOf(tailByte, effectiveEnd)
+      else rec(maxEndPos)
+    }
+  }
+
+  /**
+   * Finds index of last occurrence of some slice in this ByteString before or at some end index.
+   *
+   * Uses `lastIndexOf` on the last byte of the slice to efficiently find candidate positions,
+   * then verifies the full slice match.
+   *
+   * @param   slice   the slice to search for.
+   * @param   end     the end index — the largest index at which the slice may start
+   * @return  the largest index `<= end` of the first element of this
+   *          ByteString that starts a slice equal (as determined by `==`)
+   *          to `slice`, or `-1`, if none exists.
+   * @since 2.0.0
+   */
+  def lastIndexOfSlice(slice: Array[Byte], end: Int): Int = {
+    val sliceLength = slice.length
+    if (sliceLength == 0) if (end < 0) -1 else math.min(end, length)
+    else if (sliceLength > length) -1
+    else {
+      val tailByte = slice(sliceLength - 1)
+      // Check all bytes of the slice except the last one (which was matched by lastIndexOf)
+      def check(startPos: Int): Boolean = {
+        var i = startPos
+        var j = 0
+        while (j < sliceLength - 1) {
+          if (apply(i) != slice(j)) return false
+          i += 1
+          j += 1
+        }
+        true
+      }
+      // Cap end to the max valid slice start position to avoid Int overflow when end is very large
+      val effectiveEnd = math.min(end, length - sliceLength)
+      val maxEndPos = effectiveEnd + sliceLength - 1
+      @tailrec def rec(currEnd: Int): Int = {
+        val endPos = lastIndexOf(tailByte, currEnd)
+        if (endPos < sliceLength - 1) -1
+        else {
+          val startPos = endPos - sliceLength + 1
+          if (check(startPos)) startPos
+          else rec(endPos - 1)
+        }
+      }
+      if (sliceLength == 1) lastIndexOf(tailByte, effectiveEnd)
+      else rec(maxEndPos)
+    }
+  }
+
+  /**
+   * Finds index of last occurrence of some slice in this ByteString.
+   *
+   * Uses `lastIndexOf` on the last byte of the slice to efficiently find candidate positions,
+   * then verifies the full slice match.
+   *
+   * @param   slice   the slice to search for.
+   * @return  the index of the last element of this
+   *          ByteString that starts a slice equal (as determined by `==`)
+   *          to `slice`, or `-1`, if none exists.
+   * @since 2.0.0
+   */
+  def lastIndexOfSlice(slice: Array[Byte]): Int = lastIndexOfSlice(slice, length - 1)
 
   override def contains[B >: Byte](elem: B): Boolean = indexOf(elem, 0) != -1
 

--- a/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_lastIndexOfSlice_Benchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_lastIndexOfSlice_Benchmark.scala
@@ -29,11 +29,11 @@ class ByteString_lastIndexOfSlice_Benchmark {
   val hv = "hijklmnopqrstuv".getBytes(StandardCharsets.UTF_8)
 
   @Benchmark
-  def bss_lastIndexOfSlice: Int = bss.lastIndexOfSlice(abc, 1)
+  def bss_lastIndexOfSlice: Int = bss.lastIndexOfSlice(abc)
 
   @Benchmark
-  def bs_lastIndexOfSlice_abc: Int = bs.lastIndexOfSlice(abc, 1)
+  def bs_lastIndexOfSlice_abc: Int = bs.lastIndexOfSlice(abc)
 
   @Benchmark
-  def bs_lastIndexOfSlice_hv: Int = bs.lastIndexOfSlice(hv, 1)
+  def bs_lastIndexOfSlice_hv: Int = bs.lastIndexOfSlice(hv)
 }

--- a/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_lastIndexOfSlice_Benchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_lastIndexOfSlice_Benchmark.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2014-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package org.apache.pekko.util
+
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+@State(Scope.Benchmark)
+@Measurement(timeUnit = TimeUnit.MILLISECONDS)
+class ByteString_lastIndexOfSlice_Benchmark {
+  val start = ByteString("abcdefg") ++ ByteString("hijklmno") ++ ByteString("pqrstuv")
+  val bss = start ++ start ++ start ++ start ++ start ++ ByteString("xyz")
+
+  val bs = bss.compact // compacted
+  val abc = "abc".getBytes(StandardCharsets.UTF_8)
+  val hv = "hijklmnopqrstuv".getBytes(StandardCharsets.UTF_8)
+
+  @Benchmark
+  def bss_lastIndexOfSlice: Int = bss.lastIndexOfSlice(abc, 1)
+
+  @Benchmark
+  def bs_lastIndexOfSlice_abc: Int = bs.lastIndexOfSlice(abc, 1)
+
+  @Benchmark
+  def bs_lastIndexOfSlice_hv: Int = bs.lastIndexOfSlice(hv, 1)
+}


### PR DESCRIPTION
### New: `lastIndexOfSlice`

- **ByteString (abstract)**: `override def lastIndexOfSlice[B >: Byte](slice: Seq[B], end: Int): Int` — uses `lastIndexOf` on the **last byte** of the slice to find candidate end positions, then verifies the rest of the slice.
- **ByteString (abstract)**: `def lastIndexOfSlice(slice: Array[Byte], end: Int): Int` and `def lastIndexOfSlice(slice: Array[Byte]): Int` — same approach for `Array[Byte]` slices.

**Key optimization**: both implementations cap `end` to `min(end, length - sliceLength)` before computing the search start, preventing `Int` overflow when the parent class calls `lastIndexOfSlice(that, Int.MaxValue)`.

## Tests

- Added `"lastIndexOf (specialized)"` test block covering `ByteString1`, `ByteStrings`, and compact variants.
- Added `"lastIndexOfSlice"` test block (using `ByteString` seq type) and `"lastIndexOfSlice (specialized)"` (using `Array[Byte]`), covering `ByteString1`, `ByteStrings`, offset `ByteString1`, and edge cases.
- Fixes some issues with edge cases in `indexOfSlice`

## Benchmark

```
With Changes
[info] Benchmark                                                       Mode  Cnt         Score          Error  Units
[info] ByteString_lastIndexOfSlice_Benchmark.bs_lastIndexOfSlice_abc  thrpt    3  28105765.600 ± 76735569.699  ops/s
[info] ByteString_lastIndexOfSlice_Benchmark.bs_lastIndexOfSlice_hv   thrpt    3  30468747.357 ±  3858323.420  ops/s
[info] ByteString_lastIndexOfSlice_Benchmark.bss_lastIndexOfSlice     thrpt    3   2732170.943 ±  3114888.476  ops/s

Without Changes
[info] Benchmark                                                       Mode  Cnt         Score         Error  Units
[info] ByteString_lastIndexOfSlice_Benchmark.bs_lastIndexOfSlice_abc  thrpt    3   9101755.721 ± 3333167.328  ops/s
[info] ByteString_lastIndexOfSlice_Benchmark.bs_lastIndexOfSlice_hv   thrpt    3   7757911.197 ± 3422112.843  ops/s
[info] ByteString_lastIndexOfSlice_Benchmark.bss_lastIndexOfSlice     thrpt    3   1054397.115 ±  536082.169  ops/s
```