### PR TITLE
Remove implicit JUnit4 dependency from LogCapturingExtension (#2864)

### DIFF
--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtension.scala
@@ -21,7 +21,7 @@ final class LogCapturingExtension extends InvocationInterceptor {
 
   private val capturingAppender = CapturingAppender.get("")
 
-  private val myLogger = LoggerFactory.getLogger(classOf[LogCapturing])
+  private val myLogger = LoggerFactory.getLogger(classOf[LogCapturingExtension])
 
   @throws[Throwable]
   override def interceptTestMethod(invocation: Invocation[Void], invocationContext: ReflectiveInvocationContext[Method],


### PR DESCRIPTION
cherry pick be3a411f9167366d52e1ee0ec8cf1bf02783aa3c (#2865)

LogCapturingExtension (a JUnit5 InvocationInterceptor) was using classOf[LogCapturing] to initialize its logger, which resolves to the JUnit4 TestRule class in the same package. Change to use classOf[LogCapturingExtension] instead.