### PR TITLE
fix: stabilize async DNS dispatchers under low minimum-runnable

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/dispatch/ForkJoinExecutorConfiguratorSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/dispatch/ForkJoinExecutorConfiguratorSpec.scala
@@ -150,8 +150,17 @@ class ForkJoinExecutorConfiguratorSpec extends PekkoSpec(ForkJoinExecutorConfigu
       resolvedMinimumRunnable("fj-explicit-seven-dispatcher") shouldBe 7
     }
 
-    "keep the built-in internal dispatcher on its explicit compensation floor" in {
-      resolvedMinimumRunnable("pekko.actor.internal-dispatcher") shouldBe 4
+    "let the built-in internal dispatcher use its own auto policy" in {
+      val dispatcherConfig =
+        system.dispatchers.config("pekko.actor.internal-dispatcher").getConfig("fork-join-executor")
+      val parallelism = ThreadPoolConfig.scaledPoolSize(
+        dispatcherConfig.getInt("parallelism-min"),
+        dispatcherConfig.getDouble("parallelism-factor"),
+        dispatcherConfig.getInt("parallelism-max"))
+      resolvedMinimumRunnable("pekko.actor.internal-dispatcher") shouldBe resolveMinimumRunnable(
+        configured = dispatcherConfig.getInt("minimum-runnable"),
+        parallelism = parallelism,
+        jdkMajorVersion = JavaVersion.majorVersion)
     }
 
     "auto-scale the default (minimum-runnable not set) on JDK 25+" in {

--- a/actor-tests/src/test/scala/org/apache/pekko/dispatch/ForkJoinExecutorConfiguratorSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/dispatch/ForkJoinExecutorConfiguratorSpec.scala
@@ -150,6 +150,10 @@ class ForkJoinExecutorConfiguratorSpec extends PekkoSpec(ForkJoinExecutorConfigu
       resolvedMinimumRunnable("fj-explicit-seven-dispatcher") shouldBe 7
     }
 
+    "keep the built-in internal dispatcher on its explicit compensation floor" in {
+      resolvedMinimumRunnable("pekko.actor.internal-dispatcher") shouldBe 4
+    }
+
     "auto-scale the default (minimum-runnable not set) on JDK 25+" in {
       if (JavaVersion.majorVersion < 25) pending
 

--- a/actor/src/main/resources/reference.conf
+++ b/actor/src/main/resources/reference.conf
@@ -354,6 +354,10 @@ pekko {
         router = "round-robin-pool"
         nr-of-instances = 1
       }
+
+      "/IO-DNS/async-dns/*" {
+        dispatcher = ${pekko.io.dns.dispatcher}
+      }
     }
 
     default-dispatcher {
@@ -634,6 +638,10 @@ pekko {
         parallelism-min = 4
         parallelism-factor = 1.0
         parallelism-max = 64
+        # Keep a higher compensation floor for Pekko-internal actors and DNS resolution.
+        # Letting this dispatcher inherit the global auto policy made SD-DNS lookups
+        # noticeably more timeout-prone under actor round-trip pressure.
+        minimum-runnable = 4
       }
     }
 

--- a/actor/src/main/resources/reference.conf
+++ b/actor/src/main/resources/reference.conf
@@ -638,10 +638,7 @@ pekko {
         parallelism-min = 4
         parallelism-factor = 1.0
         parallelism-max = 64
-        # Keep a higher compensation floor for Pekko-internal actors and DNS resolution.
-        # Letting this dispatcher inherit the global auto policy made SD-DNS lookups
-        # noticeably more timeout-prone under actor round-trip pressure.
-        minimum-runnable = 4
+        minimum-runnable = -1
       }
     }
 

--- a/discovery/src/main/resources/reference.conf
+++ b/discovery/src/main/resources/reference.conf
@@ -10,6 +10,10 @@ pekko.actor.deployment {
     router = "round-robin-pool"
     nr-of-instances = 1
   }
+
+  "/SD-DNS/async-dns/*" {
+    dispatcher = ${pekko.io.dns.dispatcher}
+  }
 }
 
 pekko.discovery {
@@ -74,4 +78,3 @@ pekko.discovery {
     class = org.apache.pekko.discovery.dns.DnsServiceDiscovery
   }
 }
-


### PR DESCRIPTION
## Summary
- keep the internal dispatcher on an explicit compensation floor
- route async DNS routees for both IO-DNS and SD-DNS through the configured DNS dispatcher
- add a regression assertion for the built-in internal dispatcher floor

## Motivation
The nightly JDK 17 / Scala 3.3.x failure came from `docs.discovery.DnsDiscoveryDocSpec` timing out and going pending after `minimum-runnable` moved to the new auto policy. The isolated SD-DNS manager and resolver already used the DNS dispatcher, but the actual async DNS routees were still left on the default dispatcher, making lookups much more sensitive to starvation.

## Result
With `-Dpekko.actor.default-dispatcher.fork-join-executor.minimum-runnable=-1`, the docs DNS discovery regression now passes again instead of pending.

Fixes the failure from:
https://github.com/apache/pekko/actions/runs/24863583862/job/72794553815
