### PR TITLE
Fix early-exit bound in indexOf(elem, from, to)

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -1145,21 +1145,21 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       // Early-exit optimization: toIndex < length and searchLength < 8 (tail-only, longCount == 0)
       // ByteString1C (compact): length=26, search range [0,5) has searchLength=5 < 8
       val bsCompact = ByteString1.fromString("abcdefghijklmnopqrstuvwxyz").compact
-      bsCompact.indexOf('a'.toByte, 0, 5) should ===(0)  // found within range
-      bsCompact.indexOf('e'.toByte, 0, 5) should ===(4)  // found at last position in range
+      bsCompact.indexOf('a'.toByte, 0, 5) should ===(0) // found within range
+      bsCompact.indexOf('e'.toByte, 0, 5) should ===(4) // found at last position in range
       bsCompact.indexOf('f'.toByte, 0, 5) should ===(-1) // at toIndex, not in [0,5)
       bsCompact.indexOf('z'.toByte, 0, 5) should ===(-1) // beyond toIndex, not in [0,5)
-      bsCompact.indexOf('c'.toByte, 2, 5) should ===(2)  // found, from in middle of tail
+      bsCompact.indexOf('c'.toByte, 2, 5) should ===(2) // found, from in middle of tail
       bsCompact.indexOf('a'.toByte, 2, 5) should ===(-1) // before fromIndex, not in [2,5)
 
       // ByteString1 with startIndex > 0: length=26, search range [0,5) has searchLength=5 < 8
       val arrayLong = ("xyz" + "abcdefghijklmnopqrstuvwxyz").getBytes("UTF-8")
       val bs1 = ByteString1(arrayLong, 3, 26)
-      bs1.indexOf('a'.toByte, 0, 5) should ===(0)  // found within range
-      bs1.indexOf('e'.toByte, 0, 5) should ===(4)  // found at last position in range
+      bs1.indexOf('a'.toByte, 0, 5) should ===(0) // found within range
+      bs1.indexOf('e'.toByte, 0, 5) should ===(4) // found at last position in range
       bs1.indexOf('f'.toByte, 0, 5) should ===(-1) // at toIndex, not in [0,5)
       bs1.indexOf('z'.toByte, 0, 5) should ===(-1) // beyond toIndex, not in [0,5)
-      bs1.indexOf('c'.toByte, 2, 5) should ===(2)  // found, from in middle of tail
+      bs1.indexOf('c'.toByte, 2, 5) should ===(2) // found, from in middle of tail
       bs1.indexOf('a'.toByte, 2, 5) should ===(-1) // before fromIndex, not in [2,5)
     }
     "copyToArray" in {

--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -1141,6 +1141,26 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       byteStringLong.indexOf('z', 2, 26) should ===(25)
       byteStringLong.indexOf('z', 2, 24) should ===(-1)
       byteStringLong.indexOf('a', 2, 24) should ===(-1)
+
+      // Early-exit optimization: toIndex < length and searchLength < 8 (tail-only, longCount == 0)
+      // ByteString1C (compact): length=26, search range [0,5) has searchLength=5 < 8
+      val bsCompact = ByteString1.fromString("abcdefghijklmnopqrstuvwxyz").compact
+      bsCompact.indexOf('a'.toByte, 0, 5) should ===(0)  // found within range
+      bsCompact.indexOf('e'.toByte, 0, 5) should ===(4)  // found at last position in range
+      bsCompact.indexOf('f'.toByte, 0, 5) should ===(-1) // at toIndex, not in [0,5)
+      bsCompact.indexOf('z'.toByte, 0, 5) should ===(-1) // beyond toIndex, not in [0,5)
+      bsCompact.indexOf('c'.toByte, 2, 5) should ===(2)  // found, from in middle of tail
+      bsCompact.indexOf('a'.toByte, 2, 5) should ===(-1) // before fromIndex, not in [2,5)
+
+      // ByteString1 with startIndex > 0: length=26, search range [0,5) has searchLength=5 < 8
+      val arrayLong = ("xyz" + "abcdefghijklmnopqrstuvwxyz").getBytes("UTF-8")
+      val bs1 = ByteString1(arrayLong, 3, 26)
+      bs1.indexOf('a'.toByte, 0, 5) should ===(0)  // found within range
+      bs1.indexOf('e'.toByte, 0, 5) should ===(4)  // found at last position in range
+      bs1.indexOf('f'.toByte, 0, 5) should ===(-1) // at toIndex, not in [0,5)
+      bs1.indexOf('z'.toByte, 0, 5) should ===(-1) // beyond toIndex, not in [0,5)
+      bs1.indexOf('c'.toByte, 2, 5) should ===(2)  // found, from in middle of tail
+      bs1.indexOf('a'.toByte, 2, 5) should ===(-1) // before fromIndex, not in [2,5)
     }
     "copyToArray" in {
       val byteString = ByteString(1, 2) ++ ByteString(3) ++ ByteString(4)

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -286,7 +286,7 @@ object ByteString {
         val index = unrolledFirstIndexOf(fromIndex, byteCount, elem)
         if (index != -1) return index
         offset += byteCount
-        if (offset == length) return -1
+        if (offset >= toIndex) return -1
       }
       val longCount = searchLength >>> 3
       val pattern = if (longCount > 0) SWARUtil.compilePattern(elem) else 0L
@@ -669,7 +669,7 @@ object ByteString {
         val index = unrolledFirstIndexOf(fromIndex + startIndex, byteCount, elem)
         if (index != -1) return index - startIndex
         offset += byteCount
-        if (offset == length) return -1
+        if (offset >= toIndex) return -1
       }
       val longCount = searchLength >>> 3
       val pattern = if (longCount > 0) SWARUtil.compilePattern(elem) else 0L


### PR DESCRIPTION
After scanning the tail bytes (remainder < 8), `ByteString1C` and `ByteString1` both checked `offset == length` instead of `offset >= toIndex` to decide whether to skip the SWAR loop. When `toIndex < length` and the entire search range fits in the tail bytes, the SWAR loop was entered unnecessarily (with `longCount == 0`), missing the early exit.

Not a correctness bug — `longCount` is 0 so the loop body never executes — but a missed optimization.

## Changes

- **`ByteString1C.indexOf(Byte, from, to)`** (~line 289): `offset == length` → `offset >= toIndex`
- **`ByteString1.indexOf(Byte, from, to)`** (~line 672): same fix

## Tests

Added cases to `"indexOf from/to"` in `ByteStringSpec` targeting the exact path: `ByteString` with `length > 8`, search range with `toIndex < length` and `searchLength < 8` (all in tail bytes, `longCount == 0`). Covers both `ByteString1C` (compact) and `ByteString1` (with `startIndex` offset).

```scala
// length=26, search range [0,5): searchLength=5 < 8, toIndex=5 < length=26
val bs = ByteString1.fromString("abcdefghijklmnopqrstuvwxyz").compact
bs.indexOf('e'.toByte, 0, 5)  // 4   — last in-range hit
bs.indexOf('f'.toByte, 0, 5)  // -1  — exactly at toIndex, out of range
bs.indexOf('z'.toByte, 0, 5)  // -1  — well beyond toIndex
```