### PR TITLE
fix: MapAsyncPartitioned ordered path defers pullIfNeeded to preserve FIFO

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/MapAsyncPartitioned.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/MapAsyncPartitioned.scala
@@ -188,12 +188,12 @@ private[stream] final class MapAsyncPartitioned[In, Out, Partition](
               case Success(elem) =>
                 if (elem != null) {
                   push(out, elem)
-                  pullIfNeeded()
-                } else {
-                  // elem is null
-                  pullIfNeeded()
                 }
-
+              // pullIfNeeded is deferred until after drainQueue below so that
+              // any FIFO-suspended waiter for the just-freed partition gets started
+              // before upstream is asked for a new element. Pulling early would
+              // synchronously trigger onPush, which would claim the partition slot
+              // (canStartNextElement returns true) and starve the older waiter.
               case Failure(NonFatal(ex)) =>
                 holder.supervisionDirectiveFor(decider, ex) match {
                   // this could happen if we are looping in pushNextIfPossible and end up on a failed future before the
@@ -209,6 +209,11 @@ private[stream] final class MapAsyncPartitioned[In, Out, Partition](
             }
           }
           drainQueue()
+          // Required even when no element was pushed (failure-resume path or
+          // exit on NotYetThere head): completes the stage when upstream is
+          // closed and the buffer drained, and triggers a tryPull when buffer
+          // shrunk via failures.
+          pullIfNeeded()
         }
 
       private def pushNextIfPossibleUnordered(): Unit =


### PR DESCRIPTION
## Summary

Fixes two related bugs in `MapAsyncPartitioned`'s ordered path
(`pushNextIfPossibleOrdered`):

1. **FIFO violation under bursty downstream demand.** The success branch
   of the loop called `pullIfNeeded()` immediately after each push. With
   fused stages, `tryPull(in)` synchronously re-enters `onPush`. The
   newly grabbed element evaluates `canStartNextElement` against a
   partition slot that was *just* freed by the dequeue; if it shares a
   partition with an element already suspended at the head of the
   buffer, the new element claims the slot and the older buffered
   waiter is starved out of FIFO order.

2. **Resume-decider drain never completes the stage.** When a buffer
   drains entirely via `Supervision.resume`d failures (no successful
   push in the loop), the original code never called `pullIfNeeded`,
   so a stream where the trailing buffer entries all failed after
   `onUpstreamFinish` would not run the
   `isClosed(in) && idle()` check and would never emit completion.

## Modification

* Removed the two `pullIfNeeded()` calls inside the `Success` branch of
  the ordered loop.
* Added a single `pullIfNeeded()` after `drainQueue()` so that:
  * suspended FIFO waiters for the just-freed partition are resumed
    via `drainQueue` *before* upstream is asked for a new element;
  * `completeStage` is reached on the failure-resume drain path;
  * `tryPull` still happens once the buffer has room.

The unordered path is unchanged.

## Test plan

- [x] `sbt "stream-tests/testOnly *FlowMapAsyncPartitionedSpec"` —
      18/18 pass locally on Scala 2.13.
- [x] `sbt "stream-typed-tests/testOnly *MapAsyncPartitionedSpec"` —
      ordered + unordered suites pass; remaining flake in `afterAll`
      teardown is pre-existing on `main` (unrelated to this change).
- [x] `scalafmtOnly` on the modified file.