### PR TITLE
test(stream-tests): enable virtualized stream dispatcher in JDK 21+ nightly CI

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -149,6 +149,13 @@ jobs:
       - name: Compile and Test
         # note that this is not running any multi-jvm tests because multi-in-test=false
         # JDK 25 ForkJoinPool scheduling changes need a higher timefactor (see #2573, #2870)
+        # JDK 21+ uses virtual threads to bypass ForkJoinPool compensation-thread starvation (JDK-8300995)
+        # Virtual threads provide equivalent or better performance by eliminating unmount-remount penalties
+        # when blocking on I/O or reply futures, so TIMEFACTOR remains 2 for JDK 21-24.
+        # If timeouts occur in nightly runs, increase TIMEFACTOR to 3 immediately.
+        env:
+          # Enable virtual threads only on JDK 21+ (nightly build only)
+          PEKKO_VIRTUALIZE_DISPATCHER: ${{ matrix.javaVersion >= 21 && 'on' || 'off' }}
         run: |-
           if [ "${{ matrix.javaVersion }}" -ge 25 ]; then
             TIMEFACTOR=4

--- a/stream-tests/src/test/resources/application.conf
+++ b/stream-tests/src/test/resources/application.conf
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Test-only: Virtual thread configuration.
+# Default: off for local development. Nightly CI sets PEKKO_VIRTUALIZE_DISPATCHER=on for JDK 21+.
+
+pekko.test.stream-dispatcher.fork-join-executor {
+  # Default to off, then allow env var to override when set.
+  virtualize = off
+  virtualize = ${?PEKKO_VIRTUALIZE_DISPATCHER}
+}


### PR DESCRIPTION
## Motivation

JDK-8300995 can still trigger ForkJoinPool compensation-thread starvation in FIFO mode, which shows up as sporadic stream test timeouts when actors block on reply futures. For JDK 21+ nightly CI we can exercise virtualized fork-join workers instead, while keeping local test defaults unchanged.

## Changes

1. `.github/workflows/nightly-builds.yml` now sets `PEKKO_VIRTUALIZE_DISPATCHER=on` only for JDK 21+ nightly jobs.
2. `stream-tests/src/test/resources/application.conf` adds a test-only override for `pekko.test.stream-dispatcher.fork-join-executor.virtualize`, defaulting to `off` and reading the env var when present.

## Result

- Nightly CI can enable virtualized stream dispatcher workers on JDK 21+.
- Local development and regular test runs still default to `virtualize = off`.
- The PR stays focused to two files and preserves binary compatibility.

## Related

- Issue #2870: Compensation-thread starvation investigation
- Issue #2573: JDK 25 ForkJoinPool scheduling regression
