### PR TITLE
fix: stabilise PersistentActorRecoveryTimeoutSpec

### DIFF
--- a/persistence/src/test/scala/org/apache/pekko/persistence/PersistentActorRecoveryTimeoutSpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/PersistentActorRecoveryTimeoutSpec.scala
@@ -19,18 +19,23 @@ import org.apache.pekko
 import pekko.actor.{ Actor, ActorLogging, ActorRef, Props }
 import pekko.actor.Status.Failure
 import pekko.persistence.journal.SteppingInmemJournal
-import pekko.testkit.{ ImplicitSender, PekkoSpec, TestProbe }
+import pekko.testkit.{ ImplicitSender, PekkoSpec, TestDuration, TestProbe }
 
 import com.typesafe.config.ConfigFactory
 
 object PersistentActorRecoveryTimeoutSpec {
   val journalId = "persistent-actor-recovery-timeout-spec"
+  val receiveTimeoutJournalId = "persistent-actor-recovery-timeout-spec-receive-timeout"
+  val receiveTimeoutJournalPluginId = "pekko.persistence.journal.stepping-inmem-receive-timeout"
 
   def config =
     SteppingInmemJournal
       .config(PersistentActorRecoveryTimeoutSpec.journalId)
-      .withFallback(ConfigFactory.parseString("""
+      .withFallback(ConfigFactory.parseString(s"""
           |pekko.persistence.journal.stepping-inmem.recovery-event-timeout=3s
+          |$receiveTimeoutJournalPluginId.class=${classOf[SteppingInmemJournal].getName}
+          |$receiveTimeoutJournalPluginId.instance-id="$receiveTimeoutJournalId"
+          |$receiveTimeoutJournalPluginId.recovery-event-timeout=30s
         """.stripMargin))
       .withFallback(PersistenceSpec.config("stepping-inmem", "PersistentActorRecoveryTimeoutSpec"))
 
@@ -52,6 +57,8 @@ object PersistentActorRecoveryTimeoutSpec {
   class TestReceiveTimeoutActor(receiveTimeout: FiniteDuration, probe: ActorRef)
       extends NamedPersistentActor("recovery-timeout-actor-2")
       with ActorLogging {
+
+    override def journalPluginId: String = receiveTimeoutJournalPluginId
 
     override def preStart(): Unit = {
       context.setReceiveTimeout(receiveTimeout)
@@ -81,7 +88,7 @@ class PersistentActorRecoveryTimeoutSpec
     extends PekkoSpec(PersistentActorRecoveryTimeoutSpec.config)
     with ImplicitSender {
 
-  import PersistentActorRecoveryTimeoutSpec.journalId
+  import PersistentActorRecoveryTimeoutSpec.{ journalId, receiveTimeoutJournalId }
 
   "The recovery timeout" should {
 
@@ -127,11 +134,12 @@ class PersistentActorRecoveryTimeoutSpec
       val persisting =
         system.actorOf(Props(classOf[PersistentActorRecoveryTimeoutSpec.TestReceiveTimeoutActor], timeout, probe.ref))
 
-      awaitAssert(SteppingInmemJournal.getRef(journalId), 3.seconds)
-      val journal = SteppingInmemJournal.getRef(journalId)
+      awaitAssert(SteppingInmemJournal.getRef(receiveTimeoutJournalId), 3.seconds)
+      val journal = SteppingInmemJournal.getRef(receiveTimeoutJournalId)
 
       // initial read highest
       SteppingInmemJournal.step(journal)
+      probe.expectMsg(timeout)
 
       persisting ! "A"
       SteppingInmemJournal.step(journal)
@@ -141,18 +149,16 @@ class PersistentActorRecoveryTimeoutSpec
       system.stop(persisting)
       expectTerminated(persisting)
 
-      // now replay, but don't give the journal any tokens to replay events
-      // so that we cause the timeout to trigger
+      // now replay and verify that recovery keeps the actor's receive timeout
       system.actorOf(Props(classOf[PersistentActorRecoveryTimeoutSpec.TestReceiveTimeoutActor], timeout, probe.ref))
 
-      // initial read highest
-      SteppingInmemJournal.step(journal)
-
-      // read journal
-      SteppingInmemJournal.step(journal)
+      // Release both recovery journal operations up front. Waiting for the second stepped
+      // operation can race with the recovery timeout under heavy CI load.
+      journal ! SteppingInmemJournal.Token
+      journal ! SteppingInmemJournal.Token
 
       // we should get initial receive timeout back from actor when replay completes
-      probe.expectMsg(timeout)
+      probe.expectMsg(30.seconds.dilated, timeout)
 
     }
 

--- a/persistence/src/test/scala/org/apache/pekko/persistence/journal/SteppingInmemJournal.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/journal/SteppingInmemJournal.scala
@@ -72,12 +72,16 @@ object SteppingInmemJournal {
  * it using {{{SteppingInmemJournal.getRef(String)}}}, send it {{{SteppingInmemJournal.Token}}}s to
  * allow one journal operation to complete.
  */
-final class SteppingInmemJournal extends InmemJournal {
+final class SteppingInmemJournal(config: Config) extends InmemJournal {
+
+  def this() = this(ConfigFactory.empty)
 
   import SteppingInmemJournal._
   import context.dispatcher
 
-  val instanceId = context.system.settings.config.getString("pekko.persistence.journal.stepping-inmem.instance-id")
+  val instanceId =
+    if (config.hasPath("instance-id")) config.getString("instance-id")
+    else context.system.settings.config.getString("pekko.persistence.journal.stepping-inmem.instance-id")
 
   var queuedOps: Seq[() => Future[Unit]] = Seq.empty
   var queuedTokenRecipients = List.empty[ActorRef]


### PR DESCRIPTION
Motivation:
PersistentActorRecoveryTimeoutSpec can flake under CI load when the receive-timeout test reuses the same 3s stepped recovery timeout path as the test that intentionally times out recovery. If the second replay operation is delayed, the recovery tick can win and SteppingInmemJournal.step waits until its ask timeout.

Modification:
- Let SteppingInmemJournal read instance-id from the plugin config passed to the journal actor, while preserving the no-arg fallback for existing tests.
- Give the receive-timeout scenario its own stepping journal instance with a wider recovery timeout.
- Consume the first RecoveryCompleted signal and release both replay tokens up front so the assertion verifies successful recovery rather than racing the recovery timeout.

Result:
The timeout failure test still exercises the 3s recovery timeout, and the receive-timeout test now checks that successful recovery preserves the actor receive timeout without depending on that 3s timeout window.

Tests:
- sbt "persistence / Test / testOnly org.apache.pekko.persistence.PersistentActorRecoveryTimeoutSpec"
- sbt -Dpekko.test.timefactor=2 "persistence / Test / testOnly org.apache.pekko.persistence.PersistentActorRecoveryTimeoutSpec"
- sbt -Dpekko.test.timefactor=2 "persistence-typed-tests / Test / testOnly org.apache.pekko.persistence.typed.scaladsl.EventSourcedBehaviorRecoveryTimeoutSpec org.apache.pekko.persistence.typed.scaladsl.EventSourcedStashOverflowSpec"
- sbt -Dpekko.test.timefactor=2 "persistence / Test / testOnly org.apache.pekko.persistence.SteppingInMemPersistentActorStashingSpec"
- sbt -Dpekko.test.timefactor=2 "persistence / Test / testOnly org.apache.pekko.persistence.ThrowExceptionStrategyPersistentActorBoundedStashingSpec"
- sbt -Dpekko.test.timefactor=2 "persistence / Test / testOnly org.apache.pekko.persistence.DiscardStrategyPersistentActorBoundedStashingSpec"
- sbt -Dpekko.test.timefactor=2 "persistence / Test / testOnly org.apache.pekko.persistence.ReplyToStrategyPersistentActorBoundedStashingSpec"
- sbt "persistence / Test / scalafmtCheck"