### PR TITLE
Scale MapAsyncPartitionedSpec patience with test timefactor

### DIFF
--- a/cluster-sharding-typed/src/test/scala/org/apache/pekko/cluster/sharding/typed/delivery/ReliableDeliveryShardingSpec.scala
+++ b/cluster-sharding-typed/src/test/scala/org/apache/pekko/cluster/sharding/typed/delivery/ReliableDeliveryShardingSpec.scala
@@ -19,6 +19,7 @@ import scala.concurrent.duration._
 
 import org.apache.pekko
 import pekko.Done
+import pekko.actor.testkit.typed.scaladsl.FishingOutcomes
 import pekko.actor.testkit.typed.scaladsl.LogCapturing
 import pekko.actor.testkit.typed.scaladsl.LoggingTestKit
 import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
@@ -306,7 +307,19 @@ class ReliableDeliveryShardingSpec
 
       // when new demand the buffered messages will be be sent
       seq5.producerController ! ProducerControllerImpl.Request(confirmedSeqNr = 5L, requestUpToSeqNr = 10, true, false)
-      val seq6 = shardingProbe.receiveMessage().message
+      val seq6 = shardingProbe
+        .fishForMessage(testKit.testKitSettings.dilated(3.seconds), "waiting for buffered msg-6 after renewed demand") {
+          case ShardingEnvelope("entity-1", SequencedMessage(_, _, TestConsumer.Job("msg-6"), _, _)) =>
+            FishingOutcomes.complete
+          case ShardingEnvelope("entity-1", SequencedMessage(_, _, TestConsumer.Job(_), _, _)) =>
+            // A redelivery can race with the renewed demand, so tolerate buffered msg-6 arriving
+            // after duplicate earlier messages.
+            FishingOutcomes.continueAndIgnore
+          case other =>
+            FishingOutcomes.fail(s"Unexpected message while waiting for buffered msg-6: [$other]")
+        }
+        .last
+        .message
       seq6.message should ===(TestConsumer.Job("msg-6"))
 
       val next9 = producerProbe.receiveMessage()

--- a/stream-typed-tests/src/test/scala/org/apache/pekko/stream/MapAsyncPartitionedSpec.scala
+++ b/stream-typed-tests/src/test/scala/org/apache/pekko/stream/MapAsyncPartitionedSpec.scala
@@ -44,6 +44,7 @@ import pekko.stream.scaladsl.{
   Zip
 }
 import pekko.stream.testkit.scaladsl.TestSink
+import pekko.testkit.TestKitExtension
 
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
@@ -107,17 +108,21 @@ class MapAsyncPartitionedSpec
 
   import MapAsyncPartitionedSpec.TestData._
 
-  // These suites materialize many short-lived streams. On busy CI nodes,
-  // JDK 25 makes the 1000-sample property checks noticeably more expensive (#2573).
-  override implicit def patienceConfig: PatienceConfig = PatienceConfig(
-    timeout = 60.seconds,
-    interval = 100.millis)
-
   private val heavyPropertyChecks = minSuccessful(100)
 
   private implicit val system: ActorSystem[_] = ActorSystem(Behaviors.empty, "test-system")
   private val executor: ExecutorService = Executors.newCachedThreadPool()
   private implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(executor)
+
+  // These suites materialize many short-lived streams. On busy CI nodes,
+  // JDK 25 makes the property checks noticeably more expensive, so bind
+  // ScalaFutures patience to the test timefactor used by CI.
+  private val testTimeFactor = TestKitExtension(system.classicSystem).TestTimeFactor
+  private def dilated(duration: FiniteDuration): FiniteDuration =
+    FiniteDuration((duration.toNanos * testTimeFactor + 0.5).toLong, java.util.concurrent.TimeUnit.NANOSECONDS)
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(
+    timeout = dilated(60.seconds),
+    interval = dilated(100.millis))
 
   override protected def afterAll(): Unit = {
     system.terminate()


### PR DESCRIPTION
## Summary
- scale `MapAsyncPartitionedSpec` ScalaFutures patience using the configured classic test timefactor
- keep the typed-stream property suite aligned with nightly JDK 25 timeout dilation
- remove the fixed 60 second patience assumption that can time out on slower CI runners

## Testing
- `sbt scalafmtAll`
- `sbt -Dpekko.test.timefactor=4 -Dpekko.actor.testkit.typed.timefactor=4 'stream-typed-tests/testOnly org.apache.pekko.stream.MapAsyncPartitionedSpec'