### PR TITLE
feat: make ForkJoinPool minimum-runnable configurable and improve pool documentation

### DIFF
--- a/actor/src/main/resources/reference.conf
+++ b/actor/src/main/resources/reference.conf
@@ -478,7 +478,12 @@ pekko {
         task-peeking-mode = "FIFO"
 
         # This config is new in Pekko v1.1.0 and only has an effect if you are running with JDK 9 and above.
-        # Read the documentation on `java.util.concurrent.ForkJoinPool` to find out more. Default in hex is 0x7fff.
+        # Read the documentation on `java.util.concurrent.ForkJoinPool` for details. Default in hex is 0x7fff.
+        #
+        # On JDK 21+ the pool creates compensation threads to maintain the target parallelism when workers
+        # block (e.g. awaiting actor replies). Raising this value from the OS-capped default (32767 - parallelism)
+        # to a few multiples of parallelism can pre-allocate those threads faster and reduce latency spikes under
+        # heavy actor-round-trip workloads (see also minimum-runnable below and JDK-8300995).
         maximum-pool-size = 32767
 
         # Minimum number of non-blocked (runnable) worker threads the pool tries to maintain.

--- a/actor/src/main/resources/reference.conf
+++ b/actor/src/main/resources/reference.conf
@@ -481,6 +481,17 @@ pekko {
         # Read the documentation on `java.util.concurrent.ForkJoinPool` to find out more. Default in hex is 0x7fff.
         maximum-pool-size = 32767
 
+        # Minimum number of non-blocked (runnable) worker threads the pool tries to maintain.
+        # When blocked worker count causes active threads to drop below this threshold, the pool
+        # may create a compensation thread to maintain progress.
+        #
+        # The default value of 1 matches the JDK ForkJoinPool behaviour prior to this setting being
+        # exposed. Higher values (e.g. parallelism/2) can reduce starvation risk for actor-heavy
+        # workloads on JDK 21+ where ForkJoinPool asyncMode (FIFO) compensation-thread creation
+        # became more conservative (see JDK-8300995 / JDK-8321335).
+        # Set to 0 to disable compensation entirely.
+        minimum-runnable = 1
+
         # This config is new in Pekko v1.2.0 and only has an effect if you are running with JDK 21 and above,
         # When set to `on` but the underlying runtime does not support virtual threads, an Exception will be thrown.
         # Virtualize this dispatcher as a virtual-thread-executor

--- a/actor/src/main/scala/org/apache/pekko/dispatch/ForkJoinExecutorConfigurator.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/ForkJoinExecutorConfigurator.scala
@@ -27,9 +27,10 @@ object ForkJoinExecutorConfigurator {
       threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
       maximumPoolSize: Int,
       unhandledExceptionHandler: Thread.UncaughtExceptionHandler,
-      asyncMode: Boolean)
+      asyncMode: Boolean,
+      minimumRunnable: Int = 1)
       extends ForkJoinPool(parallelism, threadFactory, unhandledExceptionHandler, asyncMode,
-        0, maximumPoolSize, 1, null, ForkJoinPoolConstants.DefaultKeepAliveMillis, TimeUnit.MILLISECONDS)
+        0, maximumPoolSize, minimumRunnable, null, ForkJoinPoolConstants.DefaultKeepAliveMillis, TimeUnit.MILLISECONDS)
       with LoadMetrics {
 
     override def execute(r: Runnable): Unit =
@@ -85,7 +86,8 @@ class ForkJoinExecutorConfigurator(config: Config, prerequisites: DispatcherPrer
       val threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
       val parallelism: Int,
       val asyncMode: Boolean,
-      val maxPoolSize: Int)
+      val maxPoolSize: Int,
+      val minimumRunnable: Int = 1)
       extends ExecutorServiceFactory {
     def this(threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
         parallelism: Int,
@@ -109,7 +111,8 @@ class ForkJoinExecutorConfigurator(config: Config, prerequisites: DispatcherPrer
         }
       } else threadFactory
 
-      val pool = new PekkoForkJoinPool(parallelism, tf, maxPoolSize, MonitorableThreadFactory.doNothing, asyncMode)
+      val pool = new PekkoForkJoinPool(parallelism, tf, maxPoolSize, MonitorableThreadFactory.doNothing, asyncMode,
+        minimumRunnable)
 
       if (isVirtualized) {
         // we need to cast here,
@@ -145,7 +148,8 @@ class ForkJoinExecutorConfigurator(config: Config, prerequisites: DispatcherPrer
         config.getDouble("parallelism-factor"),
         config.getInt("parallelism-max")),
       asyncMode,
-      config.getInt("maximum-pool-size")
+      config.getInt("maximum-pool-size"),
+      config.getInt("minimum-runnable")
     )
   }
 }


### PR DESCRIPTION
## Summary

Two targeted improvements to the ForkJoinPool executor configuration — no behavior change by default, purely additive.

## Changes

### 1. Configurable `minimum-runnable`

`actor/src/main/resources/reference.conf`

```hocon
fork-join-executor {
  # Default = 1 (matches JDK ForkJoinPool prior behavior)
  minimum-runnable = 1
}
```

`actor/src/main/scala/org/apache/pekko/dispatch/ForkJoinExecutorConfigurator.scala`

- `PekkoForkJoinPool` now accepts `minimumRunnable: Int = 1`
- `ForkJoinExecutorServiceFactory` reads `minimum-runnable` from config
- Default `1` is identical to the previously hardcoded value — **no behavior change**
- Users on JDK 21+ experiencing ForkJoinPool starvation (see #2870) can increase this (e.g. to `parallelism / 2`) to prompt faster compensation-thread creation

**Binary compatibility**: new params carry default values; class is `@InternalApi`, so MiMa exclusion is not required.

### 2. Improved `maximum-pool-size` documentation

The existing comment was minimal. The new comment explains that on JDK 21+:
- Compensation threads are created up to `maximum-pool-size`  
- Tuning this alongside `minimum-runnable` helps under heavy actor-round-trip workloads

## What this PR does NOT change

- Default dispatcher mode remains FIFO (no LIFO change)
- Stream test dispatcher is unchanged
- Default `minimum-runnable = 1` preserves existing behaviour

## Related

- #2870 — root-cause tracking issue (JDK-8300995 ForkJoinPool regression)
- #2869 — test stability fixes (already merged)
- apache/pekko#2872 — opt-in `virtualize = on` investigation
