### PR TITLE
Scale stream TCK shutdown timeout for JDK 25 nightly

### DIFF
--- a/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/ActorSystemLifecycle.scala
+++ b/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/ActorSystemLifecycle.scala
@@ -40,7 +40,7 @@ trait ActorSystemLifecycle {
 
   def additionalConfig: Config = ConfigFactory.empty()
 
-  def shutdownTimeout: FiniteDuration = 10.seconds
+  def shutdownTimeout: FiniteDuration = Timeouts.actorSystemShutdownTimeoutMillis.millis
 
   @BeforeClass
   def createActorSystem(): Unit = {

--- a/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/Timeouts.scala
+++ b/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/Timeouts.scala
@@ -18,7 +18,7 @@ package org.apache.pekko.stream.tck
  */
 object Timeouts {
 
-  // Scale timeouts by pekko.test.timefactor (set to 3 on JDK 25 nightly builds).
+  // Scale TCK timeouts by pekko.test.timefactor.
   private val timeFactor: Double =
     sys.props.get("pekko.test.timefactor").map(_.toDouble).getOrElse(1.0)
 
@@ -27,5 +27,7 @@ object Timeouts {
   def defaultTimeoutMillis: Int = (800 * timeFactor).toInt
 
   def defaultNoSignalsTimeoutMillis: Int = (200 * timeFactor).toInt
+
+  def actorSystemShutdownTimeoutMillis: Int = math.ceil(10000 * timeFactor).toInt
 
 }


### PR DESCRIPTION
## Summary
- scale stream TCK actor-system shutdown timeout with pekko.test.timefactor
- keep TCK cleanup timeouts aligned with the rest of the JDK 25 nightly timing configuration
- reduce FlattenTest and GroupByTest shutdown aborts seen in JDK 25 nightly runs

## Testing
- sbt -Dsbt.server=false -Dsbt.supershell=false -Dpekko.test.timefactor=4 -Dpekko.actor.testkit.typed.timefactor=4 scalafmtAll 'stream-tests-tck/test'

## Context
This PR is intentionally limited to the verified stream-tests-tck shutdown-timeout issue. Other JDK 25 nightly failures remain under separate investigation.
