### PR TITLE
fix: stabilise JDK 21+ / JDK 25 nightly test runs

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -148,19 +148,17 @@ jobs:
 
       - name: Compile and Test
         # note that this is not running any multi-jvm tests because multi-in-test=false
-        # JDK 25 ForkJoinPool scheduling changes need a higher timefactor (see #2573, #2870)
-        # JDK 21+ uses virtual threads to bypass ForkJoinPool compensation-thread starvation (JDK-8300995)
-        # Virtual threads provide equivalent or better performance by eliminating unmount-remount penalties
-        # when blocking on I/O or reply futures, so TIMEFACTOR remains 2 for JDK 21-24.
-        # If timeouts occur in nightly runs, increase TIMEFACTOR to 3 immediately.
-        env:
-          # Enable virtual threads only on JDK 21+ (nightly build only)
-          PEKKO_VIRTUALIZE_DISPATCHER: ${{ matrix.javaVersion >= 21 && 'on' || 'off' }}
+        # JDK 21+ ForkJoinPool scheduling changes need a higher timefactor and a larger
+        # minimum-runnable to avoid compensation-thread starvation (see #2573, #2870).
         run: |-
+          EXTRA_JVM_OPTS=""
           if [ "${{ matrix.javaVersion }}" -ge 25 ]; then
             TIMEFACTOR=4
           else
             TIMEFACTOR=2
+          fi
+          if [ "${{ matrix.javaVersion }}" -ge 21 ]; then
+            EXTRA_JVM_OPTS="-Dpekko.actor.default-dispatcher.fork-join-executor.minimum-runnable=4 -Dpekko.remote.default-remote-dispatcher.fork-join-executor.minimum-runnable=4"
           fi
           sbt \
             -Dpekko.cluster.assert=on \
@@ -170,6 +168,7 @@ jobs:
             -Dpekko.test.tags.exclude=gh-exclude,timing \
             -Dpekko.test.multi-in-test=false \
             -Dio.netty.leakDetection.level=PARANOID \
+            $EXTRA_JVM_OPTS \
             clean "++ ${{ matrix.scalaVersion }} test" checkTestsHaveRun
 
       - name: Docs

--- a/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedStashOverflowSpec.scala
+++ b/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedStashOverflowSpec.scala
@@ -98,7 +98,7 @@ class EventSourcedStashOverflowSpec
       SteppingInmemJournal.step(journal)
 
       // exactly how many is racy but at least the first stash buffer full should complete
-      probe.receiveMessages(stashCapacity)
+      probe.receiveMessages(stashCapacity, 30.seconds)
     }
 
   }

--- a/persistence/src/test/scala/org/apache/pekko/persistence/journal/SteppingInmemJournal.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/journal/SteppingInmemJournal.scala
@@ -38,7 +38,7 @@ object SteppingInmemJournal {
    * Allow the journal to do one operation, will block until that completes
    */
   def step(journal: ActorRef)(implicit system: ActorSystem): Unit = {
-    implicit val timeout: Timeout = 3.seconds.dilated
+    implicit val timeout: Timeout = 10.seconds.dilated
     Await.result(journal ? SteppingInmemJournal.Token, timeout.duration)
   }
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/TlsSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/TlsSpec.scala
@@ -440,11 +440,12 @@ class TlsSpec extends StreamSpec(TlsSpec.configOverrides) with WithLogCapturing 
               .collect { case SessionBytes(_, b) => b }
               .scan(ByteString.empty)(_ ++ _)
               .filter(_.nonEmpty)
-              .via(new Timeout(15.seconds))
+              .via(new Timeout(15.seconds.dilated))
               .dropWhile(_.size < scenario.output.size)
               .runWith(Sink.headOption)
 
-          Await.result(output, 17.seconds).getOrElse(ByteString.empty).utf8String should be(scenario.output.utf8String)
+          Await.result(output, 17.seconds.dilated).getOrElse(ByteString.empty).utf8String should be(
+            scenario.output.utf8String)
 
           commPattern.cleanup()
         }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapAsyncPartitionedSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapAsyncPartitionedSpec.scala
@@ -30,17 +30,26 @@ import pekko.stream.Supervision
 import pekko.stream.testkit._
 import pekko.stream.testkit.scaladsl.TestSink
 import pekko.stream.testkit.scaladsl.TestSource
+import pekko.testkit.TestDuration
 import pekko.testkit.TestLatch
 import pekko.testkit.TestProbe
 import pekko.testkit.WithLogCapturing
 
 import org.scalatest.compatible.Assertion
+import org.scalatest.time.Millis
+import org.scalatest.time.Span
 
 // Tests ported from akka/akka-core#31582 and akka/akka-core#31882,
 // adapted for Pekko's mapAsyncPartitioned API (no perPartition parameter).
 // Pekko's implementation always processes at most one element per partition at a time.
 class FlowMapAsyncPartitionedSpec extends StreamSpec with WithLogCapturing {
   import Utils.TE
+
+  // The default ScalaFutures patience of 6 seconds is too tight for the supervised-resume
+  // and bulk-throughput cases in this suite under JDK 25 nightly contention. Scale by the
+  // configured pekko.test.timefactor so CI dilation is honoured.
+  override implicit def patienceConfig: PatienceConfig =
+    PatienceConfig(timeout = 30.seconds.dilated, interval = Span(15, Millis))
 
   "A Flow with mapAsyncPartitioned" must {
     "produce future elements" in {


### PR DESCRIPTION
## Summary

Targets the recurring JDK 21+ / JDK 25 nightly flakes observed in the latest [nightly run 24810320571](https://github.com/apache/pekko/actions/runs/24810320571/). Two complementary moves: (1) bump `fork-join-executor.minimum-runnable` for the JDK 21+ test JVMs to fight the JDK-8300995 / JDK-8321335 compensation regression, and (2) plug four hardcoded test timeouts that ignore `pekko.test.timefactor`.

## Why `minimum-runnable`, not LIFO

LIFO `task-peeking-mode` improves cache locality but causes head-of-line blocking and scheduling-fairness regressions across mailboxes — a poor default for actor workloads. Raising `minimum-runnable` keeps FIFO semantics and only changes how eagerly the pool spawns compensation threads when workers block, which is exactly the behaviour change needed to counter the JDK 21+ regression. The override is applied **only** in the workflow; production defaults stay at `1`.

## Changes

| File | Change | Why |
|------|--------|-----|
| `.github/workflows/nightly-builds.yml` | When `javaVersion >= 21`, append `-Dpekko.actor.default-dispatcher.fork-join-executor.minimum-runnable=4` and same for `pekko.remote.default-remote-dispatcher` | Eager compensation-thread creation under JDK 21+ FJP regression; targets artery / remoting flakes |
| `stream-tests/.../TlsSpec.scala` | Add `.dilated` to the `15.seconds` and `17.seconds` timeouts in the `ServerInitiatesViaTcp / CancellingRHSIgnoresBoth` scenario | Hardcoded timeouts ignored `timefactor` — failed at exactly 17s on JDK 25 |
| `persistence-typed-tests/.../EventSourcedStashOverflowSpec.scala` | Pass an explicit `30.seconds` budget to `probe.receiveMessages(stashCapacity)` | Default 12s on JDK 25 not enough to drain 20 K messages on slow runners |
| `persistence/.../journal/SteppingInmemJournal.scala` | Bump `step()` ask timeout from `3.seconds.dilated` to `10.seconds.dilated` | `PersistentActorRecoveryTimeoutSpec` failed at 6s (3s × timefactor=2) on JDK 17 |

## Out of scope (separate follow-ups)

- `AsyncDnsResolverIntegrationSpec` four DNS-test failures on JDK 25 / Scala 2.13 trace to Docker BIND returning `SERVER_FAILURE` — infrastructure issue, not test logic. Tracked separately.
- Auto-scaling `minimum-runnable` based on `Runtime.version().feature() >= 21` in `ForkJoinExecutorConfigurator` is a follow-up; this PR keeps production defaults unchanged.
- Deeper artery profiling (40s timeouts on `must be able to send messages concurrently preserving order`) tracked under #2573.

## Test plan

- [ ] Re-run nightly build manually after merge
- [ ] Confirm `TlsSpec` ServerInitiatesViaTcp scenario passes on JDK 25
- [ ] Confirm `EventSourcedStashOverflowSpec` passes on JDK 25
- [ ] Confirm `PersistentActorRecoveryTimeoutSpec` passes on JDK 17 / Scala 3
- [ ] Confirm artery `must be able to send messages concurrently preserving order` no longer hits 40s timeout on JDK 21+

## Related

- #2573 — JDK 25 nightly flakiness tracker
- #2870 — JDK-8300995 ForkJoinPool regression root-cause issue
- #2871 — `minimum-runnable` configurability landed (default unchanged); this PR consumes it for CI