### PR TITLE
build: ignore local AI assistant workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,13 @@ native/
 
 .tmp
 
+# Local AI assistant workspace files
+.agents/
+.aider*
+.claude/
+.codex/
+.continue/
+.cursor/
+.gemini/
+.kiro/
+.windsurf/


### PR DESCRIPTION
Motivation:
Local AI assistant workspace directories can appear as untracked files while working on the project and should not be accidentally included in unrelated changes.

Modification:
- Add .gitignore entries for common local AI assistant workspace directories and files.

Result:
Local .claude, .cursor, .kiro, and similar AI assistant workspace files stay out of the git working tree by default.

Tests:
- git check-ignore -v .claude .cursor .kiro
- git diff --check

References:
- N/A (local workspace ignore-list cleanup)