### PR TITLE
chore(stream): remove internal FanOut Unzip

### DIFF
--- a/stream/src/main/mima-filters/2.0.x.backwards.excludes/remove-internal-unzip.excludes
+++ b/stream/src/main/mima-filters/2.0.x.backwards.excludes/remove-internal-unzip.excludes
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Remove internal legacy Unzip implementation
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.stream.impl.Unzip")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.stream.impl.Unzip$")

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/FanOut.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/FanOut.scala
@@ -313,37 +313,3 @@ import org.reactivestreams.Subscription
 
   def receive = primaryInputs.subreceive.orElse[Any, Unit](outputBunch.subreceive)
 }
-
-/**
- * INTERNAL API
- */
-@InternalApi private[pekko] object Unzip {
-  def props(attributes: Attributes): Props =
-    Props(new Unzip(attributes)).withDeploy(Deploy.local)
-}
-
-/**
- * INTERNAL API
- */
-@InternalApi private[pekko] class Unzip(attributes: Attributes) extends FanOut(attributes, outputCount = 2) {
-  outputBunch.markAllOutputs()
-
-  initialPhase(
-    1,
-    TransferPhase(primaryInputs.NeedsInput && outputBunch.AllOfMarkedOutputs) { () =>
-      primaryInputs.dequeueInputElement() match {
-        case (a, b) =>
-          outputBunch.enqueue(0, a)
-          outputBunch.enqueue(1, b)
-
-        case t: pekko.japi.Pair[_, _] =>
-          outputBunch.enqueue(0, t.first)
-          outputBunch.enqueue(1, t.second)
-
-        case t =>
-          throw new IllegalArgumentException(
-            s"Unable to unzip elements of type ${t.getClass.getName}, " +
-            s"can only handle Tuple2 and org.apache.pekko.japi.Pair!")
-      }
-    })
-}


### PR DESCRIPTION
## Summary
This is the first small slice for #2860.

It removes the dead internal `org.apache.pekko.stream.impl.Unzip` implementation from `FanOut.scala` and adds the matching `2.0.x` MiMa exclusions for the deleted binary-visible symbols.

The public Scala/Java DSL `Unzip` is already GraphStage-based, so this PR only drops the stale internal actor-backed implementation. This cleanup is part of Apache Pekko, which is now Apache licensed.

## Motivation
- make #2860 progress in the smallest safe step
- remove verified dead internal legacy code before larger runtime migrations
- keep the cleanup independently reviewable and independently releasable

## Modification
- delete the internal `impl.Unzip` object/class from `stream/src/main/scala/org/apache/pekko/stream/impl/FanOut.scala`
- add `stream/src/main/mima-filters/2.0.x.backwards.excludes/remove-internal-unzip.excludes`

## Result
- the dead internal Unzip path is removed
- public `Unzip` behavior remains unchanged
- this slice stands on its own as a tiny cleanup PR before the larger fanout/TLS work

## Validation
- `sbt scalafmtAll`
- `sbt "stream/test:compile"`
- `sbt "stream/mimaReportBinaryIssues"`
- `sbt "stream-tests/testOnly org.apache.pekko.stream.scaladsl.GraphUnzipSpec"`

## Upstream / references
- Issue: https://github.com/apache/pekko/issues/2860
