### PR TITLE
fix(test): pin minimum-runnable=-1 in ForkJoinExecutorConfiguratorSpec auto fixtures

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/dispatch/ForkJoinExecutorConfiguratorSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/dispatch/ForkJoinExecutorConfiguratorSpec.scala
@@ -28,7 +28,10 @@ import com.typesafe.config.{ Config, ConfigFactory }
 object ForkJoinExecutorConfiguratorSpec {
   // Keep the root config explicit so the dispatcher-config integration checks below
   // see exactly the values this spec is asserting on (and not whatever the project's
-  // global test configuration happens to set).
+  // global test configuration happens to set). In particular, the `fj-auto-*` dispatchers
+  // pin `minimum-runnable = -1` so they always exercise the JDK-aware auto policy even
+  // when a build pins `pekko.actor.default-dispatcher.fork-join-executor.minimum-runnable`
+  // via -D (the nightly CI does this on JDK 21+ for stability — see nightly-builds.yml).
   val config: Config = ConfigFactory.parseString("""
       |fj-auto-default-dispatcher {
       |  executor = "fork-join-executor"
@@ -36,6 +39,7 @@ object ForkJoinExecutorConfiguratorSpec {
       |    parallelism-min = 8
       |    parallelism-factor = 1.0
       |    parallelism-max = 64
+      |    minimum-runnable = -1
       |  }
       |}
       |fj-auto-small-dispatcher {
@@ -44,6 +48,7 @@ object ForkJoinExecutorConfiguratorSpec {
       |    parallelism-min = 1
       |    parallelism-factor = 1.0
       |    parallelism-max = 1
+      |    minimum-runnable = -1
       |  }
       |}
       |fj-explicit-zero-dispatcher {


### PR DESCRIPTION
## Motivation

The nightly build (run [24853126603](https://github.com/apache/pekko/actions/runs/24853126603/job/72758762338)) is red on the JDK 21 / Scala 2.13.x and JDK 25 jobs with two failures in `ForkJoinExecutorConfiguratorSpec`:

```
- must keep the legacy value of 1 on JDK < 25 when the default is left untouched *** FAILED ***
  4 was not equal to 1 (ForkJoinExecutorConfiguratorSpec.scala:167)
- must never drop below 1 even for parallelism = 1 dispatchers *** FAILED ***
```

Both come from the same root cause introduced when the spec was added in #2890.

## Root cause

The two `fj-auto-*` fixtures left `minimum-runnable` unset, expecting the reference.conf default (`-1`, which selects the JDK-aware auto policy). But the nightly workflow pins it via `-D` for JDK 21+ runs ([nightly-builds.yml](https://github.com/apache/pekko/blob/main/.github/workflows/nightly-builds.yml#L160-L162)) for stability:

```yaml
if [ "${{ matrix.javaVersion }}" -ge 21 ]; then
  EXTRA_JVM_OPTS="-Dpekko.actor.default-dispatcher.fork-join-executor.minimum-runnable=4 ..."
fi
```

`Dispatchers.config(id)` resolves a dispatcher's config via:

```
idConfig(id) → appConfig → nameConfig → defaultDispatcherConfig
```

`defaultDispatcherConfig` carries the `pekko.actor.default-dispatcher` values, including any `-D` overrides. So when the spec's `fork-join-executor` block omits `minimum-runnable`, the fallback chain feeds the CI's pinned `4` into `config.getInt("minimum-runnable")` for the auto fixtures, and `resolveMinimumRunnable(4, _, _)` honours it verbatim → `4 != 1`.

## Modification

Set `minimum-runnable = -1` explicitly in `fj-auto-default-dispatcher` and `fj-auto-small-dispatcher` so the spec always exercises the auto policy regardless of surrounding `-D` pins. The two `fj-explicit-*` fixtures already pin a value and remain unchanged.

## Result

- Two failing nightly assertions go green again.
- The CI `-D` pin keeps doing its production-stability job — only the spec is hardened.
- Tested locally with `sbt actor-tests/testOnly org.apache.pekko.dispatch.ForkJoinExecutorConfiguratorSpec -Dpekko.actor.default-dispatcher.fork-join-executor.minimum-runnable=4` (reproduces the CI environment): all 11 tests pass (1 pending on JDK 25 as designed).