### PR TITLE
small optimisation on indexOf

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -234,14 +234,18 @@ object ByteString {
       else toByteString1.drop(n)
 
     override def indexOf[B >: Byte](elem: B, from: Int): Int = {
-      if (from >= length) -1
-      else {
-        var i = math.max(from, 0)
-        while (i < length) {
-          if (bytes(i) == elem) return i
-          i += 1
-        }
-        -1
+      elem match {
+        case byte: Byte => indexOf(byte, from)
+        case _          =>
+          if (from >= length) -1
+          else {
+            var i = math.max(from, 0)
+            while (i < length) {
+              if (bytes(i) == elem) return i
+              i += 1
+            }
+            -1
+          }
       }
     }
 
@@ -562,14 +566,18 @@ object ByteString {
     }
 
     override def indexOf[B >: Byte](elem: B, from: Int): Int = {
-      if (from >= length) -1
-      else {
-        var i = math.max(from, 0)
-        while (i < length) {
-          if (bytes(startIndex + i) == elem) return i
-          i += 1
-        }
-        -1
+      elem match {
+        case byte: Byte => indexOf(byte, from)
+        case _          =>
+          if (from >= length) -1
+          else {
+            var i = math.max(from, 0)
+            while (i < length) {
+              if (bytes(startIndex + i) == elem) return i
+              i += 1
+            }
+            -1
+          }
       }
     }
 


### PR DESCRIPTION
* small change from #2859
* lastIndexOf already works this way
* We have an overload for indexOf that accepts Byte input directly and the compiler will prefer this if you have a Byte that you want to match
* but a number of Seq methods use indexOf under the hood and they will use the Seq API call so it is good to pattern match and forward Byte inputs to the dedicated overload method