### PR TITLE
Fix nightly JDK 21 and 25 failures

### DIFF
--- a/cluster/src/test/scala/org/apache/pekko/cluster/StartupWithOneThreadSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/StartupWithOneThreadSpec.scala
@@ -31,12 +31,19 @@ object StartupWithOneThreadSpec {
     pekko.remote.artery.canonical.port = 0
 
     pekko.actor.default-dispatcher {
+      type = Dispatcher
       executor = thread-pool-executor
       thread-pool-executor {
         fixed-pool-size = 1
       }
     }
-    pekko.actor.internal-dispatcher = pekko.actor.default-dispatcher 
+    pekko.actor.internal-dispatcher {
+      type = Dispatcher
+      executor = thread-pool-executor
+      thread-pool-executor {
+        fixed-pool-size = 1
+      }
+    }
     """
 
   final case class GossipTo(address: Address)


### PR DESCRIPTION
## Problem
Nightly Builds failed on run https://github.com/apache/pekko/actions/runs/24971331707 for JDK 21 and JDK 25.

I re-checked the logs with `rg "\\*\\*\\*"` and the failures group as:
- JDK21 / Scala 2.13 and Scala 3.3: `StartupWithOneThreadSpec` aborted with `ConfigException$Missing` for dispatcher key `type`.
- JDK25 / Scala 2.13: the same `StartupWithOneThreadSpec` abort.
- JDK25 / Scala 3.3: remote ordering/router timeouts, stream long-stream/resource/mapAsyncUnordered failures, the same `StartupWithOneThreadSpec` abort, and cluster-sharding-typed timeouts.

## Fix so far
- Preserve the nightly virtual thread dispatcher settings, including remote, persistence, and stream test dispatchers.
- Make `StartupWithOneThreadSpec` use concrete one-thread dispatcher configs for both default and internal dispatchers. A string alias is not safe under the nightly system properties because HOCON merges `pekko.actor.internal-dispatcher.fork-join-executor.*` into the alias path and turns it into an incomplete dispatcher object without `type`.

## Verification so far
- `git diff --check`

The JDK25 / Scala 3 timing groups are still being investigated while keeping virtual threads enabled.