### PR TITLE
Remove implicit JUnit4 dependency from LogCapturingExtension

### DIFF
--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtension.scala
@@ -24,7 +24,7 @@ final class LogCapturingExtension extends InvocationInterceptor {
 
   private val capturingAppender = CapturingAppender.get("")
 
-  private val myLogger = LoggerFactory.getLogger(classOf[LogCapturing])
+  private val myLogger = LoggerFactory.getLogger(classOf[LogCapturingExtension])
 
   @throws[Throwable]
   override def interceptTestMethod(invocation: Invocation[Void], invocationContext: ReflectiveInvocationContext[Method],


### PR DESCRIPTION
## Summary

Fixes #2864

`LogCapturingExtension` is a JUnit 5 `InvocationInterceptor`, but it used `classOf[LogCapturing]` to initialize its logger. Since both classes are in the same package (`javadsl`), this resolves to `javadsl.LogCapturing` — which is the JUnit 4 `TestRule` class. This forces pure JUnit 5 users to also include JUnit 4 on their classpath.

## Changes

- Changed `classOf[LogCapturing]` to `classOf[LogCapturingExtension]` in `LogCapturingExtension.scala` line 27
- This removes the implicit JUnit 4 class reference from the JUnit 5 extension

## Testing

- [x] Code formatted with scalafmt
- [ ] Full CI tests pending