### PR TITLE
test: fix flaky MetricsBasedResizerSpec underutilizationStreak test on JDK 25

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/routing/MetricsBasedResizerSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/routing/MetricsBasedResizerSpec.scala
@@ -150,6 +150,10 @@ class MetricsBasedResizerSpec extends PekkoSpec(ResizerSpec.config) with Default
 
       val router = TestRouter(routees(2))
       router.sendToAll(await = true)
+      // Send additional messages to ensure mailbox is non-empty when checked,
+      // avoiding a race condition where currentMessage could be null momentarily
+      router.mockSend(await = false, routeeIdx = 0)
+      router.mockSend(await = false, routeeIdx = 1)
 
       resizer.reportMessageCount(router.routees, router.msgs.size)
       resizer.record.underutilizationStreak shouldBe empty


### PR DESCRIPTION
## Summary
- Fixes flaky `MetricsBasedResizerSpec` test `must stop an underutilizationStreak when fully utilized` observed on JDK 25 CI:

  ```
  Some(UnderUtilizationStreak(2026-04-24T06:47:23.043225901, 1)) was not empty (MetricsBasedResizerSpec.scala:155)
  ```

- Same race condition previously addressed in #2769 for the sibling test `must update the underutilizationStreak highestUtilization if current utilization is higher`.

## Root Cause
`sendToAll(await = true)` only guarantees that each routee has **started** processing the latched message (the first latch has been counted down). It does **not** guarantee that `cell.currentMessage` will still be non-null at the moment the resizer inspects it inside `reportMessageCount`. Under JDK 25's scheduling there is a brief window where `currentMessage` can be observed as null while the actor transitions, so `utilized` is computed as `1` instead of `2`, the router is treated as not fully utilized, and the underutilization streak is preserved instead of cleared.

## Fix
After `sendToAll(await = true)`, enqueue one extra message per routee with `await = false`. This guarantees the mailbox count is `> 0` even if `currentMessage` is momentarily indeterminate, so `utilized` is computed correctly. This mirrors the existing fix at `MetricsBasedResizerSpec.scala:191-196`.

## Test plan
- [x] `sbt 'actor-tests/testOnly org.apache.pekko.routing.MetricsBasedResizerSpec'` passes locally on JDK 25 (`25.0.1+8-LTS-27`).
- [x] `sbt actor-tests/scalafmtAll` clean.