### PR TITLE
ByteString: fix bugs, type safety, and add performance improvements with tests

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -2232,9 +2232,9 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
     }
 
     "ByteString1.apply factory returns canonical empty for non-positive length" in {
-      ByteString1(Array[Byte](1, 2, 3), 0, 0) should be theSameInstanceAs ByteString1.empty
-      ByteString1(Array[Byte](1, 2, 3), 0, -1) should be theSameInstanceAs ByteString1.empty
-      ByteString1(Array[Byte](1, 2, 3), 0, Int.MinValue) should be theSameInstanceAs ByteString1.empty
+      (ByteString1(Array[Byte](1, 2, 3), 0, 0) should be).theSameInstanceAs(ByteString1.empty)
+      (ByteString1(Array[Byte](1, 2, 3), 0, -1) should be).theSameInstanceAs(ByteString1.empty)
+      (ByteString1(Array[Byte](1, 2, 3), 0, Int.MinValue) should be).theSameInstanceAs(ByteString1.empty)
     }
 
     "ByteStringBuilder.sizeHint does not shrink existing capacity" in {

--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -2091,6 +2091,161 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       an[IndexOutOfBoundsException] should be thrownBy bss.readLongBE(-1)
       an[IndexOutOfBoundsException] should be thrownBy bss.readLongLE(-1)
     }
+
+    "have correct takeRight behaviour for boundary values" in {
+      // empty ByteString
+      ByteString.empty.takeRight(-1) should ===(ByteString.empty)
+      ByteString.empty.takeRight(0) should ===(ByteString.empty)
+      ByteString.empty.takeRight(1) should ===(ByteString.empty)
+      // n <= 0
+      ByteString1.fromString("abc").takeRight(-1) should ===(ByteString.empty)
+      ByteString1.fromString("abc").takeRight(0) should ===(ByteString.empty)
+      ByteString1C.fromString("abc").takeRight(-1) should ===(ByteString.empty)
+      ByteString1C.fromString("abc").takeRight(0) should ===(ByteString.empty)
+      val bssTR = ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd"))
+      bssTR.takeRight(-1) should ===(ByteString.empty)
+      bssTR.takeRight(0) should ===(ByteString.empty)
+      // n >= length
+      ByteString1.fromString("abc").takeRight(3) should ===(ByteString("abc"))
+      ByteString1.fromString("abc").takeRight(100) should ===(ByteString("abc"))
+      ByteString1C.fromString("abc").takeRight(3) should ===(ByteString("abc"))
+      ByteString1C.fromString("abc").takeRight(100) should ===(ByteString("abc"))
+      bssTR.takeRight(4) should ===(ByteString("abcd"))
+      bssTR.takeRight(100) should ===(ByteString("abcd"))
+      // n in range
+      ByteString1.fromString("abcde").takeRight(2) should ===(ByteString("de"))
+      ByteString1C.fromString("abcde").takeRight(2) should ===(ByteString("de"))
+      bssTR.takeRight(3) should ===(ByteString("bcd"))
+    }
+
+    "throw IndexOutOfBoundsException when apply is called with an out-of-bounds index" in {
+      val bs1C = ByteString1C(Array[Byte](1, 2, 3))
+      an[IndexOutOfBoundsException] should be thrownBy bs1C(-1)
+      an[IndexOutOfBoundsException] should be thrownBy bs1C(3)
+      val bs1 = ByteString1(Array[Byte](0, 1, 2, 3, 4), 1, 3)
+      an[IndexOutOfBoundsException] should be thrownBy bs1(-1)
+      an[IndexOutOfBoundsException] should be thrownBy bs1(3)
+      val bss = ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd"))
+      an[IndexOutOfBoundsException] should be thrownBy bss(-1)
+      an[IndexOutOfBoundsException] should be thrownBy bss(4)
+      an[IndexOutOfBoundsException] should be thrownBy ByteString.empty(0)
+    }
+
+    "return 0 from copyToArray when start >= destination length" in {
+      val bs1C = ByteString1C(Array[Byte](1, 2, 3))
+      val dest1C = new Array[Byte](3)
+      bs1C.copyToArray(dest1C, 3, 2) should ===(0)
+      bs1C.copyToArray(dest1C, 5, 2) should ===(0)
+      val bs1 = ByteString1(Array[Byte](0, 1, 2, 3, 4), 1, 3)
+      val dest1 = new Array[Byte](3)
+      bs1.copyToArray(dest1, 3, 2) should ===(0)
+      bs1.copyToArray(dest1, 5, 2) should ===(0)
+      val bss = ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd"))
+      val destBss = new Array[Byte](4)
+      bss.copyToArray(destBss, 4, 2) should ===(0)
+      bss.copyToArray(destBss, 6, 2) should ===(0)
+    }
+
+    "correctly handle sizeHint with value smaller than already committed bytes" in {
+      val builder = ByteString.newBuilder
+      builder.putBytes(Array[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+      // sizeHint smaller than already written should not throw or shrink
+      noException should be thrownBy builder.sizeHint(3)
+      noException should be thrownBy builder.sizeHint(0)
+      noException should be thrownBy builder.sizeHint(-1)
+      builder.result().length should ===(10)
+    }
+
+    "correctly handle grouped with size larger than length" in {
+      val bs = ByteString1.fromString("abc")
+      bs.grouped(10).toList should ===(List(ByteString("abc")))
+      bs.grouped(3).toList should ===(List(ByteString("abc")))
+      ByteString.empty.grouped(5).toList should ===(List.empty)
+      val bss = ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd"))
+      bss.grouped(100).toList should ===(List(ByteString("abcd")))
+    }
+
+    "map bytes correctly on each concrete type" in {
+      val inc: Byte => Byte = b => (b + 1).toByte
+      // ByteString1C
+      ByteString1C(Array[Byte](1, 2, 3)).map(inc) should ===(ByteString(Array[Byte](2, 3, 4)))
+      // ByteString1 with offset
+      ByteString1(Array[Byte](0, 1, 2, 3, 4), 1, 3).map(inc) should ===(ByteString(Array[Byte](2, 3, 4)))
+      // ByteStrings
+      val bss = ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd"))
+      bss.map(b => (b + 1).toByte) should ===(ByteString("bcde"))
+      // empty
+      ByteString.empty.map(inc) should ===(ByteString.empty)
+    }
+
+    "foreach visits each byte in order on each concrete type" in {
+      def collect(bs: ByteString): Seq[Byte] = {
+        val buf = scala.collection.mutable.ArrayBuffer.empty[Byte]
+        bs.foreach(buf += _)
+        buf.toSeq
+      }
+      // ByteString1C
+      collect(ByteString1C(Array[Byte](10, 20, 30))) should ===(Seq[Byte](10, 20, 30))
+      // ByteString1 with internal offset
+      collect(ByteString1(Array[Byte](0, 10, 20, 30, 40), 1, 3)) should ===(Seq[Byte](10, 20, 30))
+      // ByteStrings (multi-segment)
+      collect(ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd"))) should ===(
+        Seq[Byte]('a', 'b', 'c', 'd'))
+      // empty
+      collect(ByteString.empty) should ===(Seq.empty[Byte])
+    }
+
+    "slice returns correct result on ByteString1 with all boundary combinations" in {
+      val bs = ByteString1.fromString("abcde")
+      bs.slice(0, 5) should ===(ByteString("abcde"))
+      (bs.slice(0, 5) eq bs) should ===(true) // identity when full range
+      bs.slice(1, 4) should ===(ByteString("bcd"))
+      bs.slice(0, 0) should ===(ByteString.empty)
+      bs.slice(-5, 3) should ===(ByteString("abc"))
+      bs.slice(3, 100) should ===(ByteString("de"))
+      bs.slice(-5, -1) should ===(ByteString.empty)
+      bs.slice(4, 2) should ===(ByteString.empty) // from > until
+      // ByteString1 with internal offset
+      val bs2 = ByteString1(Array[Byte](0, 1, 2, 3, 4, 5, 6), 2, 4) // [2,3,4,5]
+      bs2.slice(1, 3) should ===(ByteString(Array[Byte](3, 4)))
+      bs2.slice(0, 4) should ===(ByteString(Array[Byte](2, 3, 4, 5)))
+      (bs2.slice(0, 4) eq bs2) should ===(true)
+      bs2.slice(-1, 2) should ===(ByteString(Array[Byte](2, 3)))
+    }
+
+    "indexOfSlice handles non-Byte typed Seq safely" in {
+      // Seq[Int] is B >: Byte; should not throw ClassCastException
+      val bs = ByteString("abc")
+      // 'a'.toInt == 97 — value semantics comparison works for Byte == Int through ==
+      val result = bs.indexOfSlice(Seq[Int](97, 98)) // 'a'=97, 'b'=98
+      result should ===(0)
+      bs.indexOfSlice(Seq[Int](99)) should ===(2) // 'c'=99
+      bs.indexOfSlice(Seq[Int](100)) should ===(-1) // 'd'=100 not present
+    }
+
+    "lastIndexOfSlice handles non-Byte typed Seq safely" in {
+      val bs = ByteString("aabb")
+      val result = bs.lastIndexOfSlice(Seq[Int](97, 97)) // 'a'=97
+      result should ===(0)
+      bs.lastIndexOfSlice(Seq[Int](98)) should ===(3) // 'b'=98
+      bs.lastIndexOfSlice(Seq[Int](100)) should ===(-1) // 'd'=100 not present
+    }
+
+    "ByteString1.apply factory returns canonical empty for non-positive length" in {
+      ByteString1(Array[Byte](1, 2, 3), 0, 0) should be theSameInstanceAs ByteString1.empty
+      ByteString1(Array[Byte](1, 2, 3), 0, -1) should be theSameInstanceAs ByteString1.empty
+      ByteString1(Array[Byte](1, 2, 3), 0, Int.MinValue) should be theSameInstanceAs ByteString1.empty
+    }
+
+    "ByteStringBuilder.sizeHint does not shrink existing capacity" in {
+      val builder = ByteString.newBuilder
+      builder.sizeHint(100)
+      builder.putByte(42)
+      // sizeHint smaller than current capacity — should not fail or lose data
+      noException should be thrownBy builder.sizeHint(10)
+      noException should be thrownBy builder.sizeHint(0)
+      builder.result() should ===(ByteString(42.toByte))
+    }
   }
 
   "A ByteStringIterator" must {

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -415,8 +415,7 @@ object ByteString {
 
     /** INTERNAL API: Specialized for internal use, writing multiple ByteString1C into the same ByteBuffer. */
     private[pekko] def writeToBuffer(buffer: ByteBuffer, offset: Int): Int = {
-      val available = length - offset
-      val copyLength = Math.min(buffer.remaining, available)
+      val copyLength = Math.min(buffer.remaining, length - offset)
       if (copyLength > 0) {
         buffer.put(bytes, offset, copyLength)
       }

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -415,7 +415,8 @@ object ByteString {
 
     /** INTERNAL API: Specialized for internal use, writing multiple ByteString1C into the same ByteBuffer. */
     private[pekko] def writeToBuffer(buffer: ByteBuffer, offset: Int): Int = {
-      val copyLength = Math.min(buffer.remaining, offset + length)
+      val available = length - offset
+      val copyLength = Math.min(buffer.remaining, available)
       if (copyLength > 0) {
         buffer.put(bytes, offset, copyLength)
       }
@@ -428,7 +429,7 @@ object ByteString {
     }
 
     override def copyToArray[B >: Byte](dest: Array[B], start: Int, len: Int): Int = {
-      val toCopy = math.min(math.min(len, bytes.length), dest.length - start)
+      val toCopy = math.max(0, math.min(math.min(len, bytes.length), dest.length - start))
       if (toCopy > 0) {
         Array.copy(bytes, 0, dest, start, toCopy)
       }
@@ -438,6 +439,24 @@ object ByteString {
     override def toArrayUnsafe(): Array[Byte] = bytes
 
     override def asInputStream: InputStream = new UnsynchronizedByteArrayInputStream(bytes)
+
+    override def foreach[@specialized U](f: Byte => U): Unit = {
+      var i = 0
+      while (i < bytes.length) {
+        f(bytes(i))
+        i += 1
+      }
+    }
+
+    override def map[A](f: Byte => Byte): ByteString = {
+      val result = new Array[Byte](bytes.length)
+      var i = 0
+      while (i < bytes.length) {
+        result(i) = f(bytes(i))
+        i += 1
+      }
+      ByteString1C(result)
+    }
 
     private[pekko] override def readShortBEUnchecked(offset: Int): Short =
       SWARUtil.getShort(bytes, offset, ByteOrder.BIG_ENDIAN)
@@ -459,8 +478,8 @@ object ByteString {
     def fromString(s: String): ByteString1 = apply(s.getBytes(StandardCharsets.UTF_8))
     def apply(bytes: Array[Byte]): ByteString1 = apply(bytes, 0, bytes.length)
     def apply(bytes: Array[Byte], startIndex: Int, length: Int): ByteString1 =
-      if (length == 0) empty
-      else new ByteString1(bytes, Math.max(0, startIndex), Math.max(0, length))
+      if (length <= 0) empty
+      else new ByteString1(bytes, Math.max(0, startIndex), length)
 
     val SerializationIdentity = 0.toByte
 
@@ -523,8 +542,13 @@ object ByteString {
       if (n >= length) this
       else ByteString1(bytes, startIndex, n)
 
-    override def slice(from: Int, until: Int): ByteString =
-      drop(from).take(until - Math.max(0, from))
+    override def slice(from: Int, until: Int): ByteString = {
+      val lo = math.max(0, from)
+      val hi = math.min(until, length)
+      if (lo >= hi) ByteString.empty
+      else if (lo == 0 && hi == length) this
+      else ByteString1(bytes, startIndex + lo, hi - lo)
+    }
 
     override def copyToBuffer(buffer: ByteBuffer): Int =
       writeToBuffer(buffer)
@@ -767,7 +791,7 @@ object ByteString {
 
     override def copyToArray[B >: Byte](dest: Array[B], start: Int, len: Int): Int = {
       // min of the bytes available to copy, bytes there is room for in dest and the requested number of bytes
-      val toCopy = math.min(math.min(len, length), dest.length - start)
+      val toCopy = math.max(0, math.min(math.min(len, length), dest.length - start))
       if (toCopy > 0) {
         Array.copy(bytes, startIndex, dest, start, toCopy)
       }
@@ -783,6 +807,25 @@ object ByteString {
 
     override def asInputStream: InputStream =
       new UnsynchronizedByteArrayInputStream(bytes, startIndex, length)
+
+    override def foreach[@specialized U](f: Byte => U): Unit = {
+      var i = startIndex
+      val end = startIndex + length
+      while (i < end) {
+        f(bytes(i))
+        i += 1
+      }
+    }
+
+    override def map[A](f: Byte => Byte): ByteString = {
+      val result = new Array[Byte](length)
+      var i = 0
+      while (i < length) {
+        result(i) = f(bytes(startIndex + i))
+        i += 1
+      }
+      ByteString1C(result)
+    }
 
     private[pekko] override def readShortBEUnchecked(offset: Int): Short =
       SWARUtil.getShort(bytes, startIndex + offset, ByteOrder.BIG_ENDIAN)
@@ -1160,7 +1203,7 @@ object ByteString {
       if (bytestrings.size == 1) bytestrings.head.copyToArray(dest, start, len)
       else {
         // min of the bytes available to copy, bytes there is room for in dest and the requested number of bytes
-        val totalToCopy = math.min(math.min(len, length), dest.length - start)
+        val totalToCopy = math.max(0, math.min(math.min(len, length), dest.length - start))
         if (totalToCopy > 0) {
           val bsIterator = bytestrings.iterator
           var copied = 0
@@ -1361,15 +1404,27 @@ sealed abstract class ByteString
     val sliceLength = slice.length
     if (sliceLength == 0) if (from > length) -1 else math.max(from, 0)
     else {
-      val headByte = slice.head.asInstanceOf[Byte]
-      @tailrec def rec(from: Int): Int = {
-        val startPos = indexOf(headByte, from, length - slice.length + 1)
-        if (startPos == -1) -1
-        else if (check(startPos)) startPos
-        else rec(startPos + 1)
+      slice.head match {
+        case headByte: Byte =>
+          @tailrec def rec(from: Int): Int = {
+            val startPos = indexOf(headByte, from, length - sliceLength + 1)
+            if (startPos == -1) -1
+            else if (check(startPos)) startPos
+            else rec(startPos + 1)
+          }
+          if (sliceLength == 1) indexOf(headByte, from)
+          else rec(math.max(0, from))
+        case headElem =>
+          // Non-Byte head: use generic indexOf which handles any B >: Byte via equality
+          @tailrec def rec(pos: Int): Int = {
+            val startPos = indexOf(headElem, pos)
+            if (startPos == -1 || startPos > length - sliceLength) -1
+            else if (check(startPos)) startPos
+            else rec(startPos + 1)
+          }
+          if (sliceLength == 1) indexOf(headElem, math.max(0, from))
+          else rec(math.max(0, from))
       }
-      if (sliceLength == 1) indexOf(headByte, from)
-      else rec(math.max(0, from))
     }
   }
 
@@ -1428,7 +1483,6 @@ sealed abstract class ByteString
     if (sliceLength == 0) if (end < 0) -1 else math.min(end, length)
     else if (sliceLength > length) -1
     else {
-      val tailByte = slice(sliceLength - 1).asInstanceOf[Byte]
       // Check all bytes of the slice except the last one (which was matched by lastIndexOf)
       def check(startPos: Int): Boolean = {
         var i = startPos
@@ -1444,17 +1498,33 @@ sealed abstract class ByteString
       // Cap end to the max valid slice start position to avoid Int overflow when end is very large
       val effectiveEnd = math.min(end, length - sliceLength)
       val maxEndPos = effectiveEnd + sliceLength - 1
-      @tailrec def rec(currEnd: Int): Int = {
-        val endPos = lastIndexOf(tailByte, currEnd)
-        if (endPos < sliceLength - 1) -1
-        else {
-          val startPos = endPos - sliceLength + 1
-          if (check(startPos)) startPos
-          else rec(endPos - 1)
-        }
+      slice(sliceLength - 1) match {
+        case tailByte: Byte =>
+          @tailrec def rec(currEnd: Int): Int = {
+            val endPos = lastIndexOf(tailByte, currEnd)
+            if (endPos < sliceLength - 1) -1
+            else {
+              val startPos = endPos - sliceLength + 1
+              if (check(startPos)) startPos
+              else rec(endPos - 1)
+            }
+          }
+          if (sliceLength == 1) lastIndexOf(tailByte, effectiveEnd)
+          else rec(maxEndPos)
+        case tailElem =>
+          // Non-Byte tail: use generic lastIndexOf which handles any B >: Byte via equality
+          @tailrec def rec(currEnd: Int): Int = {
+            val endPos = lastIndexOf(tailElem, currEnd)
+            if (endPos < sliceLength - 1) -1
+            else {
+              val startPos = endPos - sliceLength + 1
+              if (check(startPos)) startPos
+              else rec(endPos - 1)
+            }
+          }
+          if (sliceLength == 1) lastIndexOf(tailElem, effectiveEnd)
+          else rec(maxEndPos)
       }
-      if (sliceLength == 1) lastIndexOf(tailByte, effectiveEnd)
-      else rec(maxEndPos)
     }
   }
 
@@ -1925,7 +1995,16 @@ sealed abstract class ByteString
     (apply(offset + 6).toLong & 0xFF) << 48 |
     (apply(offset + 7).toLong & 0xFF) << 56
 
-  def map[A](f: Byte => Byte): ByteString = fromSpecific(super.map(f))
+  def map[A](f: Byte => Byte): ByteString = {
+    val b = ByteString.newBuilder
+    b.sizeHint(length)
+    var i = 0
+    while (i < length) {
+      b += f(apply(i))
+      i += 1
+    }
+    b.result()
+  }
 }
 
 object CompactByteString {
@@ -2058,7 +2137,8 @@ final class ByteStringBuilder extends Builder[Byte, ByteString] {
   def length: Int = _length
 
   override def sizeHint(len: Int): Unit = {
-    resizeTemp(len - (_length - _tempLength))
+    val needed = len - (_length - _tempLength)
+    if (needed > _tempCapacity) resizeTemp(needed)
   }
 
   private def clearTemp(): Unit = {

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -1314,7 +1314,8 @@ sealed abstract class ByteString
   override def takeWhile(p: Byte => Boolean): ByteString = iterator.takeWhile(p).toByteString
   override def dropWhile(p: Byte => Boolean): ByteString = iterator.dropWhile(p).toByteString
   override def span(p: Byte => Boolean): (ByteString, ByteString) = {
-    val (a, b) = iterator.span(p); (a.toByteString, b.toByteString)
+    val (a, b) = iterator.span(p)
+    (a.toByteString, b.toByteString)
   }
 
   override def splitAt(n: Int): (ByteString, ByteString) = (take(n), drop(n))

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -479,7 +479,7 @@ object ByteString {
     def apply(bytes: Array[Byte]): ByteString1 = apply(bytes, 0, bytes.length)
     def apply(bytes: Array[Byte], startIndex: Int, length: Int): ByteString1 =
       if (length <= 0) empty
-      else new ByteString1(bytes, Math.max(0, startIndex), length)
+      else new ByteString1(bytes, Math.max(0, startIndex), Math.max(0, length))
 
     val SerializationIdentity = 0.toByte
 


### PR DESCRIPTION
## Summary

This PR fixes several correctness bugs, a type-safety issue, adds performance improvements, and adds targeted test coverage to `ByteString` and `ByteStringBuilder`.

---

## Bug Fixes

### `ByteString1C.writeToBuffer(buffer, offset)` — wrong formula
The formula `Math.min(buffer.remaining, offset + length)` was incorrect: when `offset > 0` it could request more bytes from the backing array than actually exist past the offset, leading to `ArrayIndexOutOfBoundsException`. Fixed to `Math.min(buffer.remaining, length - offset)`.

### `ByteStringBuilder.sizeHint` — `NegativeArraySizeException`
Calling `sizeHint(n)` with `n` smaller than the number of bytes already committed to the internal `VectorBuilder` produced a negative value passed to `new Array[Byte](...)`, throwing `NegativeArraySizeException`. Fixed by guarding the resize with `needed > _tempCapacity` so hints that don't require expansion are silently ignored.

### `copyToArray` returns negative count
All three concrete subclasses (`ByteString1C`, `ByteString1`, `ByteStrings`) computed `dest.length - start` which is negative when `start >= dest.length`, and returned it directly. The Scala collection contract requires a non-negative return. Fixed with `math.max(0, ...)`.

### `ByteString1.apply` factory — negative length bypasses canonical empty
The guard `if (length == 0) empty` did not fire for negative `length` values, so `ByteString1(arr, 0, -5)` silently created a non-canonical empty instance. Fixed to `if (length <= 0) empty`. The defensive `Math.max(0, length)` is retained in the `else` branch for clarity.

---

## Type Safety

### `indexOfSlice[B >: Byte]` and `lastIndexOfSlice[B >: Byte]` — unsafe cast
Both methods used `slice.head.asInstanceOf[Byte]` (and `slice(sliceLength-1).asInstanceOf[Byte]`) which throws `ClassCastException` when `B` is not `Byte` at runtime (e.g., `Seq[Int]`). Replaced with a pattern match: when the element is a `Byte`, the optimised `indexOf(byte, ...)` path is taken; otherwise the generic `indexOf[B](elem, ...)` path is used.

---

## Performance Improvements

### `ByteString1.slice` — single allocation
`drop(from).take(until - max(0, from))` created two intermediate `ByteString1` objects. The new implementation computes the clamped range directly and delegates to `ByteString1(bytes, startIndex + lo, hi - lo)` — a single allocation. It also returns `this` when the full range is requested.

### `foreach` overrides in `ByteString1C` and `ByteString1`
The base-class implementation allocated a `ByteIterator`. The new overrides loop over the backing array directly, eliminating the allocation.

### `ByteString.map` — builder-based instead of intermediate collection
The original `fromSpecific(super.map(f))` built an intermediate `IndexedSeq[Byte]`. The new base-class implementation uses `ByteString.newBuilder` directly. `ByteString1C` and `ByteString1` additionally have direct array-based overrides that avoid per-element `apply` calls.

---

## New Tests

- `takeRight` with zero, negative, and over-length arguments for all three concrete types
- `apply(idx)` with out-of-bounds index throws `IndexOutOfBoundsException` on all concrete types
- `copyToArray(xs, start, len)` with `start >= xs.length` returns `0`
- `sizeHint` with negative/small values does not throw and does not corrupt in-progress data
- `grouped(size > length)` yields exactly one group equal to the full ByteString
- `map` correctness for `ByteString1C`, `ByteString1` (with offset), `ByteStrings`, and empty
- `foreach` visits all bytes in order for `ByteString1C`, `ByteString1` (with offset), `ByteStrings`, and empty
- `slice` boundary conditions on `ByteString1`: empty result for inverted/out-of-range, identity when full range, correct clamping
- `indexOfSlice` / `lastIndexOfSlice` with `Seq[Int]` (non-Byte B) — no `ClassCastException`
- `ByteString1.apply` factory returns the canonical `ByteString1.empty` singleton for negative lengths