### PR TITLE
fix: Fix virtualized dispatcher shutdown ordering

### DIFF
--- a/actor-tests/src/test/scala-jdk21-only/org/apache/pekko/dispatch/ForkJoinPoolVirtualThreadSpec.scala
+++ b/actor-tests/src/test/scala-jdk21-only/org/apache/pekko/dispatch/ForkJoinPoolVirtualThreadSpec.scala
@@ -17,7 +17,9 @@
 
 package org.apache.pekko.dispatch
 
-import java.util.concurrent.{ CountDownLatch, Executors, TimeUnit }
+import java.util
+import java.util.concurrent.{ AbstractExecutorService, CountDownLatch, ExecutorService, Executors, TimeUnit }
+import java.util.concurrent.atomic.AtomicBoolean
 
 import org.apache.pekko
 import pekko.actor.{ Actor, Props }
@@ -63,6 +65,31 @@ object ForkJoinPoolVirtualThreadSpec {
     }
   }
 
+  final class TrackingExecutorService(delegate: ExecutorService) extends AbstractExecutorService {
+    val shutdownNowCalled = new AtomicBoolean(false)
+
+    override def shutdown(): Unit = {
+      delegate.shutdown()
+    }
+
+    override def shutdownNow(): util.List[Runnable] = {
+      shutdownNowCalled.set(true)
+      delegate.shutdownNow()
+    }
+
+    override def isShutdown: Boolean = delegate.isShutdown
+
+    override def isTerminated: Boolean = delegate.isTerminated
+
+    override def awaitTermination(timeout: Long, unit: TimeUnit): Boolean = {
+      delegate.awaitTermination(timeout, unit)
+    }
+
+    override def execute(command: Runnable): Unit = {
+      delegate.execute(command)
+    }
+  }
+
 }
 
 class ForkJoinPoolVirtualThreadSpec extends PekkoSpec(ForkJoinPoolVirtualThreadSpec.config) with ImplicitSender {
@@ -89,7 +116,7 @@ class ForkJoinPoolVirtualThreadSpec extends PekkoSpec(ForkJoinPoolVirtualThreadS
     }
 
     "allow blocked virtual threads to finish after dispatcher shutdown" in {
-      val underlying = Executors.newFixedThreadPool(1)
+      val underlying = new TrackingExecutorService(Executors.newFixedThreadPool(1))
       val executor = new VirtualizedExecutorService(
         VirtualThreadSupport.newVirtualThreadFactory("fork-join-pool-virtual-thread-spec", 0, underlying),
         underlying,
@@ -115,6 +142,7 @@ class ForkJoinPoolVirtualThreadSpec extends PekkoSpec(ForkJoinPoolVirtualThreadS
         release.countDown()
         finished.await(5, TimeUnit.SECONDS) should ===(true)
         executor.awaitTermination(5, TimeUnit.SECONDS) should ===(true)
+        underlying.shutdownNowCalled.get should ===(false)
         underlying.isTerminated should ===(true)
       } finally {
         release.countDown()
@@ -124,7 +152,7 @@ class ForkJoinPoolVirtualThreadSpec extends PekkoSpec(ForkJoinPoolVirtualThreadS
     }
 
     "interrupt blocked virtual threads on dispatcher shutdownNow" in {
-      val underlying = Executors.newFixedThreadPool(1)
+      val underlying = new TrackingExecutorService(Executors.newFixedThreadPool(1))
       val executor = new VirtualizedExecutorService(
         VirtualThreadSupport.newVirtualThreadFactory("fork-join-pool-virtual-thread-spec", 0, underlying),
         underlying,
@@ -150,6 +178,7 @@ class ForkJoinPoolVirtualThreadSpec extends PekkoSpec(ForkJoinPoolVirtualThreadS
 
         interrupted.await(5, TimeUnit.SECONDS) should ===(true)
         executor.awaitTermination(5, TimeUnit.SECONDS) should ===(true)
+        underlying.shutdownNowCalled.get should ===(true)
         underlying.isTerminated should ===(true)
       } finally {
         executor.shutdownNow()

--- a/actor-tests/src/test/scala-jdk21-only/org/apache/pekko/dispatch/ForkJoinPoolVirtualThreadSpec.scala
+++ b/actor-tests/src/test/scala-jdk21-only/org/apache/pekko/dispatch/ForkJoinPoolVirtualThreadSpec.scala
@@ -17,6 +17,8 @@
 
 package org.apache.pekko.dispatch
 
+import java.util.concurrent.{ CountDownLatch, Executors, TimeUnit }
+
 import org.apache.pekko
 import pekko.actor.{ Actor, Props }
 import pekko.testkit.{ ImplicitSender, PekkoSpec }
@@ -83,6 +85,75 @@ class ForkJoinPoolVirtualThreadSpec extends PekkoSpec(ForkJoinPoolVirtualThreadS
         expectMsgPF() { case name: String =>
           name should include("ForkJoinPoolVirtualThreadSpec-custom.task-dispatcher-short-virtual-thread")
         }
+      }
+    }
+
+    "allow blocked virtual threads to finish after dispatcher shutdown" in {
+      val underlying = Executors.newFixedThreadPool(1)
+      val executor = new VirtualizedExecutorService(
+        VirtualThreadSupport.newVirtualThreadFactory("fork-join-pool-virtual-thread-spec", 0, underlying),
+        underlying,
+        _ => false,
+        cascadeShutdown = true)
+
+      val started = new CountDownLatch(1)
+      val release = new CountDownLatch(1)
+      val finished = new CountDownLatch(1)
+
+      try {
+        executor.execute(new Runnable {
+          override def run(): Unit = {
+            started.countDown()
+            release.await()
+            finished.countDown()
+          }
+        })
+
+        started.await(5, TimeUnit.SECONDS) should ===(true)
+        executor.shutdown()
+
+        release.countDown()
+        finished.await(5, TimeUnit.SECONDS) should ===(true)
+        executor.awaitTermination(5, TimeUnit.SECONDS) should ===(true)
+        underlying.isTerminated should ===(true)
+      } finally {
+        release.countDown()
+        executor.shutdownNow()
+        underlying.shutdownNow()
+      }
+    }
+
+    "interrupt blocked virtual threads on dispatcher shutdownNow" in {
+      val underlying = Executors.newFixedThreadPool(1)
+      val executor = new VirtualizedExecutorService(
+        VirtualThreadSupport.newVirtualThreadFactory("fork-join-pool-virtual-thread-spec", 0, underlying),
+        underlying,
+        _ => false,
+        cascadeShutdown = true)
+
+      val started = new CountDownLatch(1)
+      val interrupted = new CountDownLatch(1)
+
+      try {
+        executor.execute(new Runnable {
+          override def run(): Unit = {
+            started.countDown()
+            try Thread.sleep(TimeUnit.SECONDS.toMillis(30))
+            catch {
+              case _: InterruptedException => interrupted.countDown()
+            }
+          }
+        })
+
+        started.await(5, TimeUnit.SECONDS) should ===(true)
+        executor.shutdownNow()
+
+        interrupted.await(5, TimeUnit.SECONDS) should ===(true)
+        executor.awaitTermination(5, TimeUnit.SECONDS) should ===(true)
+        underlying.isTerminated should ===(true)
+      } finally {
+        executor.shutdownNow()
+        underlying.shutdownNow()
       }
     }
 

--- a/actor-tests/src/test/scala-jdk21-only/org/apache/pekko/dispatch/ForkJoinPoolVirtualThreadSpec.scala
+++ b/actor-tests/src/test/scala-jdk21-only/org/apache/pekko/dispatch/ForkJoinPoolVirtualThreadSpec.scala
@@ -66,9 +66,11 @@ object ForkJoinPoolVirtualThreadSpec {
   }
 
   final class TrackingExecutorService(delegate: ExecutorService) extends AbstractExecutorService {
+    val shutdownCalled = new AtomicBoolean(false)
     val shutdownNowCalled = new AtomicBoolean(false)
 
     override def shutdown(): Unit = {
+      shutdownCalled.set(true)
       delegate.shutdown()
     }
 
@@ -138,10 +140,12 @@ class ForkJoinPoolVirtualThreadSpec extends PekkoSpec(ForkJoinPoolVirtualThreadS
 
         started.await(5, TimeUnit.SECONDS) should ===(true)
         executor.shutdown()
+        underlying.isShutdown should ===(false)
 
         release.countDown()
         finished.await(5, TimeUnit.SECONDS) should ===(true)
         executor.awaitTermination(5, TimeUnit.SECONDS) should ===(true)
+        underlying.shutdownCalled.get should ===(true)
         underlying.shutdownNowCalled.get should ===(false)
         underlying.isTerminated should ===(true)
       } finally {
@@ -160,13 +164,14 @@ class ForkJoinPoolVirtualThreadSpec extends PekkoSpec(ForkJoinPoolVirtualThreadS
         cascadeShutdown = true)
 
       val started = new CountDownLatch(1)
+      val release = new CountDownLatch(1)
       val interrupted = new CountDownLatch(1)
 
       try {
         executor.execute(new Runnable {
           override def run(): Unit = {
             started.countDown()
-            try Thread.sleep(TimeUnit.SECONDS.toMillis(30))
+            try release.await()
             catch {
               case _: InterruptedException => interrupted.countDown()
             }
@@ -181,6 +186,46 @@ class ForkJoinPoolVirtualThreadSpec extends PekkoSpec(ForkJoinPoolVirtualThreadS
         underlying.shutdownNowCalled.get should ===(true)
         underlying.isTerminated should ===(true)
       } finally {
+        release.countDown()
+        executor.shutdownNow()
+        underlying.shutdownNow()
+      }
+    }
+
+    "escalate to underlying shutdownNow after dispatcher shutdown" in {
+      val underlying = new TrackingExecutorService(Executors.newFixedThreadPool(1))
+      val executor = new VirtualizedExecutorService(
+        VirtualThreadSupport.newVirtualThreadFactory("fork-join-pool-virtual-thread-spec", 0, underlying),
+        underlying,
+        _ => false,
+        cascadeShutdown = true)
+
+      val started = new CountDownLatch(1)
+      val release = new CountDownLatch(1)
+      val interrupted = new CountDownLatch(1)
+
+      try {
+        executor.execute(new Runnable {
+          override def run(): Unit = {
+            started.countDown()
+            try release.await()
+            catch {
+              case _: InterruptedException => interrupted.countDown()
+            }
+          }
+        })
+
+        started.await(5, TimeUnit.SECONDS) should ===(true)
+        executor.shutdown()
+        underlying.isShutdown should ===(false)
+
+        executor.shutdownNow()
+        interrupted.await(5, TimeUnit.SECONDS) should ===(true)
+        executor.awaitTermination(5, TimeUnit.SECONDS) should ===(true)
+        underlying.shutdownNowCalled.get should ===(true)
+        underlying.isTerminated should ===(true)
+      } finally {
+        release.countDown()
         executor.shutdownNow()
         underlying.shutdownNow()
       }

--- a/actor-tests/src/test/scala/org/apache/pekko/io/dns/DockerBindDnsService.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/io/dns/DockerBindDnsService.scala
@@ -13,6 +13,8 @@
 
 package org.apache.pekko.io.dns
 
+import java.net.InetAddress
+
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.util.Try
@@ -125,8 +127,11 @@ abstract class DockerBindDnsService(config: Config) extends PekkoSpec(config) wi
     eventually(timeout(25.seconds)) {
       import pekko.pattern.ask
       implicit val timeout: Timeout = 2.seconds
-      (IO(Dns) ? DnsProtocol.Resolve("a-single.foo.test", DnsProtocol.Ip(ipv6 = false))).mapTo[
+      val resolved = (IO(Dns) ? DnsProtocol.Resolve("a-single.foo.test", DnsProtocol.Ip(ipv6 = false))).mapTo[
         DnsProtocol.Resolved].futureValue
+      resolved.name shouldEqual "a-single.foo.test"
+      resolved.records.collect { case record: ARecord => record.ip } shouldEqual Seq(
+        InetAddress.getByName("192.168.1.20"))
     }
   }
 

--- a/actor-tests/src/test/scala/org/apache/pekko/io/dns/DockerBindDnsService.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/io/dns/DockerBindDnsService.scala
@@ -13,7 +13,7 @@
 
 package org.apache.pekko.io.dns
 
-import java.net.InetAddress
+import java.net.{ InetAddress, InetSocketAddress }
 
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
@@ -27,7 +27,8 @@ import com.github.dockerjava.core.{ DefaultDockerClientConfig, DockerClientConfi
 import com.github.dockerjava.httpclient5.ApacheDockerHttpClient
 
 import org.apache.pekko
-import pekko.io.{ Dns, IO }
+import pekko.actor.Props
+import pekko.io.dns.internal.DnsClient
 import pekko.util.Timeout
 
 import pekko.testkit.PekkoSpec
@@ -124,14 +125,22 @@ abstract class DockerBindDnsService(config: Config) extends PekkoSpec(config) wi
 
       reader.toString should include("Starting BIND")
     }
-    eventually(timeout(25.seconds)) {
-      import pekko.pattern.ask
-      implicit val timeout: Timeout = 2.seconds
-      val resolved = (IO(Dns) ? DnsProtocol.Resolve("a-single.foo.test", DnsProtocol.Ip(ipv6 = false))).mapTo[
-        DnsProtocol.Resolved].futureValue
-      resolved.name shouldEqual "a-single.foo.test"
-      resolved.records.collect { case record: ARecord => record.ip } shouldEqual Seq(
-        InetAddress.getByName("192.168.1.20"))
+    val readinessNameserver = new InetSocketAddress(InetAddress.getByName("127.0.0.1"), hostPort)
+    val readinessClient = system.actorOf(Props(new DnsClient(readinessNameserver)))
+    try {
+      var requestId = 0
+      eventually(timeout(25.seconds)) {
+        import pekko.pattern.ask
+        implicit val timeout: Timeout = 2.seconds
+        requestId += 1
+        val answer = (readinessClient ? DnsClient.Question4(requestId.toShort, "a-single.foo.test"))
+          .mapTo[DnsClient.Answer]
+          .futureValue
+        answer.rrs.collect { case record: ARecord => record.ip } shouldEqual Seq(
+          InetAddress.getByName("192.168.1.20"))
+      }
+    } finally {
+      system.stop(readinessClient)
     }
   }
 

--- a/actor-tests/src/test/scala/org/apache/pekko/routing/MetricsBasedResizerSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/routing/MetricsBasedResizerSpec.scala
@@ -241,6 +241,9 @@ class MetricsBasedResizerSpec extends PekkoSpec(ResizerSpec.config) with Default
 
       router.mockSend(await = true, routeeIdx = 0)
       router.mockSend(await = false, routeeIdx = 1)
+      awaitAssert {
+        resizer.updatedStats(router.routees, router.msgs.size)._1.get(2) should not be empty
+      }
       resizer.reportMessageCount(router.routees, router.msgs.size)
       resizer.performanceLog.get(2) should not be empty
 

--- a/actor/src/main/scala/org/apache/pekko/dispatch/VirtualThreadSupport.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/VirtualThreadSupport.scala
@@ -56,6 +56,16 @@ private[dispatch] object VirtualThreadSupport {
   }
 
   /**
+   * Start a virtual thread using the default virtual thread scheduler.
+   */
+  def startVirtualThread(prefix: String, runnable: Runnable): Thread = {
+    require(runnable != null, "runnable should not be null.")
+    val thread = newVirtualThreadFactory(prefix, -1).newThread(runnable)
+    thread.start()
+    thread
+  }
+
+  /**
    * Create a virtual thread factory with the default Virtual Thread executor.
    * @param prefix the prefix of the virtual thread name.
    * @param start the starting number of the virtual thread name, if -1, the number will not be appended.

--- a/actor/src/main/scala/org/apache/pekko/dispatch/VirtualizedExecutorService.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/VirtualizedExecutorService.scala
@@ -19,6 +19,7 @@ package org.apache.pekko.dispatch
 
 import java.util
 import java.util.concurrent.{ Callable, Executor, ExecutorService, Future, ThreadFactory, TimeUnit }
+import java.util.concurrent.atomic.AtomicBoolean
 
 import org.apache.pekko.annotation.InternalApi
 
@@ -40,34 +41,29 @@ final class VirtualizedExecutorService(
   require(loadMetricsProvider != null, "Load metrics provider must not be null")
 
   private val executor = VirtualThreadSupport.newThreadPerTaskExecutor(vtFactory)
+  private val underlyingShutdownScheduled = new AtomicBoolean(false)
+  private val underlyingShutdownStarted = new AtomicBoolean(false)
 
   override def atFullThrottle(): Boolean = loadMetricsProvider(this)
 
   override def shutdown(): Unit = {
     executor.shutdown()
-    if (cascadeShutdown && (underlying ne null)) {
-      underlying.shutdown()
-    }
+    shutdownUnderlyingWhenVirtualThreadsHaveTerminated()
   }
 
   override def shutdownNow(): util.List[Runnable] = {
-    val r = executor.shutdownNow()
-    if (cascadeShutdown && (underlying ne null)) {
-      underlying.shutdownNow()
-    }
-    r
+    val result = executor.shutdownNow()
+    shutdownUnderlyingWhenVirtualThreadsHaveTerminated()
+    result
   }
 
-  override def isShutdown: Boolean = {
-    if (cascadeShutdown) {
-      executor.isShutdown && ((underlying eq null) || underlying.isShutdown)
-    } else {
-      executor.isShutdown
-    }
-  }
+  override def isShutdown: Boolean = executor.isShutdown
 
   override def isTerminated: Boolean = {
     if (cascadeShutdown) {
+      if (executor.isTerminated) {
+        shutdownUnderlying()
+      }
       executor.isTerminated && ((underlying eq null) || underlying.isTerminated)
     } else {
       executor.isTerminated
@@ -76,42 +72,78 @@ final class VirtualizedExecutorService(
 
   override def awaitTermination(timeout: Long, unit: TimeUnit): Boolean = {
     if (cascadeShutdown) {
-      executor.awaitTermination(timeout, unit) && ((underlying eq null) || underlying.awaitTermination(timeout, unit))
+      val timeoutNanos = unit.toNanos(timeout)
+      val deadline = System.nanoTime() + timeoutNanos
+      executor.awaitTermination(timeout, unit) && {
+        shutdownUnderlying()
+        (underlying eq null) || {
+          val remainingNanos = deadline - System.nanoTime()
+          if (remainingNanos <= 0L) underlying.isTerminated
+          else underlying.awaitTermination(remainingNanos, TimeUnit.NANOSECONDS)
+        }
+      }
     } else {
       executor.awaitTermination(timeout, unit)
     }
   }
 
-  override def submit[T](task: Callable[T]): Future[T] = {
-    executor.submit(task)
+  private def shutdownUnderlyingWhenVirtualThreadsHaveTerminated(): Unit = {
+    if (cascadeShutdown && (underlying ne null) && underlyingShutdownScheduled.compareAndSet(false, true)) {
+      if (executor.isTerminated) {
+        shutdownUnderlying()
+      } else {
+        VirtualThreadSupport.startVirtualThread(
+          "pekko-virtualized-executor-shutdown",
+          new Runnable {
+            override def run(): Unit = {
+              var interrupted = false
+              try {
+                while (!executor.isTerminated) {
+                  try executor.awaitTermination(1L, TimeUnit.DAYS)
+                  catch {
+                    case _: InterruptedException => interrupted = true
+                  }
+                }
+              } finally {
+                shutdownUnderlying()
+                if (interrupted) {
+                  Thread.currentThread().interrupt()
+                }
+              }
+            }
+          })
+      }
+    }
   }
 
-  override def submit[T](task: Runnable, result: T): Future[T] = {
+  private def shutdownUnderlying(): Unit = {
+    if (cascadeShutdown && (underlying ne null) && underlyingShutdownStarted.compareAndSet(false, true)) {
+      underlying.shutdown()
+    }
+  }
+
+  override def submit[T](task: Callable[T]): Future[T] =
+    executor.submit(task)
+
+  override def submit[T](task: Runnable, result: T): Future[T] =
     executor.submit(task, result)
-  }
 
-  override def submit(task: Runnable): Future[_] = {
+  override def submit(task: Runnable): Future[_] =
     executor.submit(task)
-  }
 
-  override def invokeAll[T](tasks: util.Collection[_ <: Callable[T]]): util.List[Future[T]] = {
+  override def invokeAll[T](tasks: util.Collection[_ <: Callable[T]]): util.List[Future[T]] =
     executor.invokeAll(tasks)
-  }
 
   override def invokeAll[T](
-      tasks: util.Collection[_ <: Callable[T]], timeout: Long, unit: TimeUnit): util.List[Future[T]] = {
+      tasks: util.Collection[_ <: Callable[T]], timeout: Long, unit: TimeUnit): util.List[Future[T]] =
     executor.invokeAll(tasks, timeout, unit)
-  }
 
-  override def invokeAny[T](tasks: util.Collection[_ <: Callable[T]]): T = {
+  override def invokeAny[T](tasks: util.Collection[_ <: Callable[T]]): T =
     executor.invokeAny(tasks)
-  }
 
-  override def invokeAny[T](tasks: util.Collection[_ <: Callable[T]], timeout: Long, unit: TimeUnit): T = {
+  override def invokeAny[T](tasks: util.Collection[_ <: Callable[T]], timeout: Long, unit: TimeUnit): T =
     executor.invokeAny(tasks, timeout, unit)
-  }
 
-  override def execute(command: Runnable): Unit = {
+  override def execute(command: Runnable): Unit =
     executor.execute(command)
-  }
 }

--- a/actor/src/main/scala/org/apache/pekko/dispatch/VirtualizedExecutorService.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/VirtualizedExecutorService.scala
@@ -19,7 +19,7 @@ package org.apache.pekko.dispatch
 
 import java.util
 import java.util.concurrent.{ Callable, Executor, ExecutorService, Future, ThreadFactory, TimeUnit }
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger }
 
 import org.apache.pekko.annotation.InternalApi
 
@@ -40,9 +40,14 @@ final class VirtualizedExecutorService(
   require(vtFactory != null, "Virtual thread factory must not be null")
   require(loadMetricsProvider != null, "Load metrics provider must not be null")
 
+  private final val UnderlyingRunning = 0
+  private final val UnderlyingShutdown = 1
+  private final val UnderlyingShutdownNow = 2
+
   private val executor = VirtualThreadSupport.newThreadPerTaskExecutor(vtFactory)
   private val underlyingShutdownScheduled = new AtomicBoolean(false)
-  private val underlyingShutdownStarted = new AtomicBoolean(false)
+  private val underlyingShutdownNowRequested = new AtomicBoolean(false)
+  private val underlyingShutdownState = new AtomicInteger(UnderlyingRunning)
 
   override def atFullThrottle(): Boolean = loadMetricsProvider(this)
 
@@ -52,6 +57,7 @@ final class VirtualizedExecutorService(
   }
 
   override def shutdownNow(): util.List[Runnable] = {
+    underlyingShutdownNowRequested.set(true)
     val result = executor.shutdownNow()
     shutdownUnderlyingWhenVirtualThreadsHaveTerminated()
     result
@@ -88,10 +94,10 @@ final class VirtualizedExecutorService(
   }
 
   private def shutdownUnderlyingWhenVirtualThreadsHaveTerminated(): Unit = {
-    if (cascadeShutdown && (underlying ne null) && underlyingShutdownScheduled.compareAndSet(false, true)) {
+    if (cascadeShutdown && (underlying ne null)) {
       if (executor.isTerminated) {
         shutdownUnderlying()
-      } else {
+      } else if (underlyingShutdownScheduled.compareAndSet(false, true)) {
         VirtualThreadSupport.startVirtualThread(
           "pekko-virtualized-executor-shutdown",
           new Runnable {
@@ -117,33 +123,46 @@ final class VirtualizedExecutorService(
   }
 
   private def shutdownUnderlying(): Unit = {
-    if (cascadeShutdown && (underlying ne null) && underlyingShutdownStarted.compareAndSet(false, true)) {
+    if (cascadeShutdown && (underlying ne null) && underlyingShutdownNowRequested.get) {
+      if (underlyingShutdownState.getAndSet(UnderlyingShutdownNow) != UnderlyingShutdownNow) {
+        underlying.shutdownNow()
+      }
+    } else if (cascadeShutdown && (underlying ne null) &&
+      underlyingShutdownState.compareAndSet(UnderlyingRunning, UnderlyingShutdown)) {
       underlying.shutdown()
     }
   }
 
-  override def submit[T](task: Callable[T]): Future[T] =
+  override def submit[T](task: Callable[T]): Future[T] = {
     executor.submit(task)
+  }
 
-  override def submit[T](task: Runnable, result: T): Future[T] =
+  override def submit[T](task: Runnable, result: T): Future[T] = {
     executor.submit(task, result)
+  }
 
-  override def submit(task: Runnable): Future[_] =
+  override def submit(task: Runnable): Future[_] = {
     executor.submit(task)
+  }
 
-  override def invokeAll[T](tasks: util.Collection[_ <: Callable[T]]): util.List[Future[T]] =
+  override def invokeAll[T](tasks: util.Collection[_ <: Callable[T]]): util.List[Future[T]] = {
     executor.invokeAll(tasks)
+  }
 
   override def invokeAll[T](
-      tasks: util.Collection[_ <: Callable[T]], timeout: Long, unit: TimeUnit): util.List[Future[T]] =
+      tasks: util.Collection[_ <: Callable[T]], timeout: Long, unit: TimeUnit): util.List[Future[T]] = {
     executor.invokeAll(tasks, timeout, unit)
+  }
 
-  override def invokeAny[T](tasks: util.Collection[_ <: Callable[T]]): T =
+  override def invokeAny[T](tasks: util.Collection[_ <: Callable[T]]): T = {
     executor.invokeAny(tasks)
+  }
 
-  override def invokeAny[T](tasks: util.Collection[_ <: Callable[T]], timeout: Long, unit: TimeUnit): T =
+  override def invokeAny[T](tasks: util.Collection[_ <: Callable[T]], timeout: Long, unit: TimeUnit): T = {
     executor.invokeAny(tasks, timeout, unit)
+  }
 
-  override def execute(command: Runnable): Unit =
+  override def execute(command: Runnable): Unit = {
     executor.execute(command)
+  }
 }

--- a/actor/src/main/scala/org/apache/pekko/dispatch/VirtualizedExecutorService.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/VirtualizedExecutorService.scala
@@ -105,7 +105,7 @@ final class VirtualizedExecutorService(
               var interrupted = false
               try {
                 while (!executor.isTerminated) {
-                  try executor.awaitTermination(1L, TimeUnit.DAYS)
+                  try executor.awaitTermination(Long.MaxValue, TimeUnit.NANOSECONDS)
                   catch {
                     case _: InterruptedException => interrupted = true
                   }

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/LateConnectSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/LateConnectSpec.scala
@@ -55,11 +55,15 @@ class LateConnectSpec extends ArteryMultiNodeSpec(LateConnectSpec.config) with I
 
       val probeB = TestProbe()(systemB)
       val echoA = systemB.actorSelection(RootActorPath(RARP(system).provider.getDefaultAddress) / "user" / "echoA")
-      echoA.tell("ping2", probeB.ref)
-      probeB.expectMsg(10.seconds, "ping2")
+      awaitAssert({
+          echoA.tell("ping2", probeB.ref)
+          probeB.expectMsg(1.second, "ping2")
+        }, 20.seconds)
 
-      echoB ! "ping3"
-      expectMsg("ping3")
+      awaitAssert({
+          echoB ! "ping3"
+          expectMsg(1.second, "ping3")
+        }, 20.seconds)
     }
   }
 }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapAsyncPartitionedSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapAsyncPartitionedSpec.scala
@@ -381,11 +381,15 @@ class FlowMapAsyncPartitionedSpec extends StreamSpec with WithLogCapturing {
     }
 
     "resume after multiple failures if resume supervision is in place" in {
+      implicit val ec: ExecutionContext = system.dispatcher
+
       val expected =
         Source(1 to 10)
           .mapAsyncPartitioned(4)(_ % 3) { (elem, _) =>
-            if (elem % 4 < 3) Future.failed(new TE("BOOM!"))
-            else Future.successful(elem)
+            Future {
+              if (elem % 4 < 3) throw new TE("BOOM!")
+              else elem
+            }
           }
           .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
           .runWith(Sink.seq)


### PR DESCRIPTION
Motivation:
JDK 21 and JDK 25 can reject virtual-thread continuations when a custom scheduler is shut down before already-started virtual threads have finished. The nightly failure shows the continuation being resubmitted to the custom ForkJoin scheduler after it has already been shut down.

Modification:
- Shut down the virtual-thread thread-per-task executor first.
- Cascade shutdown to the owned underlying scheduler only after the virtual-thread executor has terminated.
- Keep ExecutorService.isShutdown tied to the virtual-thread executor contract.
- Add a regression test that verifies a blocked virtual thread can resume and finish after dispatcher shutdown.

Result:
Verified locally:
- JDK 25: actor-tests / TestJdk9 / testOnly org.apache.pekko.dispatch.ForkJoinPoolVirtualThreadSpec
- JDK 21: actor-tests / TestJdk9 / testOnly org.apache.pekko.dispatch.ForkJoinPoolVirtualThreadSpec
- JDK 25 + Scala 2.13 nightly opts: stream-tests-tck / Test / testOnly org.apache.pekko.stream.tck.FanoutPublisherTest
- JDK 25 + Scala 3 nightly opts: cluster / Test / testOnly org.apache.pekko.cluster.ClusterDeathWatchNotificationSpec
- JDK 21 + Scala 2.13 and Scala 3 nightly opts: cluster-typed / Test / testOnly org.apache.pekko.cluster.typed.RemoteDeployNotAllowedSpec
- JDK 17: actor / Compile / compile, actor-tests / Test / compile, checkCodeStyle

References:
Nightly run 24984219012