### PR TITLE
ByteString: extract shared private helpers to reduce code duplication

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -1006,7 +1006,8 @@ object ByteString {
   }
 
   // SWAR-based search for first occurrence of `elem` in bytes[fromOffset, fromOffset+searchLength).
-  // Returns the absolute index in `bytes`, or -1 if not found.
+  // `fromOffset` is an absolute index into `bytes`; the return value is also an absolute index in
+  // `bytes`, or -1 if not found. Callers are responsible for converting to/from logical indices.
   private def swarFirstIndexOf(bytes: Array[Byte], fromOffset: Int, searchLength: Int, elem: Byte): Int = {
     var offset = fromOffset
     val byteCount = searchLength & 7
@@ -1031,22 +1032,27 @@ object ByteString {
   }
 
   // SWAR-based search for last occurrence of `elem` in bytes[baseOffset, baseOffset+searchLength).
-  // Returns the logical index (absolute index minus `baseOffset`), or -1 if not found.
+  // `baseOffset` is an absolute index into `bytes`.
+  // Returns the logical index (i.e. the index relative to `baseOffset`, not the absolute index into
+  // `bytes`), or -1 if not found.
+  // Note: `chunkStart` below is a logical offset (0-based from `baseOffset`), so both return paths
+  // produce a logical index without further adjustment.
   private def swarLastIndexOf(bytes: Array[Byte], baseOffset: Int, searchLength: Int, elem: Byte): Int = {
     val tailBytes = searchLength & 7
     if (tailBytes > 0) {
       val tailStart = searchLength - tailBytes
       val index = unrolledLastIndexOf(bytes, baseOffset + tailStart, tailBytes, elem)
-      if (index != -1) return index - baseOffset
+      if (index != -1) return index - baseOffset  // convert absolute → logical
       if (tailStart == 0) return -1
     }
+    // chunkStart is a logical offset within [0, searchLength); bytes are read from baseOffset + chunkStart.
     var chunkStart = searchLength - tailBytes - 8
     if (chunkStart >= 0) {
       val pattern = SWARUtil.compilePattern(elem)
       while (chunkStart >= 0) {
         val word = SWARUtil.getLong(bytes, baseOffset + chunkStart, ByteOrder.BIG_ENDIAN)
         val result = SWARUtil.applyPattern(word, pattern)
-        if (result != 0) return chunkStart + SWARUtil.getLastIndex(result)
+        if (result != 0) return chunkStart + SWARUtil.getLastIndex(result)  // already logical
         chunkStart -= 8
       }
     }

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -489,20 +489,22 @@ object ByteString {
         }
     }
 
+    // Converts an absolute index in `bytes` (as returned by `swarFirstIndexOf` or `swarLastIndexOf`)
+    // to a logical index relative to `startIndex`, preserving -1 as the "not found" sentinel.
+    private def absToLogical(absIdx: Int): Int = if (absIdx == -1) -1 else absIdx - startIndex
+
     @nowarn
     override def indexOf(elem: Byte, from: Int): Int = {
       val fromIndex = math.max(0, from)
       if (fromIndex >= length) return -1
-      val absResult = swarFirstIndexOf(bytes, fromIndex + startIndex, length - fromIndex, elem)
-      if (absResult == -1) -1 else absResult - startIndex
+      absToLogical(swarFirstIndexOf(bytes, fromIndex + startIndex, length - fromIndex, elem))
     }
 
     override def indexOf(elem: Byte, from: Int, to: Int): Int = {
       val fromIndex = math.max(0, from)
       val toIndex = math.min(to, length)
       if (fromIndex >= toIndex) return -1
-      val absResult = swarFirstIndexOf(bytes, fromIndex + startIndex, toIndex - fromIndex, elem)
-      if (absResult == -1) -1 else absResult - startIndex
+      absToLogical(swarFirstIndexOf(bytes, fromIndex + startIndex, toIndex - fromIndex, elem))
     }
 
     override def lastIndexOf[B >: Byte](elem: B, end: Int): Int = {
@@ -525,7 +527,7 @@ object ByteString {
     override def lastIndexOf(elem: Byte, end: Int): Int = {
       val endIdx = math.min(end, length - 1)
       if (endIdx < 0) return -1
-      swarLastIndexOf(bytes, startIndex, endIdx + 1, elem)
+      absToLogical(swarLastIndexOf(bytes, startIndex, endIdx + 1, elem))
     }
 
     override def copyToArray[B >: Byte](dest: Array[B], start: Int, len: Int): Int = {
@@ -1033,26 +1035,26 @@ object ByteString {
 
   // SWAR-based search for last occurrence of `elem` in bytes[baseOffset, baseOffset+searchLength).
   // `baseOffset` is an absolute index into `bytes`.
-  // Returns the logical index (i.e. the index relative to `baseOffset`, not the absolute index into
-  // `bytes`), or -1 if not found.
-  // Note: `chunkStart` below is a logical offset (0-based from `baseOffset`), so both return paths
-  // produce a logical index without further adjustment.
+  // Returns the absolute index in `bytes`, or -1 if not found. Callers are responsible for
+  // converting to logical indices (e.g. `absResult - startIndex` for `ByteString1`).
+  // Note: `chunkStart` below is a logical offset (0-based from `baseOffset`), so the absolute
+  // result is computed as `baseOffset + chunkStart + getLastIndex(result)`.
   private def swarLastIndexOf(bytes: Array[Byte], baseOffset: Int, searchLength: Int, elem: Byte): Int = {
     val tailBytes = searchLength & 7
     if (tailBytes > 0) {
       val tailStart = searchLength - tailBytes
       val index = unrolledLastIndexOf(bytes, baseOffset + tailStart, tailBytes, elem)
-      if (index != -1) return index - baseOffset  // convert absolute → logical
+      if (index != -1) return index  // already absolute
       if (tailStart == 0) return -1
     }
-    // chunkStart is a logical offset within [0, searchLength); bytes are read from baseOffset + chunkStart.
+    // chunkStart is a logical offset within [0, searchLength); absolute position is baseOffset + chunkStart.
     var chunkStart = searchLength - tailBytes - 8
     if (chunkStart >= 0) {
       val pattern = SWARUtil.compilePattern(elem)
       while (chunkStart >= 0) {
         val word = SWARUtil.getLong(bytes, baseOffset + chunkStart, ByteOrder.BIG_ENDIAN)
         val result = SWARUtil.applyPattern(word, pattern)
-        if (result != 0) return chunkStart + SWARUtil.getLastIndex(result)  // already logical
+        if (result != 0) return baseOffset + chunkStart + SWARUtil.getLastIndex(result)  // absolute
         chunkStart -= 8
       }
     }

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -233,68 +233,32 @@ object ByteString {
       if (n <= 0) this
       else toByteString1.drop(n)
 
-    override def indexOf[B >: Byte](elem: B, from: Int): Int = {
-      if (from >= length) -1
-      else {
-        var i = math.max(from, 0)
-        while (i < length) {
-          if (bytes(i) == elem) return i
-          i += 1
+    override def indexOf[B >: Byte](elem: B, from: Int): Int = elem match {
+      case byte: Byte => indexOf(byte, from)
+      case _ =>
+        if (from >= length) -1
+        else {
+          var i = math.max(from, 0)
+          while (i < length) {
+            if (bytes(i) == elem) return i
+            i += 1
+          }
+          -1
         }
-        -1
-      }
     }
 
     @nowarn
     override def indexOf(elem: Byte, from: Int): Int = {
       val fromIndex = math.max(0, from)
       if (fromIndex >= length) return -1
-      val searchLength = length - fromIndex
-      var offset = fromIndex
-      val byteCount = searchLength & 7
-      if (byteCount > 0) {
-        val index = unrolledFirstIndexOf(fromIndex, byteCount, elem)
-        if (index != -1) return index
-        offset += byteCount
-        if (offset == length) return -1
-      }
-      val longCount = searchLength >>> 3
-      val pattern = if (longCount > 0) SWARUtil.compilePattern(elem) else 0L
-      var i = 0
-      while (i < longCount) {
-        val word = SWARUtil.getLong(bytes, offset, ByteOrder.BIG_ENDIAN)
-        val result = SWARUtil.applyPattern(word, pattern)
-        if (result != 0) return offset + SWARUtil.getIndex(result)
-        offset += java.lang.Long.BYTES
-        i += 1
-      }
-      -1
+      swarFirstIndexOf(bytes, fromIndex, length - fromIndex, elem)
     }
 
     override def indexOf(elem: Byte, from: Int, to: Int): Int = {
       val fromIndex = math.max(0, from)
       val toIndex = math.min(to, length)
       if (fromIndex >= toIndex) return -1
-      val searchLength = toIndex - fromIndex
-      var offset = fromIndex
-      val byteCount = searchLength & 7
-      if (byteCount > 0) {
-        val index = unrolledFirstIndexOf(fromIndex, byteCount, elem)
-        if (index != -1) return index
-        offset += byteCount
-        if (offset == length) return -1
-      }
-      val longCount = searchLength >>> 3
-      val pattern = if (longCount > 0) SWARUtil.compilePattern(elem) else 0L
-      var i = 0
-      while (i < longCount) {
-        val word = SWARUtil.getLong(bytes, offset, ByteOrder.BIG_ENDIAN)
-        val result = SWARUtil.applyPattern(word, pattern)
-        if (result != 0) return offset + SWARUtil.getIndex(result)
-        offset += java.lang.Long.BYTES
-        i += 1
-      }
-      -1
+      swarFirstIndexOf(bytes, fromIndex, toIndex - fromIndex, elem)
     }
 
     override def lastIndexOf[B >: Byte](elem: B, end: Int): Int = {
@@ -317,57 +281,7 @@ object ByteString {
     override def lastIndexOf(elem: Byte, end: Int): Int = {
       val endIdx = math.min(end, length - 1)
       if (endIdx < 0) return -1
-      val searchLength = endIdx + 1
-      // Check the rightmost partial chunk first (bytes not fitting in a full 8-byte block)
-      val tailBytes = searchLength & 7
-      if (tailBytes > 0) {
-        val tailStart = searchLength - tailBytes
-        val index = unrolledLastIndexOf(tailStart, tailBytes, elem)
-        if (index != -1) return index
-        if (tailStart == 0) return -1
-      }
-      // Scan full 8-byte chunks from right to left
-      var chunkStart = searchLength - tailBytes - 8
-      if (chunkStart >= 0) {
-        val pattern = SWARUtil.compilePattern(elem)
-        while (chunkStart >= 0) {
-          val word = SWARUtil.getLong(bytes, chunkStart, ByteOrder.BIG_ENDIAN)
-          val result = SWARUtil.applyPattern(word, pattern)
-          if (result != 0) return chunkStart + SWARUtil.getLastIndex(result)
-          chunkStart -= 8
-        }
-      }
-      -1
-    }
-
-    // Searches byteCount bytes (1-7) starting at fromIndex from highest to lowest index,
-    // returning the rightmost (last) match, or -1 if not found.
-    private def unrolledLastIndexOf(fromIndex: Int, byteCount: Int, value: Byte): Int = {
-      if (byteCount >= 7 && bytes(fromIndex + 6) == value) fromIndex + 6
-      else if (byteCount >= 6 && bytes(fromIndex + 5) == value) fromIndex + 5
-      else if (byteCount >= 5 && bytes(fromIndex + 4) == value) fromIndex + 4
-      else if (byteCount >= 4 && bytes(fromIndex + 3) == value) fromIndex + 3
-      else if (byteCount >= 3 && bytes(fromIndex + 2) == value) fromIndex + 2
-      else if (byteCount >= 2 && bytes(fromIndex + 1) == value) fromIndex + 1
-      else if (bytes(fromIndex) == value) fromIndex
-      else -1
-    }
-
-    private def unrolledFirstIndexOf(fromIndex: Int, byteCount: Int, value: Byte): Int = {
-      if (bytes(fromIndex) == value) fromIndex
-      else if (byteCount == 1) -1
-      else if (bytes(fromIndex + 1) == value) fromIndex + 1
-      else if (byteCount == 2) -1
-      else if (bytes(fromIndex + 2) == value) fromIndex + 2
-      else if (byteCount == 3) -1
-      else if (bytes(fromIndex + 3) == value) fromIndex + 3
-      else if (byteCount == 4) -1
-      else if (bytes(fromIndex + 4) == value) fromIndex + 4
-      else if (byteCount == 5) -1
-      else if (bytes(fromIndex + 5) == value) fromIndex + 5
-      else if (byteCount == 6) -1
-      else if (bytes(fromIndex + 6) == value) fromIndex + 6
-      else -1
+      swarLastIndexOf(bytes, 0, endIdx + 1, elem)
     }
 
     override def slice(from: Int, until: Int): ByteString =
@@ -561,69 +475,34 @@ object ByteString {
         }
     }
 
-    override def indexOf[B >: Byte](elem: B, from: Int): Int = {
-      if (from >= length) -1
-      else {
-        var i = math.max(from, 0)
-        while (i < length) {
-          if (bytes(startIndex + i) == elem) return i
-          i += 1
+    override def indexOf[B >: Byte](elem: B, from: Int): Int = elem match {
+      case byte: Byte => indexOf(byte, from)
+      case _ =>
+        if (from >= length) -1
+        else {
+          var i = math.max(from, 0)
+          while (i < length) {
+            if (bytes(startIndex + i) == elem) return i
+            i += 1
+          }
+          -1
         }
-        -1
-      }
     }
 
     @nowarn
     override def indexOf(elem: Byte, from: Int): Int = {
       val fromIndex = math.max(0, from)
       if (fromIndex >= length) return -1
-      val searchLength = length - fromIndex
-      var offset = fromIndex
-      val byteCount = searchLength & 7
-      if (byteCount > 0) {
-        val index = unrolledFirstIndexOf(fromIndex + startIndex, byteCount, elem)
-        if (index != -1) return index - startIndex
-        offset += byteCount
-        if (offset == length) return -1
-      }
-      val longCount = searchLength >>> 3
-      val pattern = if (longCount > 0) SWARUtil.compilePattern(elem) else 0L
-      var i = 0
-      while (i < longCount) {
-        val word = SWARUtil.getLong(bytes, startIndex + offset, ByteOrder.BIG_ENDIAN)
-        val result = SWARUtil.applyPattern(word, pattern)
-        if (result != 0) return offset + SWARUtil.getIndex(result)
-        offset += java.lang.Long.BYTES
-        i += 1
-      }
-      -1
+      val absResult = swarFirstIndexOf(bytes, fromIndex + startIndex, length - fromIndex, elem)
+      if (absResult == -1) -1 else absResult - startIndex
     }
 
     override def indexOf(elem: Byte, from: Int, to: Int): Int = {
       val fromIndex = math.max(0, from)
       val toIndex = math.min(to, length)
       if (fromIndex >= toIndex) return -1
-      val searchLength = toIndex - fromIndex
-      var offset = fromIndex
-      val byteCount = searchLength & 7
-      if (byteCount > 0) {
-        val index = unrolledFirstIndexOf(fromIndex + startIndex, byteCount, elem)
-        if (index != -1) return index - startIndex
-        offset += byteCount
-        if (offset == length) return -1
-      }
-      val longCount = searchLength >>> 3
-      val pattern = if (longCount > 0) SWARUtil.compilePattern(elem) else 0L
-      var i = 0
-      while (i < longCount) {
-        val word = SWARUtil.getLong(bytes, startIndex + offset, ByteOrder.BIG_ENDIAN)
-        val result = SWARUtil.applyPattern(word, pattern)
-        if (result != 0) return offset + SWARUtil.getIndex(result)
-        offset += java.lang.Long.BYTES
-        i += 1
-      }
-      -1
-
+      val absResult = swarFirstIndexOf(bytes, fromIndex + startIndex, toIndex - fromIndex, elem)
+      if (absResult == -1) -1 else absResult - startIndex
     }
 
     override def lastIndexOf[B >: Byte](elem: B, end: Int): Int = {
@@ -646,59 +525,7 @@ object ByteString {
     override def lastIndexOf(elem: Byte, end: Int): Int = {
       val endIdx = math.min(end, length - 1)
       if (endIdx < 0) return -1
-      val searchLength = endIdx + 1
-      // Check the rightmost partial chunk first (bytes not fitting in a full 8-byte block)
-      val tailBytes = searchLength & 7
-      if (tailBytes > 0) {
-        val tailStart = searchLength - tailBytes
-        val index = unrolledLastIndexOf(startIndex + tailStart, tailBytes, elem)
-        if (index != -1) return index - startIndex
-        if (tailStart == 0) return -1
-      }
-      // Scan full 8-byte chunks from right to left
-      var chunkStart = searchLength - tailBytes - 8
-      if (chunkStart >= 0) {
-        val pattern = SWARUtil.compilePattern(elem)
-        while (chunkStart >= 0) {
-          val word = SWARUtil.getLong(bytes, startIndex + chunkStart, ByteOrder.BIG_ENDIAN)
-          val result = SWARUtil.applyPattern(word, pattern)
-          if (result != 0) return chunkStart + SWARUtil.getLastIndex(result)
-          chunkStart -= 8
-        }
-      }
-      -1
-    }
-
-    // the calling code already adds the startIndex so this method does not need to
-    private def unrolledFirstIndexOf(fromIndex: Int, byteCount: Int, value: Byte): Int = {
-      if (bytes(fromIndex) == value) fromIndex
-      else if (byteCount == 1) -1
-      else if (bytes(fromIndex + 1) == value) fromIndex + 1
-      else if (byteCount == 2) -1
-      else if (bytes(fromIndex + 2) == value) fromIndex + 2
-      else if (byteCount == 3) -1
-      else if (bytes(fromIndex + 3) == value) fromIndex + 3
-      else if (byteCount == 4) -1
-      else if (bytes(fromIndex + 4) == value) fromIndex + 4
-      else if (byteCount == 5) -1
-      else if (bytes(fromIndex + 5) == value) fromIndex + 5
-      else if (byteCount == 6) -1
-      else if (bytes(fromIndex + 6) == value) fromIndex + 6
-      else -1
-    }
-
-    // the calling code already adds the startIndex so this method does not need to.
-    // Searches byteCount bytes (1-7) starting at fromIndex from highest to lowest index,
-    // returning the rightmost (last) match, or -1 if not found.
-    private def unrolledLastIndexOf(fromIndex: Int, byteCount: Int, value: Byte): Int = {
-      if (byteCount >= 7 && bytes(fromIndex + 6) == value) fromIndex + 6
-      else if (byteCount >= 6 && bytes(fromIndex + 5) == value) fromIndex + 5
-      else if (byteCount >= 5 && bytes(fromIndex + 4) == value) fromIndex + 4
-      else if (byteCount >= 4 && bytes(fromIndex + 3) == value) fromIndex + 3
-      else if (byteCount >= 3 && bytes(fromIndex + 2) == value) fromIndex + 2
-      else if (byteCount >= 2 && bytes(fromIndex + 1) == value) fromIndex + 1
-      else if (bytes(fromIndex) == value) fromIndex
-      else -1
+      swarLastIndexOf(bytes, startIndex, endIdx + 1, elem)
     }
 
     override def copyToArray[B >: Byte](dest: Array[B], start: Int, len: Int): Int = {
@@ -956,30 +783,32 @@ object ByteString {
         new ByteStrings(bytestrings(fullDrops).drop1(remainingToDrop) +: bytestrings.drop(fullDrops + 1), length - n)
     }
 
-    override def indexOf[B >: Byte](elem: B, from: Int): Int = {
-      if (from >= length) -1
-      else {
-        val byteStringsSize = bytestrings.size
+    override def indexOf[B >: Byte](elem: B, from: Int): Int = elem match {
+      case byte: Byte => indexOf(byte, from)
+      case _ =>
+        if (from >= length) -1
+        else {
+          val byteStringsSize = bytestrings.size
 
-        @tailrec
-        def find(bsIdx: Int, relativeIndex: Int, bytesPassed: Int): Int = {
-          if (bsIdx >= byteStringsSize) -1
-          else {
-            val bs = bytestrings(bsIdx)
+          @tailrec
+          def find(bsIdx: Int, relativeIndex: Int, bytesPassed: Int): Int = {
+            if (bsIdx >= byteStringsSize) -1
+            else {
+              val bs = bytestrings(bsIdx)
 
-            if (bs.length <= relativeIndex) {
-              find(bsIdx + 1, relativeIndex - bs.length, bytesPassed + bs.length)
-            } else {
-              val subIndexOf = bs.indexOf(elem, relativeIndex)
-              if (subIndexOf < 0) {
+              if (bs.length <= relativeIndex) {
                 find(bsIdx + 1, relativeIndex - bs.length, bytesPassed + bs.length)
-              } else subIndexOf + bytesPassed
+              } else {
+                val subIndexOf = bs.indexOf(elem, relativeIndex)
+                if (subIndexOf < 0) {
+                  find(bsIdx + 1, relativeIndex - bs.length, bytesPassed + bs.length)
+                } else subIndexOf + bytesPassed
+              }
             }
           }
-        }
 
-        find(0, math.max(from, 0), 0)
-      }
+          find(0, math.max(from, 0), 0)
+        }
     }
 
     override def indexOf(elem: Byte, from: Int): Int = {
@@ -1034,33 +863,35 @@ object ByteString {
       }
     }
 
-    override def lastIndexOf[B >: Byte](elem: B, end: Int): Int = {
-      if (end < 0) -1
-      else {
-        val byteStringsLast = bytestrings.size - 1
+    override def lastIndexOf[B >: Byte](elem: B, end: Int): Int = elem match {
+      case byte: Byte => lastIndexOf(byte, end)
+      case _ =>
+        if (end < 0) -1
+        else {
+          val byteStringsLast = bytestrings.size - 1
 
-        @tailrec
-        def find(bsIdx: Int, relativeIndex: Int, len: Int): Int = {
-          if (bsIdx < 0) -1
-          else {
-            val bs = bytestrings(bsIdx)
-            val bsStartIndex = len - bs.length
+          @tailrec
+          def find(bsIdx: Int, relativeIndex: Int, len: Int): Int = {
+            if (bsIdx < 0) -1
+            else {
+              val bs = bytestrings(bsIdx)
+              val bsStartIndex = len - bs.length
 
-            if (relativeIndex < bsStartIndex || bs.isEmpty) {
-              if (bsIdx == 0) -1
-              else find(bsIdx - 1, relativeIndex, bsStartIndex)
-            } else {
-              val subIndexOf = bs.lastIndexOf(elem, relativeIndex - bsStartIndex)
-              if (subIndexOf < 0) {
+              if (relativeIndex < bsStartIndex || bs.isEmpty) {
                 if (bsIdx == 0) -1
                 else find(bsIdx - 1, relativeIndex, bsStartIndex)
-              } else subIndexOf + bsStartIndex
+              } else {
+                val subIndexOf = bs.lastIndexOf(elem, relativeIndex - bsStartIndex)
+                if (subIndexOf < 0) {
+                  if (bsIdx == 0) -1
+                  else find(bsIdx - 1, relativeIndex, bsStartIndex)
+                } else subIndexOf + bsStartIndex
+              }
             }
           }
-        }
 
-        find(byteStringsLast, math.min(end, length - 1), length)
-      }
+          find(byteStringsLast, math.min(end, length - 1), length)
+        }
     }
 
     override def lastIndexOf(elem: Byte, end: Int): Int = {
@@ -1140,6 +971,86 @@ object ByteString {
   private[pekko] sealed trait Companion {
     def SerializationIdentity: Byte
     def readFromInputStream(is: ObjectInputStream): ByteString
+  }
+
+  // Searches byteCount bytes (1–7) in bytes[fromIndex..fromIndex+byteCount) for the first occurrence of value.
+  // Returns the absolute index in bytes, or -1 if not found.
+  private def unrolledFirstIndexOf(bytes: Array[Byte], fromIndex: Int, byteCount: Int, value: Byte): Int = {
+    if (bytes(fromIndex) == value) fromIndex
+    else if (byteCount == 1) -1
+    else if (bytes(fromIndex + 1) == value) fromIndex + 1
+    else if (byteCount == 2) -1
+    else if (bytes(fromIndex + 2) == value) fromIndex + 2
+    else if (byteCount == 3) -1
+    else if (bytes(fromIndex + 3) == value) fromIndex + 3
+    else if (byteCount == 4) -1
+    else if (bytes(fromIndex + 4) == value) fromIndex + 4
+    else if (byteCount == 5) -1
+    else if (bytes(fromIndex + 5) == value) fromIndex + 5
+    else if (byteCount == 6) -1
+    else if (bytes(fromIndex + 6) == value) fromIndex + 6
+    else -1
+  }
+
+  // Searches byteCount bytes (1–7) in bytes[fromIndex..fromIndex+byteCount) for the last occurrence of value.
+  // Returns the absolute index in bytes, or -1 if not found.
+  private def unrolledLastIndexOf(bytes: Array[Byte], fromIndex: Int, byteCount: Int, value: Byte): Int = {
+    if (byteCount >= 7 && bytes(fromIndex + 6) == value) fromIndex + 6
+    else if (byteCount >= 6 && bytes(fromIndex + 5) == value) fromIndex + 5
+    else if (byteCount >= 5 && bytes(fromIndex + 4) == value) fromIndex + 4
+    else if (byteCount >= 4 && bytes(fromIndex + 3) == value) fromIndex + 3
+    else if (byteCount >= 3 && bytes(fromIndex + 2) == value) fromIndex + 2
+    else if (byteCount >= 2 && bytes(fromIndex + 1) == value) fromIndex + 1
+    else if (bytes(fromIndex) == value) fromIndex
+    else -1
+  }
+
+  // SWAR-based search for first occurrence of `elem` in bytes[fromOffset, fromOffset+searchLength).
+  // Returns the absolute index in `bytes`, or -1 if not found.
+  private def swarFirstIndexOf(bytes: Array[Byte], fromOffset: Int, searchLength: Int, elem: Byte): Int = {
+    var offset = fromOffset
+    val byteCount = searchLength & 7
+    if (byteCount > 0) {
+      val index = unrolledFirstIndexOf(bytes, fromOffset, byteCount, elem)
+      if (index != -1) return index
+      offset += byteCount
+    }
+    val longCount = searchLength >>> 3
+    if (longCount > 0) {
+      val pattern = SWARUtil.compilePattern(elem)
+      var i = 0
+      while (i < longCount) {
+        val word = SWARUtil.getLong(bytes, offset, ByteOrder.BIG_ENDIAN)
+        val result = SWARUtil.applyPattern(word, pattern)
+        if (result != 0) return offset + SWARUtil.getIndex(result)
+        offset += java.lang.Long.BYTES
+        i += 1
+      }
+    }
+    -1
+  }
+
+  // SWAR-based search for last occurrence of `elem` in bytes[baseOffset, baseOffset+searchLength).
+  // Returns the logical index (absolute index minus `baseOffset`), or -1 if not found.
+  private def swarLastIndexOf(bytes: Array[Byte], baseOffset: Int, searchLength: Int, elem: Byte): Int = {
+    val tailBytes = searchLength & 7
+    if (tailBytes > 0) {
+      val tailStart = searchLength - tailBytes
+      val index = unrolledLastIndexOf(bytes, baseOffset + tailStart, tailBytes, elem)
+      if (index != -1) return index - baseOffset
+      if (tailStart == 0) return -1
+    }
+    var chunkStart = searchLength - tailBytes - 8
+    if (chunkStart >= 0) {
+      val pattern = SWARUtil.compilePattern(elem)
+      while (chunkStart >= 0) {
+        val word = SWARUtil.getLong(bytes, baseOffset + chunkStart, ByteOrder.BIG_ENDIAN)
+        val result = SWARUtil.applyPattern(word, pattern)
+        if (result != 0) return chunkStart + SWARUtil.getLastIndex(result)
+        chunkStart -= 8
+      }
+    }
+    -1
   }
 }
 

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -235,7 +235,7 @@ object ByteString {
 
     override def indexOf[B >: Byte](elem: B, from: Int): Int = elem match {
       case byte: Byte => indexOf(byte, from)
-      case _ =>
+      case _          =>
         if (from >= length) -1
         else {
           var i = math.max(from, 0)
@@ -477,7 +477,7 @@ object ByteString {
 
     override def indexOf[B >: Byte](elem: B, from: Int): Int = elem match {
       case byte: Byte => indexOf(byte, from)
-      case _ =>
+      case _          =>
         if (from >= length) -1
         else {
           var i = math.max(from, 0)
@@ -788,7 +788,7 @@ object ByteString {
 
     override def indexOf[B >: Byte](elem: B, from: Int): Int = elem match {
       case byte: Byte => indexOf(byte, from)
-      case _ =>
+      case _          =>
         if (from >= length) -1
         else {
           val byteStringsSize = bytestrings.size
@@ -868,7 +868,7 @@ object ByteString {
 
     override def lastIndexOf[B >: Byte](elem: B, end: Int): Int = elem match {
       case byte: Byte => lastIndexOf(byte, end)
-      case _ =>
+      case _          =>
         if (end < 0) -1
         else {
           val byteStringsLast = bytestrings.size - 1
@@ -1045,7 +1045,7 @@ object ByteString {
     if (tailBytes > 0) {
       val tailStart = searchLength - tailBytes
       val index = unrolledLastIndexOf(bytes, baseOffset + tailStart, tailBytes, elem)
-      if (index != -1) return index  // already absolute
+      if (index != -1) return index // already absolute
       if (tailStart == 0) return -1
     }
     // chunkStart is a logical offset within [0, searchLength); absolute position is baseOffset + chunkStart.

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -489,8 +489,9 @@ object ByteString {
         }
     }
 
-    // Converts an absolute index in `bytes` (as returned by `swarFirstIndexOf` or `swarLastIndexOf`)
-    // to a logical index relative to `startIndex`, preserving -1 as the "not found" sentinel.
+    // Converts an absolute index in bytes (as returned by the swarFirstIndexOf or swarLastIndexOf
+    // helpers in the ByteString companion object) to a logical index relative to startIndex,
+    // preserving -1 as the "not found" sentinel.
     private def absToLogical(absIdx: Int): Int = if (absIdx == -1) -1 else absIdx - startIndex
 
     @nowarn
@@ -1007,9 +1008,9 @@ object ByteString {
     else -1
   }
 
-  // SWAR-based search for first occurrence of `elem` in bytes[fromOffset, fromOffset+searchLength).
-  // `fromOffset` is an absolute index into `bytes`; the return value is also an absolute index in
-  // `bytes`, or -1 if not found. Callers are responsible for converting to/from logical indices.
+  // SWAR-based search for first occurrence of elem in bytes[fromOffset, fromOffset+searchLength).
+  // fromOffset is an absolute index into bytes; the return value is also an absolute index in
+  // bytes, or -1 if not found. Callers are responsible for converting to logical indices.
   private def swarFirstIndexOf(bytes: Array[Byte], fromOffset: Int, searchLength: Int, elem: Byte): Int = {
     var offset = fromOffset
     val byteCount = searchLength & 7
@@ -1033,12 +1034,12 @@ object ByteString {
     -1
   }
 
-  // SWAR-based search for last occurrence of `elem` in bytes[baseOffset, baseOffset+searchLength).
-  // `baseOffset` is an absolute index into `bytes`.
-  // Returns the absolute index in `bytes`, or -1 if not found. Callers are responsible for
-  // converting to logical indices (e.g. `absResult - startIndex` for `ByteString1`).
-  // Note: `chunkStart` below is a logical offset (0-based from `baseOffset`), so the absolute
-  // result is computed as `baseOffset + chunkStart + getLastIndex(result)`.
+  // SWAR-based search for last occurrence of elem in bytes[baseOffset, baseOffset+searchLength).
+  // baseOffset is an absolute index into bytes.
+  // Returns the absolute index in bytes, or -1 if not found. Callers are responsible for
+  // converting to logical indices (e.g. absResult - startIndex for ByteString1).
+  // Note: chunkStart below is a logical offset (0-based from baseOffset), so the absolute
+  // result is computed as baseOffset + chunkStart + getLastIndex(result).
   private def swarLastIndexOf(bytes: Array[Byte], baseOffset: Int, searchLength: Int, elem: Byte): Int = {
     val tailBytes = searchLength & 7
     if (tailBytes > 0) {
@@ -1054,7 +1055,7 @@ object ByteString {
       while (chunkStart >= 0) {
         val word = SWARUtil.getLong(bytes, baseOffset + chunkStart, ByteOrder.BIG_ENDIAN)
         val result = SWARUtil.applyPattern(word, pattern)
-        if (result != 0) return baseOffset + chunkStart + SWARUtil.getLastIndex(result)  // absolute
+        if (result != 0) return baseOffset + chunkStart + SWARUtil.getLastIndex(result)
         chunkStart -= 8
       }
     }


### PR DESCRIPTION
`ByteString1C` and `ByteString1` contained near-identical SWAR search loops and unrolled byte-scan helpers duplicated verbatim across both classes. `ByteStrings` similarly had identical `find` inner functions in its generic and `Byte`-typed `indexOf`/`lastIndexOf` overloads.

## New shared helpers in `object ByteString`

- **`unrolledFirstIndexOf(bytes, fromIndex, byteCount, value)`** / **`unrolledLastIndexOf(...)`** — unrolled 1–7 byte scans, previously duplicated in both `ByteString1C` and `ByteString1`
- **`swarFirstIndexOf(bytes, fromOffset, searchLength, elem)`** — SWAR forward-search loop; eliminates duplication between `indexOf(Byte, Int)` and `indexOf(Byte, Int, Int)` in both classes; returns absolute index
- **`swarLastIndexOf(bytes, baseOffset, searchLength, elem)`** — SWAR reverse-search loop; same rationale; returns absolute index (consistent with `swarFirstIndexOf`)

## Per-class changes

- **`ByteString1`** gains a private `absToLogical(absIdx)` helper to eliminate the repeated `if (absResult == -1) -1 else absResult - startIndex` pattern in all four index-search methods
- **`ByteString1C` / `ByteString1` / `ByteStrings`**: `indexOf[B >: Byte]` now pattern-matches on `elem` and dispatches to the Byte-specific SWAR overload for `Byte` inputs — removing the duplicate `find` inner function in `ByteStrings` and improving performance for `Byte` inputs (avoids boxing)
- **`ByteStrings`**: `lastIndexOf[B >: Byte]` follows the same dispatch pattern

All public APIs are unchanged. Net: −80 lines. All helpers are small and static, keeping HotSpot inlining characteristics equivalent to the original inlined code.