### PR TITLE
Fix ByteString1C serialization to use SerializationProxy

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -2015,7 +2015,7 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
         // When serialized directly the class descriptor "ByteString1C" appears in the stream;
         // with writeReplace the proxy class name appears instead.
         val streamContent = new String(serialized, StandardCharsets.ISO_8859_1)
-        streamContent should not include "ByteString1C"
+        (streamContent should not).include("ByteString1C")
         deserialize(serialized) shouldEqual bs1c
       }
 
@@ -2024,8 +2024,8 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
         val viaString = CompactByteString("hello")
         val serializedApply = serialize(viaApply)
         val serializedString = serialize(viaString)
-        new String(serializedApply, StandardCharsets.ISO_8859_1) should not include "ByteString1C"
-        new String(serializedString, StandardCharsets.ISO_8859_1) should not include "ByteString1C"
+        (new String(serializedApply, StandardCharsets.ISO_8859_1) should not).include("ByteString1C")
+        (new String(serializedString, StandardCharsets.ISO_8859_1) should not).include("ByteString1C")
         deserialize(serializedApply) shouldEqual viaApply
         deserialize(serializedString) shouldEqual viaString
       }

--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -2007,6 +2007,37 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
 
         deserialize(serialize(original)) shouldEqual original
       }
+
+      "ByteString1C serializes via SerializationProxy not directly" in {
+        val bs1c = ByteString1C(Array[Byte](1, 2, 3))
+        val serialized = serialize(bs1c)
+        // The serialized form must use SerializationProxy, not serialize ByteString1C directly.
+        // When serialized directly the class descriptor "ByteString1C" appears in the stream;
+        // with writeReplace the proxy class name appears instead.
+        val streamContent = new String(serialized, StandardCharsets.ISO_8859_1)
+        streamContent should not include "ByteString1C"
+        deserialize(serialized) shouldEqual bs1c
+      }
+
+      "CompactByteString instances serialize via SerializationProxy" in {
+        val viaApply = CompactByteString(Array[Byte](10, 20, 30))
+        val viaString = CompactByteString("hello")
+        val serializedApply = serialize(viaApply)
+        val serializedString = serialize(viaString)
+        new String(serializedApply, StandardCharsets.ISO_8859_1) should not include "ByteString1C"
+        new String(serializedString, StandardCharsets.ISO_8859_1) should not include "ByteString1C"
+        deserialize(serializedApply) shouldEqual viaApply
+        deserialize(serializedString) shouldEqual viaString
+      }
+
+      "each ByteString concrete type round-trips via serialization" in {
+        val bs1c = ByteString1C(Array[Byte](1, 2, 3))
+        val bs1 = bs1c.toByteString1
+        val bss = bs1 ++ ByteString1C(Array[Byte](4, 5, 6))
+        deserialize(serialize(bs1c)) shouldEqual bs1c
+        deserialize(serialize(bs1)) shouldEqual bs1
+        deserialize(serialize(bss)) shouldEqual bss
+      }
     }
 
     "unsafely wrap and unwrap bytes" in {

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -410,6 +410,8 @@ object ByteString {
     private[pekko] override def writeToOutputStream(os: ObjectOutputStream): Unit =
       toByteString1.writeToOutputStream(os)
 
+    protected def writeReplace(): AnyRef = new SerializationProxy(this)
+
     override def copyToBuffer(buffer: ByteBuffer): Int =
       writeToBuffer(buffer, offset = 0)
 


### PR DESCRIPTION
### Motivation

`ByteString1C` — the sole concrete implementation of `CompactByteString` — lacked a `writeReplace()` method. This caused Java serialization to serialize it directly using `@SerialVersionUID(3956956327691936932L)` rather than delegating to the `SerializationProxy` that both `ByteString1` and `ByteStrings` use. Any change to the class structure (e.g. moving to a different package) would make previously serialized `ByteString1C` data unreadable due to `SerialVersionUID` mismatches. All `CompactByteString` factory methods (`CompactByteString.apply(...)`, `CompactByteString.fromArray(...)`, etc.) return `ByteString1C`, so all of them were affected.

### Modification

Add `protected def writeReplace(): AnyRef = new SerializationProxy(this)` to `ByteString1C`, matching the pattern already present in `ByteString1` and `ByteStrings`. All infrastructure (`byteStringCompanion`, `writeToOutputStream`, `SerializationIdentity`) was already in place on `ByteString1C`; the only missing piece was the hook.

### Result

All three concrete `ByteString` types now consistently serialize via `SerializationProxy`. The serialized form no longer embeds the `ByteString1C` class descriptor, making the format resilient to class renaming/moving.

### Tests

- New test: `ByteString1C serializes via SerializationProxy not directly` — asserts the raw serialized bytes do not contain the string `"ByteString1C"` (i.e. the proxy class descriptor is written, not the raw implementation class).
- New test: `CompactByteString instances serialize via SerializationProxy` — same assertion for `CompactByteString.apply()` and `CompactByteString("hello")` factories.
- New test: `each ByteString concrete type round-trips via serialization` — explicit round-trip for `ByteString1C`, `ByteString1`, and `ByteStrings`.

Tests: run locally not possible (sbt not installed in sandbox). Tests added and reviewed; CI will validate.

### References

None - serialization proxy consistency fix for ByteString1C / CompactByteString